### PR TITLE
Add config manager

### DIFF
--- a/opamp/config.go
+++ b/opamp/config.go
@@ -1,5 +1,30 @@
 package opamp
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
 type AgentManagerConfig struct {
 	ServerEndpoint string `yaml:"server_endpoint"`
+}
+
+func ParseAgentManagerConfig(configLocation string) (*AgentManagerConfig, error) {
+	data, err := os.ReadFile(filepath.Clean(configLocation))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read agent manager config file: %w", err)
+	}
+
+	var config AgentManagerConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal file contents: %w", err)
+	}
+
+	if config.ServerEndpoint == "" {
+		return nil, fmt.Errorf("server_endpoint is required")
+	}
+	return &config, nil
 }

--- a/opamp/config_manager.go
+++ b/opamp/config_manager.go
@@ -1,9 +1,15 @@
 package opamp
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.uber.org/zap"
 )
+
+const collectorConfigKey = "collector.yaml"
 
 // agentConfigManager is responsible for managing the agent configuration
 // It is responsible for:
@@ -25,9 +31,58 @@ type remoteControlledConfig struct {
 	currentHash []byte
 }
 
+func NewDynamicConfig(configPath string, reloader reloadFunc) (*remoteControlledConfig, error) {
+	remoteControlledConfig := &remoteControlledConfig{
+		path:     configPath,
+		reloader: reloader,
+	}
+
+	if err := remoteControlledConfig.UpdateCurrentHash(); err != nil {
+		return nil, fmt.Errorf("failed to compute hash for the current config %w", err)
+	}
+
+	return remoteControlledConfig, nil
+}
+
+func (m *remoteControlledConfig) UpdateCurrentHash() error {
+	contents, err := os.ReadFile(m.path)
+	if err != nil {
+		m.currentHash = fileHash([]byte{})
+		return fmt.Errorf("failed to read config file %s: %w", m.path, err)
+	}
+	m.currentHash = fileHash(contents)
+	return nil
+}
+
+func NewAgentConfigManager(logger *zap.Logger) *agentConfigManager {
+	return &agentConfigManager{
+		logger: logger.Named("agent-config-manager"),
+	}
+}
+
+func (a *agentConfigManager) Set(remoteControlledConfig *remoteControlledConfig) {
+	a.agentConfig = remoteControlledConfig
+}
+
 // createEffectiveConfigMsg creates a protobuf message that contains the effective config.
 func (a *agentConfigManager) CreateEffectiveConfigMsg() (*protobufs.EffectiveConfig, error) {
-	return nil, nil
+	configMap := make(map[string]*protobufs.AgentConfigFile, 1)
+
+	body, err := os.ReadFile(a.agentConfig.path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file %s: %w", a.agentConfig.path, err)
+	}
+
+	configMap[collectorConfigKey] = &protobufs.AgentConfigFile{
+		Body:        body,
+		ContentType: "text/yaml",
+	}
+
+	return &protobufs.EffectiveConfig{
+		ConfigMap: &protobufs.AgentConfigMap{
+			ConfigMap: configMap,
+		},
+	}, nil
 }
 
 // Apply applies the remote configuration to the agent.
@@ -38,5 +93,39 @@ func (a *agentConfigManager) CreateEffectiveConfigMsg() (*protobufs.EffectiveCon
 // If there is an error, it returns an error.
 // The caller is responsible for sending the updated configuration to the Opamp server.
 func (a *agentConfigManager) Apply(remoteConfig *protobufs.AgentRemoteConfig) (bool, error) {
-	return false, nil
+	remoteConfigMap := remoteConfig.GetConfig().GetConfigMap()
+
+	if remoteConfigMap == nil {
+		return false, nil
+	}
+
+	remoteCollectorConfig, ok := remoteConfigMap[collectorConfigKey]
+
+	if !ok {
+		return false, nil
+	}
+
+	return a.applyRemoteConfig(a.agentConfig, remoteCollectorConfig.GetBody())
+}
+
+// applyRemoteConfig applies the remote config to the agent.
+func (a *agentConfigManager) applyRemoteConfig(currentConfig *remoteControlledConfig, newContents []byte) (changed bool, err error) {
+	newConfigHash := fileHash(newContents)
+
+	if bytes.Equal(currentConfig.currentHash, newConfigHash) {
+		return false, nil
+	}
+
+	err = currentConfig.reloader(newContents)
+	if err != nil {
+		return false, fmt.Errorf("failed to reload config: %s: %w", currentConfig.path, err)
+	}
+
+	err = currentConfig.UpdateCurrentHash()
+	if err != nil {
+		err = fmt.Errorf("failed hash compute for config %s: %w", currentConfig.path, err)
+		return true, err
+	}
+
+	return true, nil
 }

--- a/opamp/config_manager_test.go
+++ b/opamp/config_manager_test.go
@@ -1,0 +1,135 @@
+package opamp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func newLogger(t *testing.T) *zap.Logger {
+	t.Helper()
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return logger
+}
+
+func TestNewDynamicConfigInvalidPath(t *testing.T) {
+	cnt := 0
+	reloadFunc := func(contents []byte) error {
+		cnt++
+		return nil
+	}
+
+	_, err := NewDynamicConfig("./testdata/collector.yaml", reloadFunc)
+	assert.ErrorContains(t, err, "failed to read config file")
+}
+
+func TestNewDynamicConfig(t *testing.T) {
+	cnt := 0
+	reloadFunc := func(contents []byte) error {
+		cnt++
+		return nil
+	}
+
+	_, err := NewDynamicConfig("./testdata/coll-config-path.yaml", reloadFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cnt)
+}
+
+func TestNewAgentConfigManager(t *testing.T) {
+	logger := newLogger(t)
+	mgr := NewAgentConfigManager(logger)
+	assert.NotNil(t, mgr)
+}
+
+func TestNewAgentConfigManagerEffectiveConfig(t *testing.T) {
+	logger := newLogger(t)
+	mgr := NewAgentConfigManager(logger)
+	assert.NotNil(t, mgr)
+
+	cnt := 0
+	reloadFunc := func(contents []byte) error {
+		cnt++
+		return nil
+	}
+
+	cfg, err := NewDynamicConfig("./testdata/coll-config-path.yaml", reloadFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cnt)
+
+	mgr.Set(cfg)
+	effCfg, err := mgr.CreateEffectiveConfigMsg()
+	assert.NoError(t, err)
+	assert.NotNil(t, effCfg)
+	bytes, err := os.ReadFile("./testdata/coll-config-path.yaml")
+	assert.Equal(t, effCfg.GetConfigMap().ConfigMap["collector.yaml"].GetContentType(), "text/yaml")
+	assert.Equal(t, effCfg.GetConfigMap().ConfigMap["collector.yaml"].Body, bytes)
+}
+
+func TestNewAgentConfigManagerApply(t *testing.T) {
+	// make a copy of the original file
+	func() {
+		copy("./testdata/coll-config-path.yaml", "./testdata/coll-config-path-copy.yaml")
+		copy("./testdata/coll-config-path-changed.yaml", "./testdata/coll-config-path-changed-copy.yaml")
+	}()
+
+	// restore the original file
+	defer func() {
+		copy("./testdata/coll-config-path-copy.yaml", "./testdata/coll-config-path.yaml")
+		copy("./testdata/coll-config-path-changed-copy.yaml", "./testdata/coll-config-path-changed.yaml")
+		os.Remove("./testdata/coll-config-path-copy.yaml")
+		os.Remove("./testdata/coll-config-path-changed-copy.yaml")
+	}()
+
+	logger := newLogger(t)
+	mgr := NewAgentConfigManager(logger)
+	assert.NotNil(t, mgr)
+
+	cnt := 0
+	reloadFunc := func(contents []byte) error {
+		cnt++
+		return nil
+	}
+
+	cfg, err := NewDynamicConfig("./testdata/coll-config-path.yaml", reloadFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cnt)
+
+	mgr.Set(cfg)
+	effCfg, err := mgr.CreateEffectiveConfigMsg()
+	assert.NoError(t, err)
+	assert.NotNil(t, effCfg)
+
+	// Apply the same config again
+	changed, err := mgr.Apply(&protobufs.AgentRemoteConfig{
+		Config: &protobufs.AgentConfigMap{
+			ConfigMap: effCfg.GetConfigMap().ConfigMap,
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, false, changed)
+	assert.Equal(t, 0, cnt)
+
+	newContent, err := os.ReadFile("./testdata/coll-config-path-changed.yaml")
+	newEffCfg := &protobufs.AgentRemoteConfig{
+		Config: &protobufs.AgentConfigMap{
+			ConfigMap: map[string]*protobufs.AgentConfigFile{
+				"collector.yaml": {
+					ContentType: "text/yaml",
+					Body:        newContent,
+				},
+			},
+		},
+	}
+
+	// Apply a different config
+	changed, err = mgr.Apply(newEffCfg)
+	assert.NoError(t, err)
+	assert.Equal(t, true, changed)
+	assert.Equal(t, 1, cnt)
+}

--- a/opamp/config_test.go
+++ b/opamp/config_test.go
@@ -1,0 +1,32 @@
+package opamp
+
+import (
+	"testing"
+)
+
+func TestParseConfigInvalidPath(t *testing.T) {
+	_, err := ParseAgentManagerConfig("./testdata/collector.yaml")
+	if err == nil {
+		t.Errorf("expected error")
+	}
+}
+
+func TestParseConfigInvalidYaml(t *testing.T) {
+	cfg, err := ParseAgentManagerConfig("./testdata/invalid.yaml")
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config but got %v", cfg)
+	}
+}
+
+func TestParseConfig(t *testing.T) {
+	cfg, err := ParseAgentManagerConfig("./testdata/manager-config.yaml")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Errorf("expected config")
+	}
+}

--- a/opamp/helpers.go
+++ b/opamp/helpers.go
@@ -1,0 +1,96 @@
+package opamp
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GetAvailableLocalAddress finds an available local port and returns an endpoint
+// describing it. The port is available for opening when this function returns
+// provided that there is no race by some other code to grab the same port
+// immediately.
+func GetAvailableLocalAddress() string {
+	ln, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		log.Fatalf("failed to get a free local port: %v", err)
+	}
+	// There is a possible race if something else takes this same port before
+	// the test uses it, however, that is unlikely in practice.
+	defer ln.Close()
+	return ln.Addr().String()
+}
+
+func waitForPortToListen(port int) error {
+	totalDuration := 5 * time.Second
+	wait := 10 * time.Millisecond
+	address := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ticker := time.NewTicker(wait)
+	defer ticker.Stop()
+
+	timeout := time.After(totalDuration)
+
+	for {
+		select {
+		case <-ticker.C:
+			conn, err := net.Dial("tcp", address)
+			if err == nil && conn != nil {
+				conn.Close()
+				return nil
+			}
+
+		case <-timeout:
+			return fmt.Errorf("failed to wait for port %d", port)
+		}
+	}
+}
+
+// HostPortFromAddr extracts host and port from a network address
+func HostPortFromAddr(endpoint string) (host string, port int, err error) {
+	sepIndex := strings.LastIndex(endpoint, ":")
+	if sepIndex < 0 {
+		return "", -1, errors.New("failed to parse host:port")
+	}
+	host, portStr := endpoint[:sepIndex], endpoint[sepIndex+1:]
+	port, err = strconv.Atoi(portStr)
+	return host, port, err
+}
+
+func WaitForEndpoint(endpoint string) {
+	_, port, err := HostPortFromAddr(endpoint)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	waitForPortToListen(port)
+}
+
+// fileHash returns the SHA256 hash of the file at the given path.
+func fileHash(data []byte) []byte {
+	hash := sha256.New()
+	_, err := hash.Write(data)
+	if err != nil {
+		panic(fmt.Sprintf("failed to write to hash: %v", err))
+	}
+	return hash.Sum(nil)
+}
+
+func copy(src, dest string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source file %s: %w", src, err)
+	}
+
+	err = os.WriteFile(dest, data, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write to dest file %s: %w", dest, err)
+	}
+
+	return nil
+}

--- a/opamp/testdata/coll-config-path-changed.yaml
+++ b/opamp/testdata/coll-config-path-changed.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+processors:
+  batch:
+    send_batch_size: 10000
+    timeout: 10s
+extensions:
+  zpages: {}
+exporters:
+  clickhousetraces:
+    datasource: tcp://localhost:9000/?database=signoz_traces
+    migrations: exporter/clickhousetracesexporter/migrations
+  clickhousemetricswrite:
+    endpoint: tcp://localhost:9000/?database=signoz_metrics
+    resource_to_telemetry_conversion:
+      enabled: true
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhousetraces]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhousemetricswrite]

--- a/opamp/testdata/coll-config-path.yaml
+++ b/opamp/testdata/coll-config-path.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+processors:
+  batch:
+    send_batch_size: 10000
+    timeout: 10s
+extensions:
+  zpages: {}
+exporters:
+  clickhousetraces:
+    datasource: tcp://localhost:9000/?database=signoz_traces
+    migrations: exporter/clickhousetracesexporter/migrations
+  clickhousemetricswrite:
+    endpoint: tcp://localhost:9000/?database=signoz_metrics
+    resource_to_telemetry_conversion:
+      enabled: false
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhousetraces]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhousemetricswrite]

--- a/opamp/testdata/invalid.yaml
+++ b/opamp/testdata/invalid.yaml
@@ -1,0 +1,1 @@
+sever_endpoint: 

--- a/opamp/testdata/manager-config.yaml
+++ b/opamp/testdata/manager-config.yaml
@@ -1,0 +1,1 @@
+server_endpoint: ws://127.0.0.1:4320/v1/opamp


### PR DESCRIPTION
Part of https://github.com/SigNoz/signoz/issues/1786

See first https://github.com/SigNoz/signoz-otel-collector/pull/51

This PR adds a config manager to the collector. The config manager is responsible for applying the remote configuration to the collector. It restarts the collector when the configuration is updated. 