### PR TITLE
Add DB latency metric instrumentation for clickhouselogsexporter

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -171,7 +171,13 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 	if err != nil {
 		return fmt.Errorf("StatementSend:%w", err)
 	}
-	stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(exporterKey, string(component.DataTypeLogs)), tag.Upsert(tableKey, DISTRIBUTED_LOGS_TABLE)}, writeLatencyMillis.M(int64(time.Since(dbWriteStart).Milliseconds())))
+	stats.RecordWithTags(ctx,
+		[]tag.Mutator{
+			tag.Upsert(exporterKey, string(component.DataTypeLogs)),
+			tag.Upsert(tableKey, DISTRIBUTED_LOGS_TABLE),
+		},
+		writeLatencyMillis.M(int64(time.Since(dbWriteStart).Milliseconds())),
+	)
 
 	duration := time.Since(start)
 	e.logger.Debug("insert logs", zap.Int("records", ld.LogRecordCount()),

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -33,6 +33,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
@@ -164,10 +165,14 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 			}
 		}
 	}
+
+	dbWriteStart := time.Now()
 	err = statement.Send()
 	if err != nil {
 		return fmt.Errorf("StatementSend:%w", err)
 	}
+	stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(exporterKey, string(component.DataTypeLogs)), tag.Upsert(tableKey, DISTRIBUTED_LOGS_TABLE)}, writeLatencyMillis.M(int64(time.Since(dbWriteStart).Milliseconds())))
+
 	duration := time.Since(start)
 	e.logger.Debug("insert logs", zap.Int("records", ld.LogRecordCount()),
 		zap.String("cost", duration.String()))

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -168,9 +168,17 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 
 	dbWriteStart := time.Now()
 	err = statement.Send()
+	stats.RecordWithTags(ctx,
+		[]tag.Mutator{
+			tag.Upsert(exporterKey, string(component.DataTypeLogs)),
+			tag.Upsert(tableKey, DISTRIBUTED_LOGS_TABLE),
+		},
+		writeLatencyMillis.M(int64(time.Since(dbWriteStart).Milliseconds())),
+	)
 	if err != nil {
 		return fmt.Errorf("StatementSend:%w", err)
 	}
+
 	stats.RecordWithTags(ctx,
 		[]tag.Mutator{
 			tag.Upsert(exporterKey, string(component.DataTypeLogs)),

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -179,14 +179,6 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 		return fmt.Errorf("StatementSend:%w", err)
 	}
 
-	stats.RecordWithTags(ctx,
-		[]tag.Mutator{
-			tag.Upsert(exporterKey, string(component.DataTypeLogs)),
-			tag.Upsert(tableKey, DISTRIBUTED_LOGS_TABLE),
-		},
-		writeLatencyMillis.M(int64(time.Since(dbWriteStart).Milliseconds())),
-	)
-
 	duration := time.Since(start)
 	e.logger.Debug("insert logs", zap.Int("records", ld.LogRecordCount()),
 		zap.String("cost", duration.String()))

--- a/exporter/clickhouselogsexporter/factory.go
+++ b/exporter/clickhouselogsexporter/factory.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -33,8 +36,26 @@ const (
 	migrationsFolder = "./migrations"
 )
 
+var (
+	writeLatencyMillis = stats.Int64("exporter_db_write_latency", "Time taken (in millis) for exporter to write batch", "ms")
+	exporterKey        = tag.MustNewKey("exporter")
+	tableKey           = tag.MustNewKey("table")
+)
+
 // NewFactory creates a factory for Elastic exporter.
 func NewFactory() component.ExporterFactory {
+	writeLatencyDistribution := view.Distribution(100, 250, 500, 750, 1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 256000, 512000)
+
+	writeLatencyView := &view.View{
+		Name:        "exporter_db_write_latency",
+		Measure:     writeLatencyMillis,
+		Description: writeLatencyMillis.Description(),
+		TagKeys:     []tag.Key{exporterKey, tableKey},
+		Aggregation: writeLatencyDistribution,
+	}
+
+	view.Register(writeLatencyView)
+
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz-otel-collector/issues/76

similar to https://github.com/SigNoz/signoz-otel-collector/pull/78 but this is for logs