### PR TITLE
minmax index added to id for faster pagination

### DIFF
--- a/exporter/clickhouselogsexporter/migrations/000002_add_minmax_idx.down.sql
+++ b/exporter/clickhouselogsexporter/migrations/000002_add_minmax_idx.down.sql
@@ -1,0 +1,1 @@
+alter table signoz_logs.logs drop index id_minmax

--- a/exporter/clickhouselogsexporter/migrations/000002_add_minmax_idx.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/000002_add_minmax_idx.up.sql
@@ -1,0 +1,1 @@
+alter table signoz_logs.logs add index id_minmax id TYPE minmax GRANULARITY 1


### PR DESCRIPTION
Id was a secondary column in the ordery by clause (primary key), it resulted in slower queries when the timerange is large for certain operations.

after adding a minmax index, which is very lightweight the queries for pagination using id and finding a specific id is reduced to  sub `50`milliseconds from about `1` s