### PR TITLE
chore: added tail sampling processor from contrib 

### DIFF
--- a/processor/signoztailsampler/Makefile
+++ b/processor/signoztailsampler/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/processor/signoztailsampler/README.md
+++ b/processor/signoztailsampler/README.md
@@ -1,0 +1,184 @@
+# Tail Sampling Processor
+
+| Status                   |           |
+| ------------------------ | --------- |
+| Stability                | [beta]    |
+| Supported pipeline types | traces    |
+| Distributions            | [contrib] |
+
+The tail sampling processor samples traces based on a set of defined policies.
+Today, this processor only works with a single instance of the collector.
+Technically, trace ID aware load balancing could be used to support multiple
+collector instances, but this configuration has not been tested. Please refer to
+[config.go](./config.go) for the config spec.
+
+The following configuration options are required:
+- `policies` (no default): Policies used to make a sampling decision
+
+Multiple policies exist today and it is straight forward to add more. These include:
+- `always_sample`: Sample all traces
+- `latency`: Sample based on the duration of the trace. The duration is determined by looking at the earliest start time and latest end time, without taking into consideration what happened in between.
+- `numeric_attribute`: Sample based on number attributes
+- `probabilistic`: Sample a percentage of traces. Read [a comparison with the Probabilistic Sampling Processor](#probabilistic-sampling-processor-compared-to-the-tail-sampling-processor-with-the-probabilistic-policy).
+- `status_code`: Sample based upon the status code (`OK`, `ERROR` or `UNSET`)
+- `string_attribute`: Sample based on string attributes value matches, both exact and regex value matches are supported
+- `trace_state`: Sample based on [TraceState](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracestate) value matches
+- `rate_limiting`: Sample based on rate
+- `span_count`: Sample based on the minimum number of spans within a batch. If all traces within the batch have less number of spans than the threshold, the batch will not be sampled.
+- `and`: Sample based on multiple policies, creates an AND policy 
+- `composite`: Sample based on a combination of above samplers, with ordering and rate allocation per sampler. Rate allocation allocates certain percentages of spans per policy order. 
+  For example if we have set max_total_spans_per_second as 100 then we can set rate_allocation as follows
+  1. test-composite-policy-1 = 50 % of max_total_spans_per_second = 50 spans_per_second
+  2. test-composite-policy-2 = 25 % of max_total_spans_per_second = 25 spans_per_second
+  3. To ensure remaining capacity is filled use always_sample as one of the policies
+
+The following configuration options can also be modified:
+- `decision_wait` (default = 30s): Wait time since the first span of a trace before making a sampling decision
+- `num_traces` (default = 50000): Number of traces kept in memory
+- `expected_new_traces_per_sec` (default = 0): Expected number of new traces (helps in allocating data structures)
+
+Examples:
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    num_traces: 100
+    expected_new_traces_per_sec: 10
+    policies:
+      [
+          {
+            name: test-policy-1,
+            type: always_sample
+          },
+          {
+            name: test-policy-2,
+            type: latency,
+            latency: {threshold_ms: 5000}
+          },
+          {
+            name: test-policy-3,
+            type: numeric_attribute,
+            numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+          },
+          {
+            name: test-policy-4,
+            type: probabilistic,
+            probabilistic: {sampling_percentage: 10}
+          },
+          {
+            name: test-policy-5,
+            type: status_code,
+            status_code: {status_codes: [ERROR, UNSET]}
+          },
+          {
+            name: test-policy-6,
+            type: string_attribute,
+            string_attribute: {key: key2, values: [value1, value2]}
+          },
+          {
+            name: test-policy-7,
+            type: string_attribute,
+            string_attribute: {key: key2, values: [value1, val*], enabled_regex_matching: true, cache_max_size: 10}
+          },
+          {
+            name: test-policy-8,
+            type: rate_limiting,
+            rate_limiting: {spans_per_second: 35}
+         },
+         {
+            name: test-policy-9,
+            type: string_attribute,
+            string_attribute: {key: http.url, values: [\/health, \/metrics], enabled_regex_matching: true, invert_match: true}
+         },
+         {
+            name: test-policy-10,
+            type: span_count,
+            span_count: {min_spans: 2}
+         },
+         {
+             name: test-policy-11,
+             type: trace_state,
+             trace_state: { key: key3, values: [value1, value2] }
+         },
+         {
+            name: and-policy-1,
+            type: and,
+            and: {
+              and_sub_policy: 
+              [
+                {
+                  name: test-and-policy-1,
+                  type: numeric_attribute,
+                  numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+                },
+                {
+                    name: test-and-policy-2,
+                    type: string_attribute,
+                    string_attribute: { key: key2, values: [ value1, value2 ] }
+                },
+              ]
+            }
+         },
+         {
+            name: composite-policy-1,
+            type: composite,
+            composite:
+              {
+                max_total_spans_per_second: 1000,
+                policy_order: [test-composite-policy-1, test-composite-policy-2, test-composite-policy-3],
+                composite_sub_policy:
+                  [
+                    {
+                      name: test-composite-policy-1,
+                      type: numeric_attribute,
+                      numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+                    },
+                    {
+                      name: test-composite-policy-2,
+                      type: string_attribute,
+                      string_attribute: {key: key2, values: [value1, value2]}
+                    },
+                    {
+                      name: test-composite-policy-3,
+                      type: always_sample
+                    }
+                  ],
+                rate_allocation:
+                  [
+                    {
+                      policy: test-composite-policy-1,
+                      percent: 50
+                    },
+                    {
+                      policy: test-composite-policy-2,
+                      percent: 25
+                    }
+                  ]
+              }
+          },
+        ]
+```
+
+Refer to [tail_sampling_config.yaml](./testdata/tail_sampling_config.yaml) for detailed
+examples on using the processor.
+
+### Probabilistic Sampling Processor compared to the Tail Sampling Processor with the Probabilistic policy
+
+The [probabilistic sampling processor][probabilistic_sampling_processor] and the probabilistic tail sampling processor policy work very similar:
+based upon a configurable sampling percentage they will sample a fixed ratio of received traces.
+But depending on the overall processing pipeline you should prefer using one over the other.
+
+As a rule of thumb, if you want to add probabilistic sampling and...
+
+...you are not using the tail sampling processor already: use the [probabilistic sampling processor][probabilistic_sampling_processor].
+Running the probabilistic sampling processor is more efficient than the tail sampling processor.
+The probabilistic sampling policy makes decision based upon the trace ID, so waiting until more spans have arrived will not influence its decision. 
+
+...you are already using the tail sampling processor: add the probabilistic sampling policy.
+You are already incurring the cost of running the tail sampling processor, adding the probabilistic policy will be negligible.
+Additionally, using the policy within the tail sampling processor will ensure traces that are sampled by other policies will not be dropped.
+
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+[probabilistic_sampling_processor]: ../probabilisticsamplerprocessor

--- a/processor/signoztailsampler/and_helper.go
+++ b/processor/signoztailsampler/and_helper.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+func getNewAndPolicy(logger *zap.Logger, config *AndCfg) (sampling.PolicyEvaluator, error) {
+	var subPolicyEvaluators []sampling.PolicyEvaluator
+	for i := range config.SubPolicyCfg {
+		policyCfg := &config.SubPolicyCfg[i]
+		policy, err := getAndSubPolicyEvaluator(logger, policyCfg)
+		if err != nil {
+			return nil, err
+		}
+		subPolicyEvaluators = append(subPolicyEvaluators, policy)
+	}
+	return sampling.NewAnd(logger, subPolicyEvaluators), nil
+}
+
+// Return instance of and sub-policy
+func getAndSubPolicyEvaluator(logger *zap.Logger, cfg *AndSubPolicyCfg) (sampling.PolicyEvaluator, error) {
+	return getSharedPolicyEvaluator(logger, &cfg.sharedPolicyCfg)
+}

--- a/processor/signoztailsampler/and_helper_test.go
+++ b/processor/signoztailsampler/and_helper_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+func TestAndHelper(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		actual, err := getNewAndPolicy(zap.NewNop(), &AndCfg{
+			SubPolicyCfg: []AndSubPolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-and-policy-1",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 100},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		expected := sampling.NewAnd(zap.NewNop(), []sampling.PolicyEvaluator{
+			sampling.NewLatency(zap.NewNop(), 100),
+		})
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("unsupported sampling policy type", func(t *testing.T) {
+		_, err := getNewAndPolicy(zap.NewNop(), &AndCfg{
+			SubPolicyCfg: []AndSubPolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name: "test-and-policy-2",
+						Type: And, // nested and is not allowed
+					},
+				},
+			},
+		})
+		require.EqualError(t, err, "unknown sampling policy type and")
+	})
+}

--- a/processor/signoztailsampler/composite_helper.go
+++ b/processor/signoztailsampler/composite_helper.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+func getNewCompositePolicy(logger *zap.Logger, config *CompositeCfg) (sampling.PolicyEvaluator, error) {
+	var subPolicyEvalParams []sampling.SubPolicyEvalParams
+	rateAllocationsMap := getRateAllocationMap(config)
+	for i := range config.SubPolicyCfg {
+		policyCfg := &config.SubPolicyCfg[i]
+		policy, err := getCompositeSubPolicyEvaluator(logger, policyCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		evalParams := sampling.SubPolicyEvalParams{
+			Evaluator:         policy,
+			MaxSpansPerSecond: int64(rateAllocationsMap[policyCfg.Name]),
+		}
+		subPolicyEvalParams = append(subPolicyEvalParams, evalParams)
+	}
+	return sampling.NewComposite(logger, config.MaxTotalSpansPerSecond, subPolicyEvalParams, sampling.MonotonicClock{}), nil
+}
+
+// Apply rate allocations to the sub-policies
+func getRateAllocationMap(config *CompositeCfg) map[string]float64 {
+	rateAllocationsMap := make(map[string]float64)
+	maxTotalSPS := float64(config.MaxTotalSpansPerSecond)
+	// Default SPS determined by equally diving number of sub policies
+	defaultSPS := maxTotalSPS / float64(len(config.SubPolicyCfg))
+	for _, rAlloc := range config.RateAllocation {
+		if rAlloc.Percent > 0 {
+			rateAllocationsMap[rAlloc.Policy] = (float64(rAlloc.Percent) / 100) * maxTotalSPS
+		} else {
+			rateAllocationsMap[rAlloc.Policy] = defaultSPS
+		}
+	}
+	return rateAllocationsMap
+}
+
+// Return instance of composite sub-policy
+func getCompositeSubPolicyEvaluator(logger *zap.Logger, cfg *CompositeSubPolicyCfg) (sampling.PolicyEvaluator, error) {
+	switch cfg.Type {
+	case And:
+		return getNewAndPolicy(logger, &cfg.AndCfg)
+	default:
+		return getSharedPolicyEvaluator(logger, &cfg.sharedPolicyCfg)
+	}
+}

--- a/processor/signoztailsampler/composite_helper_test.go
+++ b/processor/signoztailsampler/composite_helper_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+func TestCompositeHelper(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		actual, err := getNewCompositePolicy(zap.NewNop(), &CompositeCfg{
+			MaxTotalSpansPerSecond: 1000,
+			PolicyOrder:            []string{"test-composite-policy-1"},
+			SubPolicyCfg: []CompositeSubPolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-composite-policy-1",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 100},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-composite-policy-2",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 200},
+					},
+				},
+			},
+			RateAllocation: []RateAllocationCfg{
+				{
+					Policy:  "test-composite-policy-1",
+					Percent: 25,
+				},
+				{
+					Policy:  "test-composite-policy-2",
+					Percent: 0, // will be populated with default
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		expected := sampling.NewComposite(zap.NewNop(), 1000, []sampling.SubPolicyEvalParams{
+			{
+				Evaluator:         sampling.NewLatency(zap.NewNop(), 100),
+				MaxSpansPerSecond: 250,
+			},
+			{
+				Evaluator:         sampling.NewLatency(zap.NewNop(), 200),
+				MaxSpansPerSecond: 500,
+			},
+		}, sampling.MonotonicClock{})
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("unsupported sampling policy type", func(t *testing.T) {
+		_, err := getNewCompositePolicy(zap.NewNop(), &CompositeCfg{
+			SubPolicyCfg: []CompositeSubPolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name: "test-composite-policy-1",
+						Type: Composite, // nested composite is not allowed
+					},
+				},
+			},
+		})
+		require.EqualError(t, err, "unknown sampling policy type composite")
+	})
+}

--- a/processor/signoztailsampler/config.go
+++ b/processor/signoztailsampler/config.go
@@ -1,0 +1,212 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+// PolicyType indicates the type of sampling policy.
+type PolicyType string
+
+const (
+	// AlwaysSample samples all traces, typically used for debugging.
+	AlwaysSample PolicyType = "always_sample"
+	// Latency sample traces that are longer than a given threshold.
+	Latency PolicyType = "latency"
+	// NumericAttribute sample traces that have a given numeric attribute in a specified
+	// range, e.g.: attribute "http.status_code" >= 399 and <= 999.
+	NumericAttribute PolicyType = "numeric_attribute"
+	// Probabilistic samples a given percentage of traces.
+	Probabilistic PolicyType = "probabilistic"
+	// StatusCode sample traces that have a given status code.
+	StatusCode PolicyType = "status_code"
+	// StringAttribute sample traces that a attribute, of type string, matching
+	// one of the listed values.
+	StringAttribute PolicyType = "string_attribute"
+	// RateLimiting allows all traces until the specified limits are satisfied.
+	RateLimiting PolicyType = "rate_limiting"
+	// Composite allows defining a composite policy, combining the other policies in one
+	Composite PolicyType = "composite"
+	// And allows defining a And policy, combining the other policies in one
+	And PolicyType = "and"
+	// SpanCount sample traces that are have more spans per Trace than a given threshold.
+	SpanCount PolicyType = "span_count"
+	// TraceState sample traces with specified values by the given key
+	TraceState PolicyType = "trace_state"
+)
+
+// sharedPolicyCfg holds the common configuration to all policies that are used in derivative policy configurations
+// such as the and & composite policies.
+type sharedPolicyCfg struct {
+	// Name given to the instance of the policy to make easy to identify it in metrics and logs.
+	Name string `mapstructure:"name"`
+	// Type of the policy this will be used to match the proper configuration of the policy.
+	Type PolicyType `mapstructure:"type"`
+	// Configs for latency filter sampling policy evaluator.
+	LatencyCfg LatencyCfg `mapstructure:"latency"`
+	// Configs for numeric attribute filter sampling policy evaluator.
+	NumericAttributeCfg NumericAttributeCfg `mapstructure:"numeric_attribute"`
+	// Configs for probabilistic sampling policy evaluator.
+	ProbabilisticCfg ProbabilisticCfg `mapstructure:"probabilistic"`
+	// Configs for status code filter sampling policy evaluator.
+	StatusCodeCfg StatusCodeCfg `mapstructure:"status_code"`
+	// Configs for string attribute filter sampling policy evaluator.
+	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
+	// Configs for rate limiting filter sampling policy evaluator.
+	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
+	// Configs for span count filter sampling policy evaluator.
+	SpanCountCfg SpanCountCfg `mapstructure:"span_count"`
+	// Configs for defining trace_state policy
+	TraceStateCfg TraceStateCfg `mapstructure:"trace_state"`
+}
+
+// CompositeSubPolicyCfg holds the common configuration to all policies under composite policy.
+type CompositeSubPolicyCfg struct {
+	sharedPolicyCfg `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// Configs for and policy evaluator.
+	AndCfg AndCfg `mapstructure:"and"`
+}
+
+// AndSubPolicyCfg holds the common configuration to all policies under and policy.
+type AndSubPolicyCfg struct {
+	sharedPolicyCfg `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+}
+
+type TraceStateCfg struct {
+	// Tag that the filter is going to be matching against.
+	Key string `mapstructure:"key"`
+	// Values indicate the set of values to use when matching against trace_state values.
+	Values []string `mapstructure:"values"`
+}
+
+type AndCfg struct {
+	SubPolicyCfg []AndSubPolicyCfg `mapstructure:"and_sub_policy"`
+}
+
+// CompositeCfg holds the configurable settings to create a composite
+// sampling policy evaluator.
+type CompositeCfg struct {
+	MaxTotalSpansPerSecond int64                   `mapstructure:"max_total_spans_per_second"`
+	PolicyOrder            []string                `mapstructure:"policy_order"`
+	SubPolicyCfg           []CompositeSubPolicyCfg `mapstructure:"composite_sub_policy"`
+	RateAllocation         []RateAllocationCfg     `mapstructure:"rate_allocation"`
+}
+
+// RateAllocationCfg  used within composite policy
+type RateAllocationCfg struct {
+	Policy  string `mapstructure:"policy"`
+	Percent int64  `mapstructure:"percent"`
+}
+
+// PolicyCfg holds the common configuration to all policies.
+type PolicyCfg struct {
+	sharedPolicyCfg `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// Configs for defining composite policy
+	CompositeCfg CompositeCfg `mapstructure:"composite"`
+	// Configs for defining and policy
+	AndCfg AndCfg `mapstructure:"and"`
+}
+
+// LatencyCfg holds the configurable settings to create a latency filter sampling policy
+// evaluator
+type LatencyCfg struct {
+	// ThresholdMs in milliseconds.
+	ThresholdMs int64 `mapstructure:"threshold_ms"`
+}
+
+// NumericAttributeCfg holds the configurable settings to create a numeric attribute filter
+// sampling policy evaluator.
+type NumericAttributeCfg struct {
+	// Tag that the filter is going to be matching against.
+	Key string `mapstructure:"key"`
+	// MinValue is the minimum value of the attribute to be considered a match.
+	MinValue int64 `mapstructure:"min_value"`
+	// MaxValue is the maximum value of the attribute to be considered a match.
+	MaxValue int64 `mapstructure:"max_value"`
+}
+
+// ProbabilisticCfg holds the configurable settings to create a probabilistic
+// sampling policy evaluator.
+type ProbabilisticCfg struct {
+	// HashSalt allows one to configure the hashing salts. This is important in scenarios where multiple layers of collectors
+	// have different sampling rates: if they use the same salt all passing one layer may pass the other even if they have
+	// different sampling rates, configuring different salts avoids that.
+	HashSalt string `mapstructure:"hash_salt"`
+	// SamplingPercentage is the percentage rate at which traces are going to be sampled. Defaults to zero, i.e.: no sample.
+	// Values greater or equal 100 are treated as "sample all traces".
+	SamplingPercentage float64 `mapstructure:"sampling_percentage"`
+}
+
+// StatusCodeCfg holds the configurable settings to create a status code filter sampling
+// policy evaluator.
+type StatusCodeCfg struct {
+	StatusCodes []string `mapstructure:"status_codes"`
+}
+
+// StringAttributeCfg holds the configurable settings to create a string attribute filter
+// sampling policy evaluator.
+type StringAttributeCfg struct {
+	// Tag that the filter is going to be matching against.
+	Key string `mapstructure:"key"`
+	// Values indicate the set of values or regular expressions to use when matching against attribute values.
+	// StringAttribute Policy will apply exact value match on Values unless EnabledRegexMatching is true.
+	Values []string `mapstructure:"values"`
+	// EnabledRegexMatching determines whether match attribute values by regexp string.
+	EnabledRegexMatching bool `mapstructure:"enabled_regex_matching"`
+	// CacheMaxSize is the maximum number of attribute entries of LRU Cache that stores the matched result
+	// from the regular expressions defined in Values.
+	// CacheMaxSize will not be used if EnabledRegexMatching is set to false.
+	CacheMaxSize int `mapstructure:"cache_max_size"`
+	// InvertMatch indicates that values or regular expressions must not match against attribute values.
+	// If InvertMatch is true and Values is equal to 'acme', all other values will be sampled except 'acme'.
+	// Also, if the specified Key does not match on any resource or span attributes, data will be sampled.
+	InvertMatch bool `mapstructure:"invert_match"`
+}
+
+// RateLimitingCfg holds the configurable settings to create a rate limiting
+// sampling policy evaluator.
+type RateLimitingCfg struct {
+	// SpansPerSecond sets the limit on the maximum nuber of spans that can be processed each second.
+	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+}
+
+// SpanCountCfg holds the configurable settings to create a Span Count filter sampling policy
+// sampling policy evaluator
+type SpanCountCfg struct {
+	// Minimum number of spans in a Trace
+	MinSpans int32 `mapstructure:"min_spans"`
+}
+
+// Config holds the configuration for tail-based sampling.
+type Config struct {
+	config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	// DecisionWait is the desired wait time from the arrival of the first span of
+	// trace until the decision about sampling it or not is evaluated.
+	DecisionWait time.Duration `mapstructure:"decision_wait"`
+	// NumTraces is the number of traces kept on memory. Typically most of the data
+	// of a trace is released after a sampling decision is taken.
+	NumTraces uint64 `mapstructure:"num_traces"`
+	// ExpectedNewTracesPerSec sets the expected number of new traces sending to the tail sampling processor
+	// per second. This helps with allocating data structures with closer to actual usage size.
+	ExpectedNewTracesPerSec uint64 `mapstructure:"expected_new_traces_per_sec"`
+	// PolicyCfgs sets the tail-based sampling policy which makes a sampling decision
+	// for a given trace when requested.
+	PolicyCfgs []PolicyCfg `mapstructure:"policies"`
+}

--- a/processor/signoztailsampler/config_test.go
+++ b/processor/signoztailsampler/config_test.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "tail_sampling_config.yaml"))
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalProcessorConfig(sub, cfg))
+
+	assert.Equal(t,
+		cfg,
+		&Config{
+			ProcessorSettings:       config.NewProcessorSettings(component.NewID(typeStr)),
+			DecisionWait:            10 * time.Second,
+			NumTraces:               100,
+			ExpectedNewTracesPerSec: 10,
+			PolicyCfgs: []PolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name: "test-policy-1",
+						Type: AlwaysSample,
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-policy-2",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 5000},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:                "test-policy-3",
+						Type:                NumericAttribute,
+						NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:             "test-policy-4",
+						Type:             Probabilistic,
+						ProbabilisticCfg: ProbabilisticCfg{HashSalt: "custom-salt", SamplingPercentage: 0.1},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:          "test-policy-5",
+						Type:          StatusCode,
+						StatusCodeCfg: StatusCodeCfg{StatusCodes: []string{"ERROR", "UNSET"}},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:               "test-policy-6",
+						Type:               StringAttribute,
+						StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:            "test-policy-7",
+						Type:            RateLimiting,
+						RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:         "test-policy-8",
+						Type:         SpanCount,
+						SpanCountCfg: SpanCountCfg{MinSpans: 2},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:          "test-policy-9",
+						Type:          TraceState,
+						TraceStateCfg: TraceStateCfg{Key: "key3", Values: []string{"value1", "value2"}},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name: "and-policy-1",
+						Type: And,
+					},
+					AndCfg: AndCfg{
+						SubPolicyCfg: []AndSubPolicyCfg{
+							{
+								sharedPolicyCfg: sharedPolicyCfg{
+									Name:                "test-and-policy-1",
+									Type:                NumericAttribute,
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+								},
+							},
+							{
+								sharedPolicyCfg: sharedPolicyCfg{
+									Name:               "test-and-policy-2",
+									Type:               StringAttribute,
+									StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+								},
+							},
+						},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name: "composite-policy-1",
+						Type: Composite,
+					},
+					CompositeCfg: CompositeCfg{
+						MaxTotalSpansPerSecond: 1000,
+						PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2", "test-composite-policy-3"},
+						SubPolicyCfg: []CompositeSubPolicyCfg{
+							{
+								sharedPolicyCfg: sharedPolicyCfg{
+									Name:                "test-composite-policy-1",
+									Type:                NumericAttribute,
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+								},
+							},
+							{
+								sharedPolicyCfg: sharedPolicyCfg{
+									Name:               "test-composite-policy-2",
+									Type:               StringAttribute,
+									StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+								},
+							},
+							{
+								sharedPolicyCfg: sharedPolicyCfg{
+									Name: "test-composite-policy-3",
+									Type: AlwaysSample,
+								},
+							},
+						},
+						RateAllocation: []RateAllocationCfg{
+							{
+								Policy:  "test-composite-policy-1",
+								Percent: 50,
+							},
+							{
+								Policy:  "test-composite-policy-2",
+								Percent: 25,
+							},
+						},
+					},
+				},
+			},
+		})
+}

--- a/processor/signoztailsampler/factory.go
+++ b/processor/signoztailsampler/factory.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats/view"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/consumer"
+)
+
+const (
+	// The value of "type" Tail Sampling in configuration.
+	typeStr = "tail_sampling"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
+)
+
+var onceMetrics sync.Once
+
+// NewFactory returns a new factory for the Tail Sampling processor.
+func NewFactory() component.ProcessorFactory {
+	onceMetrics.Do(func() {
+		// TODO: this is hardcoding the metrics level and skips error handling
+		_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+	})
+
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithTracesProcessor(createTracesProcessor, stability))
+}
+
+func createDefaultConfig() component.ProcessorConfig {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(component.NewID(typeStr)),
+		DecisionWait:      30 * time.Second,
+		NumTraces:         50000,
+	}
+}
+
+func createTracesProcessor(
+	_ context.Context,
+	params component.ProcessorCreateSettings,
+	cfg component.ProcessorConfig,
+	nextConsumer consumer.Traces,
+) (component.TracesProcessor, error) {
+	tCfg := cfg.(*Config)
+	return newTracesProcessor(params.Logger, nextConsumer, *tCfg)
+}

--- a/processor/signoztailsampler/factory_test.go
+++ b/processor/signoztailsampler/factory_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+func TestCreateProcessor(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "tail_sampling_config.yaml"))
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalProcessorConfig(sub, cfg))
+
+	params := componenttest.NewNopProcessorCreateSettings()
+	tp, err := factory.CreateTracesProcessor(context.Background(), params, cfg, consumertest.NewNop())
+	assert.NotNil(t, tp)
+	assert.NoError(t, err, "cannot create trace processor")
+
+	// this will cause the processor to properly initialize, so that we can later shutdown and
+	// have all the go routines cleanly shut down
+	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, tp.Shutdown(context.Background()))
+}

--- a/processor/signoztailsampler/internal/idbatcher/id_batcher.go
+++ b/processor/signoztailsampler/internal/idbatcher/id_batcher.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idbatcher defines a pipeline of fixed size in which the
+// elements are batches of ids.
+package idbatcher // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
+
+import (
+	"errors"
+	"sync"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+var (
+	// ErrInvalidNumBatches occurs when an invalid number of batches is specified.
+	ErrInvalidNumBatches = errors.New("invalid number of batches, it must be greater than zero")
+	// ErrInvalidBatchChannelSize occurs when an invalid batch channel size is specified.
+	ErrInvalidBatchChannelSize = errors.New("invalid batch channel size, it must be greater than zero")
+)
+
+// Batch is the type of batches held by the Batcher.
+type Batch []pcommon.TraceID
+
+// Batcher behaves like a pipeline of batches that has a fixed number of batches in the pipe
+// and a new batch being built outside of the pipe. Items can be concurrently added to the batch
+// currently being built. When the batch being built is closed, the oldest batch in the pipe
+// is pushed out so the one just closed can be put on the end of the pipe (this is done as an
+// atomic operation). The caller is in control of when a batch is completed and a new one should
+// be started.
+type Batcher interface {
+	// AddToCurrentBatch puts the given id on the batch being currently built. The client is in charge
+	// of limiting the growth of the current batch if appropriate for its scenario. It can
+	// either call CloseCurrentAndTakeFirstBatch earlier or stop adding new items depending on what is
+	// required by the scenario.
+	AddToCurrentBatch(id pcommon.TraceID)
+	// CloseCurrentAndTakeFirstBatch takes the batch at the front of the pipe, and moves the current
+	// batch to the end of the pipe, creating a new batch to receive new items. This operation should
+	// be atomic.
+	// It returns the batch that was in front of the pipe and a boolean that if true indicates that
+	// there are more batches to be retrieved.
+	CloseCurrentAndTakeFirstBatch() (Batch, bool)
+	// Stop informs that no more items are going to be batched and the pipeline can be read until it
+	// is empty. After this method is called attempts to enqueue new items will panic.
+	Stop()
+}
+
+var _ Batcher = (*batcher)(nil)
+
+type batcher struct {
+	pendingIds chan pcommon.TraceID // Channel for the ids to be added to the next batch.
+	batches    chan Batch           // Channel with already captured batches.
+
+	// cbMutex protects the currentBatch storing ids.
+	cbMutex      sync.Mutex
+	currentBatch Batch
+
+	newBatchesInitialCapacity uint64
+	stopchan                  chan bool
+	stopped                   bool
+	stopLock                  sync.RWMutex
+}
+
+// New creates a Batcher that will hold numBatches in its pipeline, having a channel with
+// batchChannelSize to receive new items. New batches will be created with capacity set to
+// newBatchesInitialCapacity.
+func New(numBatches, newBatchesInitialCapacity, batchChannelSize uint64) (Batcher, error) {
+	if numBatches < 1 {
+		return nil, ErrInvalidNumBatches
+	}
+	if batchChannelSize < 1 {
+		return nil, ErrInvalidBatchChannelSize
+	}
+
+	batches := make(chan Batch, numBatches)
+	// First numBatches batches will be empty in order to simplify clients that are running
+	// CloseCurrentAndTakeFirstBatch on a timer and want to delay the processing of the first
+	// batch with actual data. This way there is no need for accounting on the client side and
+	// a single timer can be started immediately.
+	for i := uint64(0); i < numBatches; i++ {
+		batches <- nil
+	}
+
+	batcher := &batcher{
+		pendingIds:                make(chan pcommon.TraceID, batchChannelSize),
+		batches:                   batches,
+		currentBatch:              make(Batch, 0, newBatchesInitialCapacity),
+		newBatchesInitialCapacity: newBatchesInitialCapacity,
+		stopchan:                  make(chan bool),
+	}
+
+	// Single goroutine that keeps filling the current batch, contention is expected only
+	// when the current batch is being switched.
+	go func() {
+		for id := range batcher.pendingIds {
+			batcher.cbMutex.Lock()
+			batcher.currentBatch = append(batcher.currentBatch, id)
+			batcher.cbMutex.Unlock()
+		}
+		batcher.stopchan <- true
+	}()
+
+	return batcher, nil
+}
+
+func (b *batcher) AddToCurrentBatch(id pcommon.TraceID) {
+	b.pendingIds <- id
+}
+
+func (b *batcher) CloseCurrentAndTakeFirstBatch() (Batch, bool) {
+	if readBatch, ok := <-b.batches; ok {
+		b.stopLock.RLock()
+		if !b.stopped {
+			nextBatch := make(Batch, 0, b.newBatchesInitialCapacity)
+			b.cbMutex.Lock()
+			b.batches <- b.currentBatch
+			b.currentBatch = nextBatch
+			b.cbMutex.Unlock()
+		}
+		b.stopLock.RUnlock()
+		return readBatch, true
+	}
+
+	readBatch := b.currentBatch
+	b.currentBatch = nil
+	return readBatch, false
+}
+
+func (b *batcher) Stop() {
+	close(b.pendingIds)
+	b.stopLock.Lock()
+	b.stopped = <-b.stopchan
+	b.stopLock.Unlock()
+	close(b.batches)
+}

--- a/processor/signoztailsampler/internal/idbatcher/id_batcher_test.go
+++ b/processor/signoztailsampler/internal/idbatcher/id_batcher_test.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idbatcher
+
+import (
+	"encoding/binary"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/atomic"
+)
+
+func TestBatcherNew(t *testing.T) {
+	tests := []struct {
+		name                      string
+		numBatches                uint64
+		newBatchesInitialCapacity uint64
+		batchChannelSize          uint64
+		wantErr                   error
+	}{
+		{"invalid numBatches", 0, 0, 1, ErrInvalidNumBatches},
+		{"invalid batchChannelSize", 1, 0, 0, ErrInvalidBatchChannelSize},
+		{"valid", 1, 0, 1, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.numBatches, tt.newBatchesInitialCapacity, tt.batchChannelSize)
+			require.ErrorIs(t, err, tt.wantErr)
+			if got != nil {
+				got.Stop()
+			}
+		})
+	}
+}
+
+func TestTypicalConfig(t *testing.T) {
+	concurrencyTest(t, 10, 100, uint64(4*runtime.NumCPU()))
+}
+
+func TestMinBufferedChannels(t *testing.T) {
+	concurrencyTest(t, 1, 0, 1)
+}
+
+func BenchmarkConcurrentEnqueue(b *testing.B) {
+	ids := generateSequentialIds(1)
+	batcher, err := New(10, 100, uint64(4*runtime.NumCPU()))
+	defer batcher.Stop()
+	if err != nil {
+		b.Fatalf("Failed to create Batcher: %v", err)
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	ticked := atomic.NewInt64(0)
+	received := atomic.NewInt64(0)
+	go func() {
+		for range ticker.C {
+			batch, _ := batcher.CloseCurrentAndTakeFirstBatch()
+			ticked.Inc()
+			received.Add(int64(len(batch)))
+		}
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			batcher.AddToCurrentBatch(ids[0])
+		}
+	})
+}
+
+func concurrencyTest(t *testing.T, numBatches, newBatchesInitialCapacity, batchChannelSize uint64) {
+	batcher, err := New(numBatches, newBatchesInitialCapacity, batchChannelSize)
+	require.NoError(t, err, "Failed to create Batcher: %v", err)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	stopTicker := make(chan bool)
+	var got Batch
+	go func() {
+		var completedDequeues uint64
+	outer:
+		for {
+			select {
+			case <-ticker.C:
+				g, _ := batcher.CloseCurrentAndTakeFirstBatch()
+				completedDequeues++
+				if completedDequeues <= numBatches && len(g) != 0 {
+					t.Error("Some of the first batches were not empty")
+					return
+				}
+				got = append(got, g...)
+			case <-stopTicker:
+				break outer
+			}
+		}
+	}()
+
+	ids := generateSequentialIds(10000)
+	wg := &sync.WaitGroup{}
+	for i := 0; i < len(ids); i++ {
+		wg.Add(1)
+		go func(id pcommon.TraceID) {
+			batcher.AddToCurrentBatch(id)
+			wg.Done()
+		}(ids[i])
+	}
+
+	wg.Wait()
+	stopTicker <- true
+	ticker.Stop()
+	batcher.Stop()
+
+	// Get all ids added to the batcher
+	for {
+		batch, ok := batcher.CloseCurrentAndTakeFirstBatch()
+		got = append(got, batch...)
+		if !ok {
+			break
+		}
+	}
+
+	require.Equal(t, len(ids), len(got), "Batcher got incorrect count of traces from batches")
+
+	idSeen := make(map[[16]byte]bool, len(ids))
+	for _, id := range got {
+		idSeen[id] = true
+	}
+
+	for i := 0; i < len(ids); i++ {
+		require.True(t, idSeen[ids[i]], "want id %v but id was not seen", ids[i])
+	}
+}
+
+func generateSequentialIds(numIds uint64) []pcommon.TraceID {
+	ids := make([]pcommon.TraceID, numIds)
+	for i := uint64(0); i < numIds; i++ {
+		traceID := [16]byte{}
+		binary.BigEndian.PutUint64(traceID[:8], 0)
+		binary.BigEndian.PutUint64(traceID[8:], i)
+		ids[i] = pcommon.TraceID(traceID)
+	}
+	return ids
+}

--- a/processor/signoztailsampler/internal/sampling/always_sample.go
+++ b/processor/signoztailsampler/internal/sampling/always_sample.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+type alwaysSample struct {
+	logger *zap.Logger
+}
+
+var _ PolicyEvaluator = (*alwaysSample)(nil)
+
+// NewAlwaysSample creates a policy evaluator the samples all traces.
+func NewAlwaysSample(logger *zap.Logger) PolicyEvaluator {
+	return &alwaysSample{
+		logger: logger,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (as *alwaysSample) Evaluate(pcommon.TraceID, *TraceData) (Decision, error) {
+	as.logger.Debug("Evaluating spans in always-sample filter")
+	return Sampled, nil
+}

--- a/processor/signoztailsampler/internal/sampling/always_sample_test.go
+++ b/processor/signoztailsampler/internal/sampling/always_sample_test.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+func TestEvaluate_AlwaysSample(t *testing.T) {
+	filter := NewAlwaysSample(zap.NewNop())
+	decision, err := filter.Evaluate(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		16}), newTraceStringAttrs(nil, "example", "value"))
+	assert.Nil(t, err)
+	assert.Equal(t, decision, Sampled)
+}

--- a/processor/signoztailsampler/internal/sampling/and.go
+++ b/processor/signoztailsampler/internal/sampling/and.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+type And struct {
+	// the subpolicy evaluators
+	subpolicies []PolicyEvaluator
+	logger      *zap.Logger
+}
+
+func NewAnd(
+	logger *zap.Logger,
+	subpolicies []PolicyEvaluator,
+) PolicyEvaluator {
+
+	return &And{
+		subpolicies: subpolicies,
+		logger:      logger,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (c *And) Evaluate(traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
+	// The policy iterates over all sub-policies and returns Sampled if all sub-policies returned a Sampled Decision.
+	// If any subpolicy returns NotSampled, it returns NotSampled Decision.
+	for _, sub := range c.subpolicies {
+		decision, err := sub.Evaluate(traceID, trace)
+		if err != nil {
+			return Unspecified, err
+		}
+		if decision == NotSampled || decision == InvertNotSampled {
+			return NotSampled, nil
+		}
+
+	}
+	return Sampled, nil
+}
+
+// OnDroppedSpans is called when the trace needs to be dropped, due to memory
+// pressure, before the decision_wait time has been reached.
+func (c *And) OnDroppedSpans(pcommon.TraceID, *TraceData) (Decision, error) {
+	return Sampled, nil
+}

--- a/processor/signoztailsampler/internal/sampling/and_test.go
+++ b/processor/signoztailsampler/internal/sampling/and_test.go
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestAndEvaluatorNotSampled(t *testing.T) {
+	n1 := NewStringAttributeFilter(zap.NewNop(), "name", []string{"value"}, false, 0, false)
+	n2, err := NewStatusCodeFilter(zap.NewNop(), []string{"ERROR"})
+	if err != nil {
+		t.FailNow()
+	}
+
+	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+
+	span := ils.Spans().AppendEmpty()
+	span.Status().SetCode(ptrace.StatusCodeError)
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	trace := &TraceData{
+		ReceivedBatches: traces,
+	}
+	decision, err := and.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
+	assert.Equal(t, decision, NotSampled)
+
+}
+
+func TestAndEvaluatorSampled(t *testing.T) {
+	n1 := NewStringAttributeFilter(zap.NewNop(), "attribute_name", []string{"attribute_value"}, false, 0, false)
+	n2, err := NewStatusCodeFilter(zap.NewNop(), []string{"ERROR"})
+	if err != nil {
+		t.FailNow()
+	}
+
+	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+
+	span := ils.Spans().AppendEmpty()
+	span.Attributes().PutStr("attribute_name", "attribute_value")
+	span.Status().SetCode(ptrace.StatusCodeError)
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	trace := &TraceData{
+		ReceivedBatches: traces,
+	}
+	decision, err := and.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
+	assert.Equal(t, decision, Sampled)
+
+}
+
+func TestAndEvaluatorStringInvertSampled(t *testing.T) {
+	n1 := NewStringAttributeFilter(zap.NewNop(), "attribute_name", []string{"no_match"}, false, 0, true)
+	n2, err := NewStatusCodeFilter(zap.NewNop(), []string{"ERROR"})
+	if err != nil {
+		t.FailNow()
+	}
+
+	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+
+	span := ils.Spans().AppendEmpty()
+	span.Attributes().PutStr("attribute_name", "attribute_value")
+	span.Status().SetCode(ptrace.StatusCodeError)
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	trace := &TraceData{
+		ReceivedBatches: traces,
+	}
+	decision, err := and.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
+	assert.Equal(t, decision, Sampled)
+
+}
+
+func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
+	n1 := NewStringAttributeFilter(zap.NewNop(), "attribute_name", []string{"attribute_value"}, false, 0, true)
+	n2, err := NewStatusCodeFilter(zap.NewNop(), []string{"ERROR"})
+	if err != nil {
+		t.FailNow()
+	}
+
+	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+
+	span := ils.Spans().AppendEmpty()
+	span.Attributes().PutStr("attribute_name", "attribute_value")
+	span.Status().SetCode(ptrace.StatusCodeError)
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	trace := &TraceData{
+		ReceivedBatches: traces,
+	}
+	decision, err := and.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
+	assert.Equal(t, decision, NotSampled)
+
+}

--- a/processor/signoztailsampler/internal/sampling/composite.go
+++ b/processor/signoztailsampler/internal/sampling/composite.go
@@ -1,0 +1,153 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+type subpolicy struct {
+	// the subpolicy evaluator
+	evaluator PolicyEvaluator
+
+	// spans per second allocated to each subpolicy
+	allocatedSPS int64
+
+	// spans per second that each subpolicy sampled in this period
+	sampledSPS int64
+}
+
+// Composite evaluator and its internal data
+type Composite struct {
+	// the subpolicy evaluators
+	subpolicies []*subpolicy
+
+	// maximum total spans per second that must be sampled
+	maxTotalSPS int64
+
+	// current unix timestamp second
+	currentSecond int64
+
+	// The time provider (can be different from clock for testing purposes)
+	timeProvider TimeProvider
+
+	logger *zap.Logger
+}
+
+var _ PolicyEvaluator = (*Composite)(nil)
+
+// SubPolicyEvalParams defines the evaluator and max rate for a sub-policy
+type SubPolicyEvalParams struct {
+	Evaluator         PolicyEvaluator
+	MaxSpansPerSecond int64
+}
+
+// NewComposite creates a policy evaluator that samples all subpolicies.
+func NewComposite(
+	logger *zap.Logger,
+	maxTotalSpansPerSecond int64,
+	subPolicyParams []SubPolicyEvalParams,
+	timeProvider TimeProvider,
+) PolicyEvaluator {
+
+	var subpolicies []*subpolicy
+
+	for i := 0; i < len(subPolicyParams); i++ {
+		sub := &subpolicy{}
+		sub.evaluator = subPolicyParams[i].Evaluator
+		sub.allocatedSPS = subPolicyParams[i].MaxSpansPerSecond
+
+		// We are just starting, so there is no previous input, set it to 0
+		sub.sampledSPS = 0
+
+		subpolicies = append(subpolicies, sub)
+	}
+
+	return &Composite{
+		maxTotalSPS:  maxTotalSpansPerSecond,
+		subpolicies:  subpolicies,
+		timeProvider: timeProvider,
+		logger:       logger,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (c *Composite) Evaluate(traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
+	// Rate limiting works by counting spans that are sampled during each 1 second
+	// time period. Until the total number of spans during a particular second
+	// exceeds the allocated number of spans-per-second the traces are sampled,
+	// once the limit is exceeded the traces are no longer sampled. The counter
+	// restarts at the beginning of each second.
+	// Current counters and rate limits are kept separately for each subpolicy.
+
+	currSecond := c.timeProvider.getCurSecond()
+	if c.currentSecond != currSecond {
+		// This is a new second
+		c.currentSecond = currSecond
+		// Reset counters
+		for i := range c.subpolicies {
+			c.subpolicies[i].sampledSPS = 0
+		}
+	}
+
+	for _, sub := range c.subpolicies {
+		decision, err := sub.evaluator.Evaluate(traceID, trace)
+		if err != nil {
+			return Unspecified, err
+		}
+
+		if decision == Sampled || decision == InvertSampled {
+			// The subpolicy made a decision to Sample. Now we need to make our decision.
+
+			// Calculate resulting SPS counter if we decide to sample this trace
+			spansInSecondIfSampled := sub.sampledSPS + trace.SpanCount.Load()
+
+			// Check if the rate will be within the allocated bandwidth.
+			if spansInSecondIfSampled <= sub.allocatedSPS && spansInSecondIfSampled <= c.maxTotalSPS {
+				sub.sampledSPS = spansInSecondIfSampled
+
+				// Let the sampling happen
+				return Sampled, nil
+			}
+
+			// We exceeded the rate limit. Don't sample this trace.
+			// Note that we will continue evaluating new incoming traces against
+			// allocated SPS, we do not update sub.sampledSPS here in order to give
+			// chance to another smaller trace to be accepted later.
+			return NotSampled, nil
+		}
+	}
+
+	return NotSampled, nil
+}
+
+// OnDroppedSpans is called when the trace needs to be dropped, due to memory
+// pressure, before the decision_wait time has been reached.
+func (c *Composite) OnDroppedSpans(pcommon.TraceID, *TraceData) (Decision, error) {
+	// Here we have a number of possible solutions:
+	// 1. Random sample traces based on maxTotalSPS.
+	// 2. Perform full composite sampling logic by calling Composite.Evaluate(), essentially
+	//    using partial trace data for sampling.
+	// 3. Sample everything.
+	//
+	// It seems that #2 may be the best choice from end user perspective, but
+	// it is not certain and it is also additional performance penalty when we are
+	// already under a memory (and possibly CPU) pressure situation.
+	//
+	// For now we are playing safe and go with #3. Investigating alternate options
+	// should be a future task.
+	return Sampled, nil
+}

--- a/processor/signoztailsampler/internal/sampling/composite_test.go
+++ b/processor/signoztailsampler/internal/sampling/composite_test.go
@@ -1,0 +1,280 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sampling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+type FakeTimeProvider struct {
+	second int64
+}
+
+func (f FakeTimeProvider) getCurSecond() int64 {
+	return f.second
+}
+
+var traceID = pcommon.TraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x96, 0x9A, 0x89, 0x55, 0x57, 0x1A, 0x3F})
+
+func createTrace() *TraceData {
+	trace := &TraceData{SpanCount: atomic.NewInt64(1), ReceivedBatches: ptrace.NewTraces()}
+	return trace
+}
+
+func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+	span := ils.Spans().AppendEmpty()
+	span.SetTraceID(traceID)
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(
+		time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+	))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(
+		time.Date(2020, 1, 1, 12, 0, 16, 0, time.UTC),
+	))
+	span.Attributes().PutInt(key, val)
+
+	return &TraceData{
+		ReceivedBatches: traces,
+		SpanCount:       atomic.NewInt64(1),
+	}
+}
+
+func TestCompositeEvaluatorNotSampled(t *testing.T) {
+
+	// Create 2 policies which do not match any trace
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewNumericAttributeFilter(zap.NewNop(), "tag", 200, 300)
+	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
+
+	trace := createTrace()
+
+	decision, err := c.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+	// None of the numeric filters should match since input trace data does not contain
+	// the "tag", so the decision should be NotSampled.
+	expected := NotSampled
+	assert.Equal(t, decision, expected)
+}
+
+func TestCompositeEvaluatorSampled(t *testing.T) {
+
+	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
+
+	trace := createTrace()
+
+	decision, err := c.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+	// The second policy is AlwaysSample, so the decision should be Sampled.
+	expected := Sampled
+	assert.Equal(t, decision, expected)
+}
+
+func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
+
+	timeProvider := &FakeTimeProvider{second: 0}
+
+	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	c := NewComposite(zap.NewNop(), 3, []SubPolicyEvalParams{{n1, 1}, {n2, 1}}, timeProvider)
+
+	trace := newTraceWithKV(traceID, "tag", int64(10))
+
+	decision, err := c.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+	// The first policy is NewNumericAttributeFilter and trace tag matches criteria, so the decision should be Sampled.
+	expected := Sampled
+	assert.Equal(t, decision, expected)
+
+	trace = newTraceWithKV(traceID, "tag", int64(11))
+
+	decision, err = c.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+	// The first policy is NewNumericAttributeFilter and trace tag matches criteria, so the decision should be Sampled.
+	expected = NotSampled
+	assert.Equal(t, decision, expected)
+
+	trace = newTraceWithKV(traceID, "tag", int64(1001))
+	decision, err = c.Evaluate(traceID, trace)
+	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+	// The first policy fails as the tag value is higher than the range set where as the second policy is AlwaysSample, so the decision should be Sampled.
+	expected = Sampled
+	assert.Equal(t, decision, expected)
+}
+
+func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
+
+	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	c := NewComposite(zap.NewNop(), 10, []SubPolicyEvalParams{{n1, 20}, {n2, 20}}, FakeTimeProvider{})
+
+	for i := 1; i <= 10; i++ {
+		trace := createTrace()
+
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		// The second policy is AlwaysSample, so the decision should be Sampled.
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+}
+
+func TestCompositeEvaluatorInverseSampled_AlwaysSampled(t *testing.T) {
+
+	// The first policy does not match, the second matches through invert
+	n1 := NewStringAttributeFilter(zap.NewNop(), "tag", []string{"foo"}, false, 0, false)
+	n2 := NewStringAttributeFilter(zap.NewNop(), "tag", []string{"foo"}, false, 0, true)
+	c := NewComposite(zap.NewNop(), 10, []SubPolicyEvalParams{{n1, 20}, {n2, 20}}, FakeTimeProvider{})
+
+	for i := 1; i <= 10; i++ {
+		trace := createTrace()
+
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		// The second policy is AlwaysSample, so the decision should be Sampled.
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+}
+
+func TestCompositeEvaluatorThrottling(t *testing.T) {
+
+	// Create only one subpolicy, with 100% Sampled policy.
+	n1 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 10
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS}}, timeProvider)
+
+	trace := createTrace()
+
+	// First totalSPS traces should be 100% Sampled
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+
+	// Now we hit the rate limit, so subsequent evaluations should result in 100% NotSampled
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := NotSampled
+		assert.Equal(t, decision, expected)
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// Subsequent sampling should be Sampled again because it is a new second.
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+}
+
+func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
+
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 10
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS / 2}, {n2, totalSPS / 2}}, timeProvider)
+
+	trace := createTrace()
+
+	// We have 2 subpolicies, so each should initially get half the bandwidth
+
+	// First totalSPS/2 should be Sampled until we hit the rate limit
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Now we hit the rate limit for second subpolicy, so subsequent evaluations should result in NotSampled
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := NotSampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// It is a new second, so we should start sampling again.
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+
+	// Now let's hit the hard limit and exceed the total by a factor of 2
+	for i := 0; i < 2*totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := NotSampled
+		assert.Equal(t, decision, expected)
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// It is a new second, so we should start sampling again.
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
+
+		expected := Sampled
+		assert.Equal(t, decision, expected)
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/doc.go
+++ b/processor/signoztailsampler/internal/sampling/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sampling contains the interfaces and data types used to implement
+// the various sampling policies.
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"

--- a/processor/signoztailsampler/internal/sampling/latency.go
+++ b/processor/signoztailsampler/internal/sampling/latency.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+type latency struct {
+	logger      *zap.Logger
+	thresholdMs int64
+}
+
+var _ PolicyEvaluator = (*latency)(nil)
+
+// NewLatency creates a policy evaluator sampling traces with a duration higher than a configured threshold
+func NewLatency(logger *zap.Logger, thresholdMs int64) PolicyEvaluator {
+	return &latency{
+		logger:      logger,
+		thresholdMs: thresholdMs,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (l *latency) Evaluate(_ pcommon.TraceID, traceData *TraceData) (Decision, error) {
+	l.logger.Debug("Evaluating spans in latency filter")
+
+	traceData.Lock()
+	batches := traceData.ReceivedBatches
+	traceData.Unlock()
+
+	var minTime pcommon.Timestamp
+	var maxTime pcommon.Timestamp
+
+	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
+		if minTime == 0 || span.StartTimestamp() < minTime {
+			minTime = span.StartTimestamp()
+		}
+		if maxTime == 0 || span.EndTimestamp() > maxTime {
+			maxTime = span.EndTimestamp()
+		}
+
+		duration := maxTime.AsTime().Sub(minTime.AsTime())
+		return duration.Milliseconds() >= l.thresholdMs
+	}), nil
+}

--- a/processor/signoztailsampler/internal/sampling/latency_test.go
+++ b/processor/signoztailsampler/internal/sampling/latency_test.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestEvaluate_Latency(t *testing.T) {
+	filter := NewLatency(zap.NewNop(), 5000)
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	now := time.Now()
+
+	cases := []struct {
+		Desc     string
+		Spans    []spanWithTimeAndDuration
+		Decision Decision
+	}{
+		{
+			"trace duration shorter than threshold",
+			[]spanWithTimeAndDuration{
+				{
+					StartTime: now,
+					Duration:  4500 * time.Millisecond,
+				},
+			},
+			NotSampled,
+		},
+		{
+			"trace duration is equal to threshold",
+			[]spanWithTimeAndDuration{
+				{
+					StartTime: now,
+					Duration:  5000 * time.Millisecond,
+				},
+			},
+			Sampled,
+		},
+		{
+			"total trace duration is longer than threshold but every single span is shorter",
+			[]spanWithTimeAndDuration{
+				{
+					StartTime: now,
+					Duration:  3000 * time.Millisecond,
+				},
+				{
+					StartTime: now.Add(2500 * time.Millisecond),
+					Duration:  3000 * time.Millisecond,
+				},
+			},
+			Sampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			decision, err := filter.Evaluate(traceID, newTraceWithSpans(c.Spans))
+
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+type spanWithTimeAndDuration struct {
+	StartTime time.Time
+	Duration  time.Duration
+}
+
+func newTraceWithSpans(spans []spanWithTimeAndDuration) *TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+
+	for _, s := range spans {
+		span := ils.Spans().AppendEmpty()
+		span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(s.StartTime))
+		span.SetEndTimestamp(pcommon.NewTimestampFromTime(s.StartTime.Add(s.Duration)))
+	}
+
+	return &TraceData{
+		ReceivedBatches: traces,
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/numeric_tag_filter.go
+++ b/processor/signoztailsampler/internal/sampling/numeric_tag_filter.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+type numericAttributeFilter struct {
+	key                string
+	minValue, maxValue int64
+	logger             *zap.Logger
+}
+
+var _ PolicyEvaluator = (*numericAttributeFilter)(nil)
+
+// NewNumericAttributeFilter creates a policy evaluator that samples all traces with
+// the given attribute in the given numeric range.
+func NewNumericAttributeFilter(logger *zap.Logger, key string, minValue, maxValue int64) PolicyEvaluator {
+	return &numericAttributeFilter{
+		key:      key,
+		minValue: minValue,
+		maxValue: maxValue,
+		logger:   logger,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (naf *numericAttributeFilter) Evaluate(_ pcommon.TraceID, trace *TraceData) (Decision, error) {
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
+		if v, ok := span.Attributes().Get(naf.key); ok {
+			value := v.Int()
+			if value >= naf.minValue && value <= naf.maxValue {
+				return true
+			}
+		}
+		return false
+	}), nil
+}

--- a/processor/signoztailsampler/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/signoztailsampler/internal/sampling/numeric_tag_filter_test.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestNumericTagFilter(t *testing.T) {
+
+	var empty = map[string]interface{}{}
+	filter := NewNumericAttributeFilter(zap.NewNop(), "example", math.MinInt32, math.MaxInt32)
+
+	resAttr := map[string]interface{}{}
+	resAttr["example"] = 8
+
+	cases := []struct {
+		Desc     string
+		Trace    *TraceData
+		Decision Decision
+	}{
+		{
+			Desc:     "nonmatching span attribute",
+			Trace:    newTraceIntAttrs(empty, "non_matching", math.MinInt32),
+			Decision: NotSampled,
+		},
+		{
+			Desc:     "span attribute with lower limit",
+			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
+			Decision: Sampled,
+		},
+		{
+			Desc:     "span attribute with upper limit",
+			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
+			Decision: Sampled,
+		},
+		{
+			Desc:     "span attribute below min limit",
+			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32-1),
+			Decision: NotSampled,
+		},
+		{
+			Desc:     "span attribute above max limit",
+			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32+1),
+			Decision: NotSampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			u, _ := uuid.NewRandom()
+			decision, err := filter.Evaluate(pcommon.TraceID(u), c.Trace)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+func newTraceIntAttrs(nodeAttrs map[string]interface{}, spanAttrKey string, spanAttrValue int64) *TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	//nolint:errcheck
+	rs.Resource().Attributes().FromRaw(nodeAttrs)
+	ils := rs.ScopeSpans().AppendEmpty()
+	span := ils.Spans().AppendEmpty()
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	span.Attributes().PutInt(spanAttrKey, spanAttrValue)
+	return &TraceData{
+		ReceivedBatches: traces,
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/policy.go
+++ b/processor/signoztailsampler/internal/sampling/policy.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
+)
+
+// TraceData stores the sampling related trace data.
+type TraceData struct {
+	sync.Mutex
+	// Decisions gives the current status of the sampling decision for each policy.
+	Decisions []Decision
+	// Arrival time the first span for the trace was received.
+	ArrivalTime time.Time
+	// Decisiontime time when sampling decision was taken.
+	DecisionTime time.Time
+	// SpanCount track the number of spans on the trace.
+	SpanCount *atomic.Int64
+	// ReceivedBatches stores all the batches received for the trace.
+	ReceivedBatches ptrace.Traces
+}
+
+// Decision gives the status of sampling decision.
+type Decision int32
+
+const (
+	// Unspecified indicates that the status of the decision was not set yet.
+	Unspecified Decision = iota
+	// Pending indicates that the policy was not evaluated yet.
+	Pending
+	// Sampled is used to indicate that the decision was already taken
+	// to sample the data.
+	Sampled
+	// NotSampled is used to indicate that the decision was already taken
+	// to not sample the data.
+	NotSampled
+	// Dropped is used when data needs to be purged before the sampling policy
+	// had a chance to evaluate it.
+	Dropped
+	// Error is used to indicate that policy evaluation was not succeeded.
+	Error
+	// InvertSampled is used on the invert match flow and indicates to sample
+	// the data.
+	InvertSampled
+	// InvertNotSampled is used on the invert match flow and indicates to not
+	// sample the data.
+	InvertNotSampled
+)
+
+// PolicyEvaluator implements a tail-based sampling policy evaluator,
+// which makes a sampling decision for a given trace when requested.
+type PolicyEvaluator interface {
+	// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+	Evaluate(traceID pcommon.TraceID, trace *TraceData) (Decision, error)
+}

--- a/processor/signoztailsampler/internal/sampling/probabilistic.go
+++ b/processor/signoztailsampler/internal/sampling/probabilistic.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"hash/fnv"
+	"math"
+	"math/big"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultHashSalt = "default-hash-seed"
+)
+
+type probabilisticSampler struct {
+	logger    *zap.Logger
+	threshold uint64
+	hashSalt  string
+}
+
+var _ PolicyEvaluator = (*probabilisticSampler)(nil)
+
+// NewProbabilisticSampler creates a policy evaluator that samples a percentage of
+// traces.
+func NewProbabilisticSampler(logger *zap.Logger, hashSalt string, samplingPercentage float64) PolicyEvaluator {
+	if hashSalt == "" {
+		hashSalt = defaultHashSalt
+	}
+
+	return &probabilisticSampler{
+		logger: logger,
+		// calculate threshold once
+		threshold: calculateThreshold(samplingPercentage / 100),
+		hashSalt:  hashSalt,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (s *probabilisticSampler) Evaluate(traceID pcommon.TraceID, _ *TraceData) (Decision, error) {
+	s.logger.Debug("Evaluating spans in probabilistic filter")
+
+	if hashTraceID(s.hashSalt, traceID[:]) <= s.threshold {
+		return Sampled, nil
+	}
+
+	return NotSampled, nil
+}
+
+// calculateThreshold converts a ratio into a value between 0 and MaxUint64
+func calculateThreshold(ratio float64) uint64 {
+	// Use big.Float and big.Int to calculate threshold because directly convert
+	// math.MaxUint64 to float64 will cause digits/bits to be cut off if the converted value
+	// doesn't fit into bits that are used to store digits for float64 in Golang
+	boundary := new(big.Float).SetInt(new(big.Int).SetUint64(math.MaxUint64))
+	res, _ := boundary.Mul(boundary, big.NewFloat(ratio)).Uint64()
+	return res
+}
+
+// hashTraceID creates a hash using the FNV-1a algorithm.
+func hashTraceID(salt string, b []byte) uint64 {
+	hasher := fnv.New64a()
+	// the implementation fnv.Write() never returns an error, see hash/fnv/fnv.go
+	_, _ = hasher.Write([]byte(salt))
+	_, _ = hasher.Write(b)
+	return hasher.Sum64()
+}

--- a/processor/signoztailsampler/internal/sampling/probabilistic_test.go
+++ b/processor/signoztailsampler/internal/sampling/probabilistic_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+func TestProbabilisticSampling(t *testing.T) {
+	tests := []struct {
+		name                       string
+		samplingPercentage         float64
+		hashSalt                   string
+		expectedSamplingPercentage float64
+	}{
+		{
+			"100%",
+			100,
+			"",
+			100,
+		},
+		{
+			"0%",
+			0,
+			"",
+			0,
+		},
+		{
+			"25%",
+			25,
+			"",
+			25,
+		},
+		{
+			"33%",
+			33,
+			"",
+			33,
+		},
+		{
+			"33% - custom salt",
+			33,
+			"test-salt",
+			33,
+		},
+		{
+			"-%50",
+			-50,
+			"",
+			0,
+		},
+		{
+			"150%",
+			150,
+			"",
+			100,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			traceCount := 100_000
+
+			probabilisticSampler := NewProbabilisticSampler(zap.NewNop(), tt.hashSalt, tt.samplingPercentage)
+
+			sampled := 0
+			for _, traceID := range genRandomTraceIDs(traceCount) {
+				trace := newTraceStringAttrs(nil, "example", "value")
+
+				decision, err := probabilisticSampler.Evaluate(traceID, trace)
+				assert.NoError(t, err)
+
+				if decision == Sampled {
+					sampled++
+				}
+			}
+
+			effectiveSamplingPercentage := float32(sampled) / float32(traceCount) * 100
+			assert.InDelta(t, tt.expectedSamplingPercentage, effectiveSamplingPercentage, 0.2,
+				"Effective sampling percentage is %f, expected %f", effectiveSamplingPercentage, tt.expectedSamplingPercentage,
+			)
+		})
+	}
+}
+
+func genRandomTraceIDs(num int) (ids []pcommon.TraceID) {
+	r := rand.New(rand.NewSource(1))
+	ids = make([]pcommon.TraceID, 0, num)
+	for i := 0; i < num; i++ {
+		traceID := [16]byte{}
+		binary.BigEndian.PutUint64(traceID[:8], r.Uint64())
+		binary.BigEndian.PutUint64(traceID[8:], r.Uint64())
+		ids = append(ids, pcommon.TraceID(traceID))
+	}
+	return ids
+}

--- a/processor/signoztailsampler/internal/sampling/rate_limiting.go
+++ b/processor/signoztailsampler/internal/sampling/rate_limiting.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+type rateLimiting struct {
+	currentSecond        int64
+	spansInCurrentSecond int64
+	spansPerSecond       int64
+	logger               *zap.Logger
+}
+
+var _ PolicyEvaluator = (*rateLimiting)(nil)
+
+// NewRateLimiting creates a policy evaluator the samples all traces.
+func NewRateLimiting(logger *zap.Logger, spansPerSecond int64) PolicyEvaluator {
+	return &rateLimiting{
+		spansPerSecond: spansPerSecond,
+		logger:         logger,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (r *rateLimiting) Evaluate(_ pcommon.TraceID, trace *TraceData) (Decision, error) {
+	r.logger.Debug("Evaluating spans in rate-limiting filter")
+	currSecond := time.Now().Unix()
+	if r.currentSecond != currSecond {
+		r.currentSecond = currSecond
+		r.spansInCurrentSecond = 0
+	}
+
+	spansInSecondIfSampled := r.spansInCurrentSecond + trace.SpanCount.Load()
+	if spansInSecondIfSampled < r.spansPerSecond {
+		r.spansInCurrentSecond = spansInSecondIfSampled
+		return Sampled, nil
+	}
+
+	return NotSampled, nil
+}

--- a/processor/signoztailsampler/internal/sampling/rate_limiting_test.go
+++ b/processor/signoztailsampler/internal/sampling/rate_limiting_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+func TestRateLimiter(t *testing.T) {
+	trace := newTraceStringAttrs(nil, "example", "value")
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rateLimiter := NewRateLimiting(zap.NewNop(), 3)
+
+	// Trace span count greater than spans per second
+	trace.SpanCount = atomic.NewInt64(10)
+	decision, err := rateLimiter.Evaluate(traceID, trace)
+	assert.Nil(t, err)
+	assert.Equal(t, decision, NotSampled)
+
+	// Trace span count equal to spans per second
+	trace.SpanCount = atomic.NewInt64(3)
+	decision, err = rateLimiter.Evaluate(traceID, trace)
+	assert.Nil(t, err)
+	assert.Equal(t, decision, NotSampled)
+
+	// Trace span count less than spans per second
+	trace.SpanCount = atomic.NewInt64(2)
+	decision, err = rateLimiter.Evaluate(traceID, trace)
+	assert.Nil(t, err)
+	assert.Equal(t, decision, Sampled)
+
+	// Trace span count less than spans per second
+	trace.SpanCount = atomic.NewInt64(0)
+	decision, err = rateLimiter.Evaluate(traceID, trace)
+	assert.Nil(t, err)
+	assert.Equal(t, decision, Sampled)
+}

--- a/processor/signoztailsampler/internal/sampling/span_count_sampler.go
+++ b/processor/signoztailsampler/internal/sampling/span_count_sampler.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+type spanCount struct {
+	logger   *zap.Logger
+	minSpans int32
+}
+
+var _ PolicyEvaluator = (*spanCount)(nil)
+
+// NewSpanCount creates a policy evaluator sampling traces with more than one span per trace
+func NewSpanCount(logger *zap.Logger, minSpans int32) PolicyEvaluator {
+	return &spanCount{
+		logger:   logger,
+		minSpans: minSpans,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (c *spanCount) Evaluate(_ pcommon.TraceID, traceData *TraceData) (Decision, error) {
+	c.logger.Debug("Evaluating spans counts in filter")
+
+	if int(traceData.SpanCount.Load()) >= int(c.minSpans) {
+		return Sampled, nil
+	}
+	return NotSampled, nil
+}

--- a/processor/signoztailsampler/internal/sampling/span_count_sampler_test.go
+++ b/processor/signoztailsampler/internal/sampling/span_count_sampler_test.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+func TestEvaluate_NumberSpans(t *testing.T) {
+	filter := NewSpanCount(zap.NewNop(), 2)
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	cases := []struct {
+		Desc        string
+		NumberSpans []int32
+		Decision    Decision
+	}{
+		{
+			"Only one trace, less than the threshold",
+			[]int32{
+				1,
+			},
+			NotSampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, in one single batch",
+			[]int32{
+				3,
+			},
+			Sampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, with different span count per batch",
+			[]int32{
+				1, 2, 1,
+			},
+			Sampled,
+		},
+		{
+			"Same number of spans as the threshold, in one single batch",
+			[]int32{
+				2,
+			},
+			Sampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, across multiple batches",
+			[]int32{
+				1, 1, 1,
+			},
+			Sampled,
+		},
+		{
+			"Bigger amount of spans than the threshold, with a different number",
+			[]int32{
+				1, 3, 1,
+			},
+			Sampled,
+		},
+		{
+			"Same number of spans as the threshold, across multiple batches",
+			[]int32{
+				1, 1,
+			},
+			Sampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			decision, err := filter.Evaluate(traceID, newTraceWithMultipleSpans(c.NumberSpans))
+
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
+	var totalNumberSpans = int32(0)
+
+	// For each resource, going to create the number of spans defined in the array
+	traces := ptrace.NewTraces()
+	for i := range numberSpans {
+		// Creates trace
+		rs := traces.ResourceSpans().AppendEmpty()
+		ils := rs.ScopeSpans().AppendEmpty()
+
+		for r := 0; r < int(numberSpans[i]); r++ {
+			span := ils.Spans().AppendEmpty()
+			span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+			span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		}
+		totalNumberSpans += numberSpans[i]
+	}
+
+	return &TraceData{
+		ReceivedBatches: traces,
+		SpanCount:       atomic.NewInt64(int64(totalNumberSpans)),
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/status_code.go
+++ b/processor/signoztailsampler/internal/sampling/status_code.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+type statusCodeFilter struct {
+	logger      *zap.Logger
+	statusCodes []ptrace.StatusCode
+}
+
+var _ PolicyEvaluator = (*statusCodeFilter)(nil)
+
+// NewStatusCodeFilter creates a policy evaluator that samples all traces with
+// a given status code.
+func NewStatusCodeFilter(logger *zap.Logger, statusCodeString []string) (PolicyEvaluator, error) {
+	if len(statusCodeString) == 0 {
+		return nil, errors.New("expected at least one status code to filter on")
+	}
+
+	statusCodes := make([]ptrace.StatusCode, len(statusCodeString))
+
+	for i := range statusCodeString {
+		switch statusCodeString[i] {
+		case "OK":
+			statusCodes[i] = ptrace.StatusCodeOk
+		case "ERROR":
+			statusCodes[i] = ptrace.StatusCodeError
+		case "UNSET":
+			statusCodes[i] = ptrace.StatusCodeUnset
+		default:
+			return nil, fmt.Errorf("unknown status code %q, supported: OK, ERROR, UNSET", statusCodeString[i])
+		}
+	}
+
+	return &statusCodeFilter{
+		logger:      logger,
+		statusCodes: statusCodes,
+	}, nil
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (r *statusCodeFilter) Evaluate(_ pcommon.TraceID, trace *TraceData) (Decision, error) {
+	r.logger.Debug("Evaluating spans in status code filter")
+
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
+		for _, statusCode := range r.statusCodes {
+			if span.Status().Code() == statusCode {
+				return true
+			}
+		}
+		return false
+	}), nil
+}

--- a/processor/signoztailsampler/internal/sampling/status_code_test.go
+++ b/processor/signoztailsampler/internal/sampling/status_code_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestNewStatusCodeFilter_errorHandling(t *testing.T) {
+	_, err := NewStatusCodeFilter(zap.NewNop(), []string{})
+	assert.Error(t, err, "expected at least one status code to filter on")
+
+	_, err = NewStatusCodeFilter(zap.NewNop(), []string{"OK", "ERR"})
+	assert.EqualError(t, err, "unknown status code \"ERR\", supported: OK, ERROR, UNSET")
+}
+
+func TestStatusCodeSampling(t *testing.T) {
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	cases := []struct {
+		Desc                  string
+		StatusCodesToFilterOn []string
+		StatusCodesPresent    []ptrace.StatusCode
+		Decision              Decision
+	}{
+		{
+			Desc:                  "filter on ERROR - none match",
+			StatusCodesToFilterOn: []string{"ERROR"},
+			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeOk, ptrace.StatusCodeUnset, ptrace.StatusCodeOk},
+			Decision:              NotSampled,
+		},
+		{
+			Desc:                  "filter on OK and ERROR - none match",
+			StatusCodesToFilterOn: []string{"OK", "ERROR"},
+			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeUnset, ptrace.StatusCodeUnset},
+			Decision:              NotSampled,
+		},
+		{
+			Desc:                  "filter on UNSET - matches",
+			StatusCodesToFilterOn: []string{"UNSET"},
+			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeUnset},
+			Decision:              Sampled,
+		},
+		{
+			Desc:                  "filter on OK and UNSET - matches",
+			StatusCodesToFilterOn: []string{"OK", "UNSET"},
+			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeError, ptrace.StatusCodeOk},
+			Decision:              Sampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			traces := ptrace.NewTraces()
+			rs := traces.ResourceSpans().AppendEmpty()
+			ils := rs.ScopeSpans().AppendEmpty()
+
+			for _, statusCode := range c.StatusCodesPresent {
+				span := ils.Spans().AppendEmpty()
+				span.Status().SetCode(statusCode)
+				span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+				span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+			}
+
+			trace := &TraceData{
+				ReceivedBatches: traces,
+			}
+
+			statusCodeFilter, err := NewStatusCodeFilter(zap.NewNop(), c.StatusCodesToFilterOn)
+			assert.NoError(t, err)
+
+			decision, err := statusCodeFilter.Evaluate(traceID, trace)
+			assert.NoError(t, err)
+			assert.Equal(t, c.Decision, decision)
+		})
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/string_tag_filter.go
+++ b/processor/signoztailsampler/internal/sampling/string_tag_filter.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"regexp"
+
+	"github.com/golang/groupcache/lru"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+const defaultCacheSize = 128
+
+type stringAttributeFilter struct {
+	key    string
+	logger *zap.Logger
+	// matcher defines the func to match the attribute values in strict string
+	// or in regular expression
+	matcher     func(string) bool
+	invertMatch bool
+}
+
+type regexStrSetting struct {
+	matchedAttrs *lru.Cache
+	filterList   []*regexp.Regexp
+}
+
+var _ PolicyEvaluator = (*stringAttributeFilter)(nil)
+
+// NewStringAttributeFilter creates a policy evaluator that samples all traces with
+// the given attribute in the given numeric range.
+func NewStringAttributeFilter(logger *zap.Logger, key string, values []string, regexMatchEnabled bool, evictSize int, invertMatch bool) PolicyEvaluator {
+	// initialize regex filter rules and LRU cache for matched results
+	if regexMatchEnabled {
+		if evictSize <= 0 {
+			evictSize = defaultCacheSize
+		}
+		filterList := addFilters(values)
+		regexStrSetting := &regexStrSetting{
+			matchedAttrs: lru.New(evictSize),
+			filterList:   filterList,
+		}
+
+		return &stringAttributeFilter{
+			key:    key,
+			logger: logger,
+			// matcher returns true if the given string matches the regex rules defined in string attribute filters
+			matcher: func(toMatch string) bool {
+				if v, ok := regexStrSetting.matchedAttrs.Get(toMatch); ok {
+					return v.(bool)
+				}
+
+				for _, r := range regexStrSetting.filterList {
+					if r.MatchString(toMatch) {
+						regexStrSetting.matchedAttrs.Add(toMatch, true)
+						return true
+					}
+				}
+
+				regexStrSetting.matchedAttrs.Add(toMatch, false)
+				return false
+			},
+			invertMatch: invertMatch,
+		}
+	}
+
+	// initialize the exact value map
+	valuesMap := make(map[string]struct{})
+	for _, value := range values {
+		if value != "" {
+			valuesMap[value] = struct{}{}
+		}
+	}
+	return &stringAttributeFilter{
+		key:    key,
+		logger: logger,
+		// matcher returns true if the given string matches any of the string attribute filters
+		matcher: func(toMatch string) bool {
+			_, matched := valuesMap[toMatch]
+			return matched
+		},
+		invertMatch: invertMatch,
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+// The SamplingDecision is made by comparing the attribute values with the matching values,
+// which might be static strings or regular expressions.
+func (saf *stringAttributeFilter) Evaluate(_ pcommon.TraceID, trace *TraceData) (Decision, error) {
+	saf.logger.Debug("Evaluting spans in string-tag filter")
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	if saf.invertMatch {
+		// Invert Match returns true by default, except when key and value are matched
+		return invertHasResourceOrSpanWithCondition(
+			batches,
+			func(resource pcommon.Resource) bool {
+				if v, ok := resource.Attributes().Get(saf.key); ok {
+					if ok := saf.matcher(v.Str()); ok {
+						return false
+					}
+				}
+				return true
+			},
+			func(span ptrace.Span) bool {
+				if v, ok := span.Attributes().Get(saf.key); ok {
+					truncableStr := v.Str()
+					if len(truncableStr) > 0 {
+						if ok := saf.matcher(v.Str()); ok {
+							return false
+						}
+					}
+				}
+				return true
+			},
+		), nil
+	}
+
+	return hasResourceOrSpanWithCondition(
+		batches,
+		func(resource pcommon.Resource) bool {
+			if v, ok := resource.Attributes().Get(saf.key); ok {
+				if ok := saf.matcher(v.Str()); ok {
+					return true
+				}
+			}
+			return false
+		},
+		func(span ptrace.Span) bool {
+			if v, ok := span.Attributes().Get(saf.key); ok {
+				truncableStr := v.Str()
+				if len(truncableStr) > 0 {
+					if ok := saf.matcher(v.Str()); ok {
+						return true
+					}
+				}
+			}
+			return false
+		},
+	), nil
+}
+
+// addFilters compiles all the given filters and stores them as regexes.
+// All regexes are automatically anchored to enforce full string matches.
+func addFilters(exprs []string) []*regexp.Regexp {
+	list := make([]*regexp.Regexp, 0, len(exprs))
+	for _, entry := range exprs {
+		rule := regexp.MustCompile(entry)
+		list = append(list, rule)
+	}
+	return list
+}

--- a/processor/signoztailsampler/internal/sampling/string_tag_filter_test.go
+++ b/processor/signoztailsampler/internal/sampling/string_tag_filter_test.go
@@ -1,0 +1,256 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+// TestStringAttributeCfg is replicated with StringAttributeCfg
+type TestStringAttributeCfg struct {
+	Key                  string
+	Values               []string
+	EnabledRegexMatching bool
+	CacheMaxSize         int
+	InvertMatch          bool
+}
+
+func TestStringTagFilter(t *testing.T) {
+
+	cases := []struct {
+		Desc      string
+		Trace     *TraceData
+		filterCfg *TestStringAttributeCfg
+		Decision  Decision
+	}{
+		{
+			Desc:      "nonmatching node attribute key",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"non_matching": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "nonmatching node attribute value",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "non_matching"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching node attribute",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching span attribute key",
+			Trace:     newTraceStringAttrs(nil, "nonmatching", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "nonmatching span attribute value",
+			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching span attribute",
+			Trace:     newTraceStringAttrs(nil, "example", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "matching span attribute with regex",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching span attribute with regex",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[a-z]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching span attribute with regex without CacheSize provided in config",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "matching plain text node attribute in regex",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching span attribute on empty filter list",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{}, EnabledRegexMatching: true},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "invert nonmatching node attribute key",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"non_matching": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert nonmatching node attribute value",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "non_matching"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert nonmatching node attribute list",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "non_matching"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert matching node attribute",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert matching node attribute list",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute key",
+			Trace:     newTraceStringAttrs(nil, "nonmatching", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute value",
+			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute list",
+			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert matching span attribute",
+			Trace:     newTraceStringAttrs(nil, "example", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert matching span attribute list",
+			Trace:     newTraceStringAttrs(nil, "example", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert matching span attribute with regex",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert matching span attribute with regex list",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"^http", "v[0-9]+.HealthCheck$", "metrics$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute with regex",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[a-z]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute with regex list",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"^http", "v[a-z]+.HealthCheck$", "metrics$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+		{
+			Desc:      "invert matching plain text node attribute in regex",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert matching plain text node attribute in regex list",
+			Trace:     newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
+			Decision:  InvertNotSampled,
+		},
+		{
+			Desc:      "invert nonmatching span attribute on empty filter list",
+			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{}, EnabledRegexMatching: true, InvertMatch: true},
+			Decision:  InvertSampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			filter := NewStringAttributeFilter(zap.NewNop(), c.filterCfg.Key, c.filterCfg.Values, c.filterCfg.EnabledRegexMatching, c.filterCfg.CacheMaxSize, c.filterCfg.InvertMatch)
+			decision, err := filter.Evaluate(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), c.Trace)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+func BenchmarkStringTagFilterEvaluatePlainText(b *testing.B) {
+	trace := newTraceStringAttrs(map[string]interface{}{"example": "value"}, "", "")
+	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"value"}, false, 0, false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := filter.Evaluate(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), trace)
+		assert.NoError(b, err)
+	}
+}
+
+func BenchmarkStringTagFilterEvaluateRegex(b *testing.B) {
+	trace := newTraceStringAttrs(map[string]interface{}{"example": "grpc.health.v1.HealthCheck"}, "", "")
+	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"v[0-9]+.HealthCheck$"}, true, 0, false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := filter.Evaluate(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), trace)
+		assert.NoError(b, err)
+	}
+}
+
+func newTraceStringAttrs(nodeAttrs map[string]interface{}, spanAttrKey string, spanAttrValue string) *TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	//nolint:errcheck
+	rs.Resource().Attributes().FromRaw(nodeAttrs)
+	ils := rs.ScopeSpans().AppendEmpty()
+	span := ils.Spans().AppendEmpty()
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	span.Attributes().PutStr(spanAttrKey, spanAttrValue)
+	return &TraceData{
+		ReceivedBatches: traces,
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/time_provider.go
+++ b/processor/signoztailsampler/internal/sampling/time_provider.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"time"
+)
+
+// TimeProvider allows to get current Unix second
+type TimeProvider interface {
+	getCurSecond() int64
+}
+
+// MonotonicClock provides monotonic real clock-based current Unix second.
+// Use it when creating a NewComposite which should measure sample rates
+// against a realtime clock (this is almost always what you want to do,
+// the exception is usually only automated testing where you may want
+// to have fake clocks).
+type MonotonicClock struct{}
+
+func (c MonotonicClock) getCurSecond() int64 {
+	return time.Now().Unix()
+}

--- a/processor/signoztailsampler/internal/sampling/time_provider_test.go
+++ b/processor/signoztailsampler/internal/sampling/time_provider_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeProvider(t *testing.T) {
+	clock := MonotonicClock{}
+	assert.Greater(t, clock.getCurSecond(), int64(0))
+}

--- a/processor/signoztailsampler/internal/sampling/trace_state_filter.go
+++ b/processor/signoztailsampler/internal/sampling/trace_state_filter.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	tracesdk "go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+type traceStateFilter struct {
+	key     string
+	logger  *zap.Logger
+	matcher func(string) bool
+}
+
+var _ PolicyEvaluator = (*traceStateFilter)(nil)
+
+// NewTraceStateFilter creates a policy evaluator that samples all traces with
+// the given value by the specific key in the trace_state.
+func NewTraceStateFilter(logger *zap.Logger, key string, values []string) PolicyEvaluator {
+	// initialize the exact value map
+	valuesMap := make(map[string]struct{})
+	for _, value := range values {
+		// the key-value pair("=" will take one character) in trace_state can't exceed 256 characters
+		if value != "" && len(key)+len(value) < 256 {
+			valuesMap[value] = struct{}{}
+		}
+	}
+	return &traceStateFilter{
+		key:    key,
+		logger: logger,
+		matcher: func(toMatch string) bool {
+			_, matched := valuesMap[toMatch]
+			return matched
+		},
+	}
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (tsf *traceStateFilter) Evaluate(_ pcommon.TraceID, trace *TraceData) (Decision, error) {
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
+		traceState, err := tracesdk.ParseTraceState(span.TraceState().AsRaw())
+		if err != nil {
+			return false
+		}
+		if ok := tsf.matcher(traceState.Get(tsf.key)); ok {
+			return true
+		}
+		return false
+	}), nil
+}

--- a/processor/signoztailsampler/internal/sampling/trace_state_filter_test.go
+++ b/processor/signoztailsampler/internal/sampling/trace_state_filter_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+// TestTraceStateCfg is replicated with StringAttributeCfg
+type TestTraceStateCfg struct {
+	Key    string
+	Values []string
+}
+
+func TestTraceStateFilter(t *testing.T) {
+
+	cases := []struct {
+		Desc      string
+		Trace     *TraceData
+		filterCfg *TestTraceStateCfg
+		Decision  Decision
+	}{
+		{
+			Desc:      "nonmatching trace_state key",
+			Trace:     newTraceState("non_matching=value"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "nonmatching trace_state value",
+			Trace:     newTraceState("example=non_matching"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching trace_state",
+			Trace:     newTraceState("example=value"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching trace_state on empty filter list",
+			Trace:     newTraceState("example=value"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{}},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "nonmatching trace_state on multiple key-values",
+			Trace:     newTraceState("example=non_matching,non_matching=value"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching trace_state on multiple key-values",
+			Trace:     newTraceState("example=value,non_matching=value"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching trace_state on multiple filter list",
+			Trace:     newTraceState("example=non_matching"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value1", "value2"}},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching trace_state on multiple filter list",
+			Trace:     newTraceState("example=value1"),
+			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value1", "value2"}},
+			Decision:  Sampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			filter := NewTraceStateFilter(zap.NewNop(), c.filterCfg.Key, c.filterCfg.Values)
+			decision, err := filter.Evaluate(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), c.Trace)
+			assert.NoError(t, err)
+			assert.Equal(t, decision, c.Decision)
+		})
+	}
+}
+
+func newTraceState(traceState string) *TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ils := rs.ScopeSpans().AppendEmpty()
+	span := ils.Spans().AppendEmpty()
+	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	span.TraceState().FromRaw(traceState)
+	return &TraceData{
+		ReceivedBatches: traces,
+	}
+}

--- a/processor/signoztailsampler/internal/sampling/util.go
+++ b/processor/signoztailsampler/internal/sampling/util.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// hasResourceOrSpanWithCondition iterates through all the resources and instrumentation library spans until any
+// callback returns true.
+func hasResourceOrSpanWithCondition(
+	td ptrace.Traces,
+	shouldSampleResource func(resource pcommon.Resource) bool,
+	shouldSampleSpan func(span ptrace.Span) bool,
+) Decision {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+
+		resource := rs.Resource()
+		if shouldSampleResource(resource) {
+			return Sampled
+		}
+
+		if hasInstrumentationLibrarySpanWithCondition(rs.ScopeSpans(), shouldSampleSpan) {
+			return Sampled
+		}
+	}
+	return NotSampled
+}
+
+// invertHasResourceOrSpanWithCondition iterates through all the resources and instrumentation library spans until any
+// callback returns false.
+func invertHasResourceOrSpanWithCondition(
+	td ptrace.Traces,
+	shouldSampleResource func(resource pcommon.Resource) bool,
+	shouldSampleSpan func(span ptrace.Span) bool,
+) Decision {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+
+		resource := rs.Resource()
+		if !shouldSampleResource(resource) {
+			return InvertNotSampled
+		}
+
+		if !invertHasInstrumentationLibrarySpanWithCondition(rs.ScopeSpans(), shouldSampleSpan) {
+			return InvertNotSampled
+		}
+	}
+	return InvertSampled
+}
+
+// hasSpanWithCondition iterates through all the instrumentation library spans until any callback returns true.
+func hasSpanWithCondition(td ptrace.Traces, shouldSample func(span ptrace.Span) bool) Decision {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+
+		if hasInstrumentationLibrarySpanWithCondition(rs.ScopeSpans(), shouldSample) {
+			return Sampled
+		}
+	}
+	return NotSampled
+}
+
+func hasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlice, check func(span ptrace.Span) bool) bool {
+	for i := 0; i < ilss.Len(); i++ {
+		ils := ilss.At(i)
+
+		for j := 0; j < ils.Spans().Len(); j++ {
+			span := ils.Spans().At(j)
+
+			if check(span) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func invertHasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlice, check func(span ptrace.Span) bool) bool {
+	for i := 0; i < ilss.Len(); i++ {
+		ils := ilss.At(i)
+
+		for j := 0; j < ils.Spans().Len(); j++ {
+			span := ils.Spans().At(j)
+
+			if !check(span) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/processor/signoztailsampler/main_test.go
+++ b/processor/signoztailsampler/main_test.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}

--- a/processor/signoztailsampler/metrics.go
+++ b/processor/signoztailsampler/metrics.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/obsreport"
+)
+
+// Variables related to metrics specific to tail sampling.
+var (
+	tagPolicyKey, _    = tag.NewKey("policy")
+	tagSampledKey, _   = tag.NewKey("sampled")
+	tagSourceFormat, _ = tag.NewKey("source_format")
+
+	statDecisionLatencyMicroSec  = stats.Int64("sampling_decision_latency", "Latency (in microseconds) of a given sampling policy", "µs")
+	statOverallDecisionLatencyUs = stats.Int64("sampling_decision_timer_latency", "Latency (in microseconds) of each run of the sampling decision timer", "µs")
+
+	statTraceRemovalAgeSec           = stats.Int64("sampling_trace_removal_age", "Time (in seconds) from arrival of a new trace until its removal from memory", "s")
+	statLateSpanArrivalAfterDecision = stats.Int64("sampling_late_span_age", "Time (in seconds) from the sampling decision was taken and the arrival of a late span", "s")
+
+	statPolicyEvaluationErrorCount = stats.Int64("sampling_policy_evaluation_error", "Count of sampling policy evaluation errors", stats.UnitDimensionless)
+
+	statCountTracesSampled = stats.Int64("count_traces_sampled", "Count of traces that were sampled or not", stats.UnitDimensionless)
+
+	statDroppedTooEarlyCount    = stats.Int64("sampling_trace_dropped_too_early", "Count of traces that needed to be dropped the configured wait time", stats.UnitDimensionless)
+	statNewTraceIDReceivedCount = stats.Int64("new_trace_id_received", "Counts the arrival of new traces", stats.UnitDimensionless)
+	statTracesOnMemoryGauge     = stats.Int64("sampling_traces_on_memory", "Tracks the number of traces current on memory", stats.UnitDimensionless)
+)
+
+// SamplingProcessorMetricViews return the metrics views according to given telemetry level.
+func SamplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
+	if level == configtelemetry.LevelNone {
+		return nil
+	}
+
+	policyTagKeys := []tag.Key{tagPolicyKey}
+
+	latencyDistributionAggregation := view.Distribution(1, 2, 5, 10, 25, 50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000)
+	ageDistributionAggregation := view.Distribution(1, 2, 5, 10, 20, 30, 40, 50, 60, 90, 120, 180, 300, 600, 1800, 3600, 7200)
+
+	decisionLatencyView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statDecisionLatencyMicroSec.Name()),
+		Measure:     statDecisionLatencyMicroSec,
+		Description: statDecisionLatencyMicroSec.Description(),
+		TagKeys:     policyTagKeys,
+		Aggregation: latencyDistributionAggregation,
+	}
+	overallDecisionLatencyView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statOverallDecisionLatencyUs.Name()),
+		Measure:     statOverallDecisionLatencyUs,
+		Description: statOverallDecisionLatencyUs.Description(),
+		Aggregation: latencyDistributionAggregation,
+	}
+
+	traceRemovalAgeView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statTraceRemovalAgeSec.Name()),
+		Measure:     statTraceRemovalAgeSec,
+		Description: statTraceRemovalAgeSec.Description(),
+		Aggregation: ageDistributionAggregation,
+	}
+	lateSpanArrivalView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statLateSpanArrivalAfterDecision.Name()),
+		Measure:     statLateSpanArrivalAfterDecision,
+		Description: statLateSpanArrivalAfterDecision.Description(),
+		Aggregation: ageDistributionAggregation,
+	}
+
+	countPolicyEvaluationErrorView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statPolicyEvaluationErrorCount.Name()),
+		Measure:     statPolicyEvaluationErrorCount,
+		Description: statPolicyEvaluationErrorCount.Description(),
+		Aggregation: view.Sum(),
+	}
+
+	sampledTagKeys := []tag.Key{tagPolicyKey, tagSampledKey}
+	countTracesSampledView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statCountTracesSampled.Name()),
+		Measure:     statCountTracesSampled,
+		Description: statCountTracesSampled.Description(),
+		TagKeys:     sampledTagKeys,
+		Aggregation: view.Sum(),
+	}
+
+	countTraceDroppedTooEarlyView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statDroppedTooEarlyCount.Name()),
+		Measure:     statDroppedTooEarlyCount,
+		Description: statDroppedTooEarlyCount.Description(),
+		Aggregation: view.Sum(),
+	}
+	countTraceIDArrivalView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statNewTraceIDReceivedCount.Name()),
+		Measure:     statNewTraceIDReceivedCount,
+		Description: statNewTraceIDReceivedCount.Description(),
+		Aggregation: view.Sum(),
+	}
+	trackTracesOnMemorylView := &view.View{
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statTracesOnMemoryGauge.Name()),
+		Measure:     statTracesOnMemoryGauge,
+		Description: statTracesOnMemoryGauge.Description(),
+		Aggregation: view.LastValue(),
+	}
+
+	return []*view.View{
+		decisionLatencyView,
+		overallDecisionLatencyView,
+
+		traceRemovalAgeView,
+		lateSpanArrivalView,
+
+		countPolicyEvaluationErrorView,
+
+		countTracesSampledView,
+
+		countTraceDroppedTooEarlyView,
+		countTraceIDArrivalView,
+		trackTracesOnMemorylView,
+	}
+}

--- a/processor/signoztailsampler/processor.go
+++ b/processor/signoztailsampler/processor.go
@@ -1,0 +1,444 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+// policy combines a sampling policy evaluator with the destinations to be
+// used for that policy.
+type policy struct {
+	// name used to identify this policy instance.
+	name string
+	// evaluator that decides if a trace is sampled or not by this policy instance.
+	evaluator sampling.PolicyEvaluator
+	// ctx used to carry metric tags of each policy.
+	ctx context.Context
+}
+
+// tailSamplingSpanProcessor handles the incoming trace data and uses the given sampling
+// policy to sample traces.
+type tailSamplingSpanProcessor struct {
+	ctx             context.Context
+	nextConsumer    consumer.Traces
+	maxNumTraces    uint64
+	policies        []*policy
+	logger          *zap.Logger
+	idToTrace       sync.Map
+	policyTicker    timeutils.TTicker
+	tickerFrequency time.Duration
+	decisionBatcher idbatcher.Batcher
+	deleteChan      chan pcommon.TraceID
+	numTracesOnMap  *atomic.Uint64
+}
+
+const (
+	sourceFormat = "tail_sampling"
+)
+
+// newTracesProcessor returns a processor.TracesProcessor that will perform tail sampling according to the given
+// configuration.
+func newTracesProcessor(logger *zap.Logger, nextConsumer consumer.Traces, cfg Config) (component.TracesProcessor, error) {
+	if nextConsumer == nil {
+		return nil, component.ErrNilNextConsumer
+	}
+
+	numDecisionBatches := uint64(cfg.DecisionWait.Seconds())
+	inBatcher, err := idbatcher.New(numDecisionBatches, cfg.ExpectedNewTracesPerSec, uint64(2*runtime.NumCPU()))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	var policies []*policy
+	for i := range cfg.PolicyCfgs {
+		policyCfg := &cfg.PolicyCfgs[i]
+		policyCtx, err := tag.New(ctx, tag.Upsert(tagPolicyKey, policyCfg.Name), tag.Upsert(tagSourceFormat, sourceFormat))
+		if err != nil {
+			return nil, err
+		}
+		eval, err := getPolicyEvaluator(logger, policyCfg)
+		if err != nil {
+			return nil, err
+		}
+		p := &policy{
+			name:      policyCfg.Name,
+			evaluator: eval,
+			ctx:       policyCtx,
+		}
+		policies = append(policies, p)
+	}
+
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             ctx,
+		nextConsumer:    nextConsumer,
+		maxNumTraces:    cfg.NumTraces,
+		logger:          logger,
+		decisionBatcher: inBatcher,
+		policies:        policies,
+		tickerFrequency: time.Second,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+
+	tsp.policyTicker = &timeutils.PolicyTicker{OnTickFunc: tsp.samplingPolicyOnTick}
+	tsp.deleteChan = make(chan pcommon.TraceID, cfg.NumTraces)
+
+	return tsp, nil
+}
+
+func getPolicyEvaluator(logger *zap.Logger, cfg *PolicyCfg) (sampling.PolicyEvaluator, error) {
+	switch cfg.Type {
+	case Composite:
+		return getNewCompositePolicy(logger, &cfg.CompositeCfg)
+	case And:
+		return getNewAndPolicy(logger, &cfg.AndCfg)
+	default:
+		return getSharedPolicyEvaluator(logger, &cfg.sharedPolicyCfg)
+	}
+}
+
+func getSharedPolicyEvaluator(logger *zap.Logger, cfg *sharedPolicyCfg) (sampling.PolicyEvaluator, error) {
+	switch cfg.Type {
+	case AlwaysSample:
+		return sampling.NewAlwaysSample(logger), nil
+	case Latency:
+		lfCfg := cfg.LatencyCfg
+		return sampling.NewLatency(logger, lfCfg.ThresholdMs), nil
+	case NumericAttribute:
+		nafCfg := cfg.NumericAttributeCfg
+		return sampling.NewNumericAttributeFilter(logger, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
+	case Probabilistic:
+		pCfg := cfg.ProbabilisticCfg
+		return sampling.NewProbabilisticSampler(logger, pCfg.HashSalt, pCfg.SamplingPercentage), nil
+	case StringAttribute:
+		safCfg := cfg.StringAttributeCfg
+		return sampling.NewStringAttributeFilter(logger, safCfg.Key, safCfg.Values, safCfg.EnabledRegexMatching, safCfg.CacheMaxSize, safCfg.InvertMatch), nil
+	case StatusCode:
+		scfCfg := cfg.StatusCodeCfg
+		return sampling.NewStatusCodeFilter(logger, scfCfg.StatusCodes)
+	case RateLimiting:
+		rlfCfg := cfg.RateLimitingCfg
+		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil
+	case SpanCount:
+		spCfg := cfg.SpanCountCfg
+		return sampling.NewSpanCount(logger, spCfg.MinSpans), nil
+	case TraceState:
+		tsfCfg := cfg.TraceStateCfg
+		return sampling.NewTraceStateFilter(logger, tsfCfg.Key, tsfCfg.Values), nil
+	default:
+		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
+	}
+}
+
+type policyMetrics struct {
+	idNotFoundOnMapCount, evaluateErrorCount, decisionSampled, decisionNotSampled int64
+}
+
+func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
+	metrics := policyMetrics{}
+
+	startTime := time.Now()
+	batch, _ := tsp.decisionBatcher.CloseCurrentAndTakeFirstBatch()
+	batchLen := len(batch)
+	tsp.logger.Debug("Sampling Policy Evaluation ticked")
+	for _, id := range batch {
+		d, ok := tsp.idToTrace.Load(id)
+		if !ok {
+			metrics.idNotFoundOnMapCount++
+			continue
+		}
+		trace := d.(*sampling.TraceData)
+		trace.DecisionTime = time.Now()
+
+		decision, policy := tsp.makeDecision(id, trace, &metrics)
+
+		// Sampled or not, remove the batches
+		trace.Lock()
+		allSpans := ptrace.NewTraces()
+		trace.ReceivedBatches.MoveTo(allSpans)
+		trace.Unlock()
+
+		if decision == sampling.Sampled {
+			_ = tsp.nextConsumer.ConsumeTraces(policy.ctx, allSpans)
+		}
+	}
+
+	stats.Record(tsp.ctx,
+		statOverallDecisionLatencyUs.M(int64(time.Since(startTime)/time.Microsecond)),
+		statDroppedTooEarlyCount.M(metrics.idNotFoundOnMapCount),
+		statPolicyEvaluationErrorCount.M(metrics.evaluateErrorCount),
+		statTracesOnMemoryGauge.M(int64(tsp.numTracesOnMap.Load())))
+
+	tsp.logger.Debug("Sampling policy evaluation completed",
+		zap.Int("batch.len", batchLen),
+		zap.Int64("sampled", metrics.decisionSampled),
+		zap.Int64("notSampled", metrics.decisionNotSampled),
+		zap.Int64("droppedPriorToEvaluation", metrics.idNotFoundOnMapCount),
+		zap.Int64("policyEvaluationErrors", metrics.evaluateErrorCount),
+	)
+}
+
+func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sampling.TraceData, metrics *policyMetrics) (sampling.Decision, *policy) {
+	finalDecision := sampling.NotSampled
+	var matchingPolicy *policy
+	samplingDecision := map[sampling.Decision]bool{
+		sampling.Error:            false,
+		sampling.Sampled:          false,
+		sampling.NotSampled:       false,
+		sampling.InvertSampled:    false,
+		sampling.InvertNotSampled: false,
+	}
+
+	// Check all policies before making a final decision
+	for i, p := range tsp.policies {
+		policyEvaluateStartTime := time.Now()
+		decision, err := p.evaluator.Evaluate(id, trace)
+		stats.Record(
+			p.ctx,
+			statDecisionLatencyMicroSec.M(int64(time.Since(policyEvaluateStartTime)/time.Microsecond)))
+
+		if err != nil {
+			samplingDecision[sampling.Error] = true
+			trace.Decisions[i] = sampling.NotSampled
+			metrics.evaluateErrorCount++
+			tsp.logger.Debug("Sampling policy error", zap.Error(err))
+		} else {
+			switch decision {
+			case sampling.Sampled:
+				samplingDecision[sampling.Sampled] = true
+				trace.Decisions[i] = decision
+
+			case sampling.NotSampled:
+				samplingDecision[sampling.NotSampled] = true
+				trace.Decisions[i] = decision
+
+			case sampling.InvertSampled:
+				samplingDecision[sampling.InvertSampled] = true
+				trace.Decisions[i] = sampling.Sampled
+
+			case sampling.InvertNotSampled:
+				samplingDecision[sampling.InvertNotSampled] = true
+				trace.Decisions[i] = sampling.NotSampled
+			}
+		}
+	}
+
+	// InvertNotSampled takes precedence over any other decision
+	switch {
+	case samplingDecision[sampling.InvertNotSampled]:
+		finalDecision = sampling.NotSampled
+	case samplingDecision[sampling.Sampled]:
+		finalDecision = sampling.Sampled
+	case samplingDecision[sampling.InvertSampled] && !samplingDecision[sampling.NotSampled]:
+		finalDecision = sampling.Sampled
+	}
+
+	for _, p := range tsp.policies {
+		switch finalDecision {
+		case sampling.Sampled:
+			// any single policy that decides to sample will cause the decision to be sampled
+			// the nextConsumer will get the context from the first matching policy
+			if matchingPolicy == nil {
+				matchingPolicy = p
+			}
+
+			_ = stats.RecordWithTags(
+				p.ctx,
+				[]tag.Mutator{tag.Upsert(tagSampledKey, "true")},
+				statCountTracesSampled.M(int64(1)),
+			)
+			metrics.decisionSampled++
+
+		case sampling.NotSampled:
+			_ = stats.RecordWithTags(
+				p.ctx,
+				[]tag.Mutator{tag.Upsert(tagSampledKey, "false")},
+				statCountTracesSampled.M(int64(1)),
+			)
+			metrics.decisionNotSampled++
+		}
+	}
+
+	return finalDecision, matchingPolicy
+}
+
+// ConsumeTraces is required by the component.TracesProcessor interface.
+func (tsp *tailSamplingSpanProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	resourceSpans := td.ResourceSpans()
+	for i := 0; i < resourceSpans.Len(); i++ {
+		tsp.processTraces(resourceSpans.At(i))
+	}
+	return nil
+}
+
+func (tsp *tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans ptrace.ResourceSpans) map[pcommon.TraceID][]*ptrace.Span {
+	idToSpans := make(map[pcommon.TraceID][]*ptrace.Span)
+	ilss := resourceSpans.ScopeSpans()
+	for j := 0; j < ilss.Len(); j++ {
+		spans := ilss.At(j).Spans()
+		spansLen := spans.Len()
+		for k := 0; k < spansLen; k++ {
+			span := spans.At(k)
+			key := span.TraceID()
+			idToSpans[key] = append(idToSpans[key], &span)
+		}
+	}
+	return idToSpans
+}
+
+func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.ResourceSpans) {
+	// Group spans per their traceId to minimize contention on idToTrace
+	idToSpans := tsp.groupSpansByTraceKey(resourceSpans)
+	var newTraceIDs int64
+	for id, spans := range idToSpans {
+		lenSpans := int64(len(spans))
+		lenPolicies := len(tsp.policies)
+		initialDecisions := make([]sampling.Decision, lenPolicies)
+		for i := 0; i < lenPolicies; i++ {
+			initialDecisions[i] = sampling.Pending
+		}
+		d, loaded := tsp.idToTrace.Load(id)
+		if !loaded {
+			d, loaded = tsp.idToTrace.LoadOrStore(id, &sampling.TraceData{
+				Decisions:       initialDecisions,
+				ArrivalTime:     time.Now(),
+				SpanCount:       atomic.NewInt64(lenSpans),
+				ReceivedBatches: ptrace.NewTraces(),
+			})
+		}
+		actualData := d.(*sampling.TraceData)
+		if loaded {
+			actualData.SpanCount.Add(lenSpans)
+		} else {
+			newTraceIDs++
+			tsp.decisionBatcher.AddToCurrentBatch(id)
+			tsp.numTracesOnMap.Add(1)
+			postDeletion := false
+			currTime := time.Now()
+			for !postDeletion {
+				select {
+				case tsp.deleteChan <- id:
+					postDeletion = true
+				default:
+					traceKeyToDrop := <-tsp.deleteChan
+					tsp.dropTrace(traceKeyToDrop, currTime)
+				}
+			}
+		}
+
+		for i, p := range tsp.policies {
+			actualData.Lock()
+			actualDecision := actualData.Decisions[i]
+			// If decision is pending, we want to add the new spans still under the lock, so the decision doesn't happen
+			// in between the transition from pending.
+			if actualDecision == sampling.Pending {
+				// Add the spans to the trace, but only once for all policy, otherwise same spans will
+				// be duplicated in the final trace.
+				appendToTraces(actualData.ReceivedBatches, resourceSpans, spans)
+				actualData.Unlock()
+				break
+			}
+			actualData.Unlock()
+
+			switch actualDecision {
+			case sampling.Sampled:
+				// Forward the spans to the policy destinations
+				traceTd := ptrace.NewTraces()
+				appendToTraces(traceTd, resourceSpans, spans)
+				if err := tsp.nextConsumer.ConsumeTraces(p.ctx, traceTd); err != nil {
+					tsp.logger.Warn("Error sending late arrived spans to destination",
+						zap.String("policy", p.name),
+						zap.Error(err))
+				}
+			case sampling.NotSampled:
+				stats.Record(tsp.ctx, statLateSpanArrivalAfterDecision.M(int64(time.Since(actualData.DecisionTime)/time.Second)))
+
+			default:
+				tsp.logger.Warn("Encountered unexpected sampling decision",
+					zap.String("policy", p.name),
+					zap.Int("decision", int(actualDecision)))
+			}
+
+			// At this point the late arrival has been passed to nextConsumer. Need to break out of the policy loop
+			// so that it isn't sent to nextConsumer more than once when multiple policies chose to sample
+			if actualDecision == sampling.Sampled {
+				break
+			}
+		}
+	}
+
+	stats.Record(tsp.ctx, statNewTraceIDReceivedCount.M(newTraceIDs))
+}
+
+func (tsp *tailSamplingSpanProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+// Start is invoked during service startup.
+func (tsp *tailSamplingSpanProcessor) Start(context.Context, component.Host) error {
+	tsp.policyTicker.Start(tsp.tickerFrequency)
+	return nil
+}
+
+// Shutdown is invoked during service shutdown.
+func (tsp *tailSamplingSpanProcessor) Shutdown(context.Context) error {
+	tsp.decisionBatcher.Stop()
+	tsp.policyTicker.Stop()
+	return nil
+}
+
+func (tsp *tailSamplingSpanProcessor) dropTrace(traceID pcommon.TraceID, deletionTime time.Time) {
+	var trace *sampling.TraceData
+	if d, ok := tsp.idToTrace.Load(traceID); ok {
+		trace = d.(*sampling.TraceData)
+		tsp.idToTrace.Delete(traceID)
+		// Subtract one from numTracesOnMap per https://godoc.org/sync/atomic#AddUint64
+		tsp.numTracesOnMap.Add(^uint64(0))
+	}
+	if trace == nil {
+		tsp.logger.Error("Attempt to delete traceID not on table")
+		return
+	}
+
+	stats.Record(tsp.ctx, statTraceRemovalAgeSec.M(int64(deletionTime.Sub(trace.ArrivalTime)/time.Second)))
+}
+
+func appendToTraces(dest ptrace.Traces, rss ptrace.ResourceSpans, spans []*ptrace.Span) {
+	rs := dest.ResourceSpans().AppendEmpty()
+	rss.Resource().CopyTo(rs.Resource())
+	ils := rs.ScopeSpans().AppendEmpty()
+	for _, span := range spans {
+		sp := ils.Spans().AppendEmpty()
+		span.CopyTo(sp)
+	}
+}

--- a/processor/signoztailsampler/processor_test.go
+++ b/processor/signoztailsampler/processor_test.go
@@ -1,0 +1,706 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+)
+
+const (
+	defaultTestDecisionWait = 30 * time.Second
+)
+
+var testPolicy = []PolicyCfg{{sharedPolicyCfg: sharedPolicyCfg{Name: "test-policy", Type: AlwaysSample}}}
+
+func TestSequentialTraceArrival(t *testing.T) {
+	traceIds, batches := generateIdsAndBatches(128)
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(2 * len(traceIds)),
+		ExpectedNewTracesPerSec: 64,
+		PolicyCfgs:              testPolicy,
+	}
+	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
+	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	for _, batch := range batches {
+		require.NoError(t, tsp.ConsumeTraces(context.Background(), batch))
+	}
+
+	for i := range traceIds {
+		d, ok := tsp.idToTrace.Load(traceIds[i])
+		require.True(t, ok, "Missing expected traceId")
+		v := d.(*sampling.TraceData)
+		require.Equal(t, int64(i+1), v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
+	}
+}
+
+func TestConcurrentTraceArrival(t *testing.T) {
+	t.Skip("Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10205")
+	traceIds, batches := generateIdsAndBatches(128)
+
+	var wg sync.WaitGroup
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(2 * len(traceIds)),
+		ExpectedNewTracesPerSec: 64,
+		PolicyCfgs:              testPolicy,
+	}
+	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
+	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	for _, batch := range batches {
+		// Add the same traceId twice.
+		wg.Add(2)
+		go func(td ptrace.Traces) {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+			wg.Done()
+		}(batch)
+		go func(td ptrace.Traces) {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+			wg.Done()
+		}(batch)
+	}
+
+	wg.Wait()
+
+	for i := range traceIds {
+		d, ok := tsp.idToTrace.Load(traceIds[i])
+		require.True(t, ok, "Missing expected traceId")
+		v := d.(*sampling.TraceData)
+		require.Equal(t, int64(i+1)*2, v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
+	}
+}
+
+func TestSequentialTraceMapSize(t *testing.T) {
+	traceIds, batches := generateIdsAndBatches(210)
+	const maxSize = 100
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(maxSize),
+		ExpectedNewTracesPerSec: 64,
+		PolicyCfgs:              testPolicy,
+	}
+	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
+	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	for _, batch := range batches {
+		require.NoError(t, tsp.ConsumeTraces(context.Background(), batch))
+	}
+
+	// On sequential insertion it is possible to know exactly which traces should be still on the map.
+	for i := 0; i < len(traceIds)-maxSize; i++ {
+		_, ok := tsp.idToTrace.Load(traceIds[i])
+		require.False(t, ok, "Found unexpected traceId[%d] still on map (id: %v)", i, traceIds[i])
+	}
+}
+
+func TestConcurrentTraceMapSize(t *testing.T) {
+	t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9126")
+	_, batches := generateIdsAndBatches(210)
+	const maxSize = 100
+	var wg sync.WaitGroup
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(maxSize),
+		ExpectedNewTracesPerSec: 64,
+		PolicyCfgs:              testPolicy,
+	}
+	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
+	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	for _, batch := range batches {
+		wg.Add(1)
+		go func(td ptrace.Traces) {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+			wg.Done()
+		}(batch)
+	}
+
+	wg.Wait()
+
+	// Since we can't guarantee the order of insertion the only thing that can be checked is
+	// if the number of traces on the map matches the expected value.
+	cnt := 0
+	tsp.idToTrace.Range(func(_ interface{}, _ interface{}) bool {
+		cnt++
+		return true
+	})
+	require.Equal(t, maxSize, cnt, "Incorrect traces count on idToTrace")
+}
+
+func TestSamplingPolicyTypicalPath(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 5
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	_, batches := generateIdsAndBatches(210)
+	currItem := 0
+	numSpansPerBatchWindow := 10
+	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
+	for evalNum := 0; evalNum < decisionWaitSeconds; evalNum++ {
+		for ; currItem < numSpansPerBatchWindow*(evalNum+1); currItem++ {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[currItem]))
+			require.True(t, mtt.Started, "Time ticker was expected to have started")
+		}
+		tsp.samplingPolicyOnTick()
+		require.False(
+			t,
+			msp.SpanCount() != 0 || mpe.EvaluationCount != 0,
+			"policy for initial items was evaluated before decision wait period",
+		)
+	}
+
+	// Now the first batch that waited the decision period.
+	mpe.NextDecision = sampling.Sampled
+	tsp.samplingPolicyOnTick()
+	require.False(
+		t,
+		msp.SpanCount() == 0 || mpe.EvaluationCount == 0,
+		"policy should have been evaluated totalspans == %d and evaluationcount == %d",
+		msp.SpanCount(),
+		mpe.EvaluationCount,
+	)
+
+	require.Equal(t, numSpansPerBatchWindow, msp.SpanCount(), "not all spans of first window were accounted for")
+
+	// Late span of a sampled trace should be sent directly down the pipeline exporter
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	expectedNumWithLateSpan := numSpansPerBatchWindow + 1
+	require.Equal(t, expectedNumWithLateSpan, msp.SpanCount(), "late span was not accounted for")
+}
+
+func TestSamplingPolicyInvertSampled(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 5
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	_, batches := generateIdsAndBatches(210)
+	currItem := 0
+	numSpansPerBatchWindow := 10
+	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
+	for evalNum := 0; evalNum < decisionWaitSeconds; evalNum++ {
+		for ; currItem < numSpansPerBatchWindow*(evalNum+1); currItem++ {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[currItem]))
+			require.True(t, mtt.Started, "Time ticker was expected to have started")
+		}
+		tsp.samplingPolicyOnTick()
+		require.False(
+			t,
+			msp.SpanCount() != 0 || mpe.EvaluationCount != 0,
+			"policy for initial items was evaluated before decision wait period",
+		)
+	}
+
+	// Now the first batch that waited the decision period.
+	mpe.NextDecision = sampling.InvertSampled
+	tsp.samplingPolicyOnTick()
+	require.False(
+		t,
+		msp.SpanCount() == 0 || mpe.EvaluationCount == 0,
+		"policy should have been evaluated totalspans == %d and evaluationcount == %d",
+		msp.SpanCount(),
+		mpe.EvaluationCount,
+	)
+
+	require.Equal(t, numSpansPerBatchWindow, msp.SpanCount(), "not all spans of first window were accounted for")
+
+	// Late span of a sampled trace should be sent directly down the pipeline exporter
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	expectedNumWithLateSpan := numSpansPerBatchWindow + 1
+	require.Equal(t, expectedNumWithLateSpan, msp.SpanCount(), "late span was not accounted for")
+}
+
+func TestSamplingMultiplePolicies(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 5
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe1 := &mockPolicyEvaluator{}
+	mpe2 := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies: []*policy{
+			{
+				name: "policy-1", evaluator: mpe1, ctx: context.TODO(),
+			},
+			{
+				name: "policy-2", evaluator: mpe2, ctx: context.TODO(),
+			}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	_, batches := generateIdsAndBatches(210)
+	currItem := 0
+	numSpansPerBatchWindow := 10
+	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
+	for evalNum := 0; evalNum < decisionWaitSeconds; evalNum++ {
+		for ; currItem < numSpansPerBatchWindow*(evalNum+1); currItem++ {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[currItem]))
+			require.True(t, mtt.Started, "Time ticker was expected to have started")
+		}
+		tsp.samplingPolicyOnTick()
+		require.False(
+			t,
+			msp.SpanCount() != 0 || mpe1.EvaluationCount != 0 || mpe2.EvaluationCount != 0,
+			"policy for initial items was evaluated before decision wait period",
+		)
+	}
+
+	// Both policies will decide to sample
+	mpe1.NextDecision = sampling.Sampled
+	mpe2.NextDecision = sampling.Sampled
+	tsp.samplingPolicyOnTick()
+	require.False(
+		t,
+		msp.SpanCount() == 0 || mpe1.EvaluationCount == 0 || mpe2.EvaluationCount == 0,
+		"policy should have been evaluated totalspans == %d and evaluationcount(1) == %d and evaluationcount(2) == %d",
+		msp.SpanCount(),
+		mpe1.EvaluationCount,
+		mpe2.EvaluationCount,
+	)
+
+	require.Equal(t, numSpansPerBatchWindow, msp.SpanCount(), "nextConsumer should've been called with exactly 1 batch of spans")
+
+	// Late span of a sampled trace should be sent directly down the pipeline exporter
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	expectedNumWithLateSpan := numSpansPerBatchWindow + 1
+	require.Equal(t, expectedNumWithLateSpan, msp.SpanCount(), "late span was not accounted for")
+}
+
+func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 5
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	_, batches := generateIdsAndBatches(210)
+	currItem := 0
+	numSpansPerBatchWindow := 10
+	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
+	for evalNum := 0; evalNum < decisionWaitSeconds; evalNum++ {
+		for ; currItem < numSpansPerBatchWindow*(evalNum+1); currItem++ {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[currItem]))
+			require.True(t, mtt.Started, "Time ticker was expected to have started")
+		}
+		tsp.samplingPolicyOnTick()
+		require.False(
+			t,
+			msp.SpanCount() != 0 || mpe.EvaluationCount != 0,
+			"policy for initial items was evaluated before decision wait period",
+		)
+	}
+
+	// Now the first batch that waited the decision period.
+	mpe.NextDecision = sampling.NotSampled
+	tsp.samplingPolicyOnTick()
+	require.EqualValues(t, 0, msp.SpanCount(), "exporter should have received zero spans")
+	require.EqualValues(t, 4, mpe.EvaluationCount, "policy should have been evaluated 4 times")
+
+	// Late span of a non-sampled trace should be ignored
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	require.Equal(t, 0, msp.SpanCount())
+
+	mpe.NextDecision = sampling.Unspecified
+	mpe.NextError = errors.New("mock policy error")
+	tsp.samplingPolicyOnTick()
+	require.EqualValues(t, 0, msp.SpanCount(), "exporter should have received zero spans")
+	require.EqualValues(t, 6, mpe.EvaluationCount, "policy should have been evaluated 6 times")
+
+	// Late span of a non-sampled trace should be ignored
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	require.Equal(t, 0, msp.SpanCount())
+}
+
+func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 5
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	_, batches := generateIdsAndBatches(210)
+	currItem := 0
+	numSpansPerBatchWindow := 10
+	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
+	for evalNum := 0; evalNum < decisionWaitSeconds; evalNum++ {
+		for ; currItem < numSpansPerBatchWindow*(evalNum+1); currItem++ {
+			require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[currItem]))
+			require.True(t, mtt.Started, "Time ticker was expected to have started")
+		}
+		tsp.samplingPolicyOnTick()
+		require.False(
+			t,
+			msp.SpanCount() != 0 || mpe.EvaluationCount != 0,
+			"policy for initial items was evaluated before decision wait period",
+		)
+	}
+
+	// Now the first batch that waited the decision period.
+	mpe.NextDecision = sampling.InvertNotSampled
+	tsp.samplingPolicyOnTick()
+	require.EqualValues(t, 0, msp.SpanCount(), "exporter should have received zero spans")
+	require.EqualValues(t, 4, mpe.EvaluationCount, "policy should have been evaluated 4 times")
+
+	// Late span of a non-sampled trace should be ignored
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	require.Equal(t, 0, msp.SpanCount())
+
+	mpe.NextDecision = sampling.Unspecified
+	mpe.NextError = errors.New("mock policy error")
+	tsp.samplingPolicyOnTick()
+	require.EqualValues(t, 0, msp.SpanCount(), "exporter should have received zero spans")
+	require.EqualValues(t, 6, mpe.EvaluationCount, "policy should have been evaluated 6 times")
+
+	// Late span of a non-sampled trace should be ignored
+	require.NoError(t, tsp.ConsumeTraces(context.Background(), batches[0]))
+	require.Equal(t, 0, msp.SpanCount())
+}
+
+func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
+	const maxSize = 100
+	const decisionWaitSeconds = 1
+	// For this test explicitly control the timer calls and batcher, and set a mock
+	// sampling policy evaluator.
+	msp := new(consumertest.TracesSink)
+	mpe := &mockPolicyEvaluator{}
+	mtt := &manualTTicker{}
+	tsp := &tailSamplingSpanProcessor{
+		ctx:             context.Background(),
+		nextConsumer:    msp,
+		maxNumTraces:    maxSize,
+		logger:          zap.NewNop(),
+		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
+		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
+		deleteChan:      make(chan pcommon.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
+		numTracesOnMap:  atomic.NewUint64(0),
+	}
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	mpe.NextDecision = sampling.Sampled
+
+	traceIds, batches := generateIdsAndBatches(3)
+	for _, batch := range batches {
+		require.NoError(t, tsp.ConsumeTraces(context.Background(), batch))
+	}
+
+	tsp.samplingPolicyOnTick()
+	tsp.samplingPolicyOnTick()
+
+	require.EqualValues(t, 3, len(msp.AllTraces()), "There should be three batches, one for each trace")
+
+	expectedSpanIds := make(map[int][]pcommon.SpanID)
+	expectedSpanIds[0] = []pcommon.SpanID{
+		uInt64ToSpanID(uint64(1)),
+	}
+	expectedSpanIds[1] = []pcommon.SpanID{
+		uInt64ToSpanID(uint64(2)),
+		uInt64ToSpanID(uint64(3)),
+	}
+	expectedSpanIds[2] = []pcommon.SpanID{
+		uInt64ToSpanID(uint64(4)),
+		uInt64ToSpanID(uint64(5)),
+		uInt64ToSpanID(uint64(6)),
+	}
+
+	receivedTraces := msp.AllTraces()
+	for i, traceID := range traceIds {
+		trace := findTrace(t, receivedTraces, traceID)
+		require.EqualValues(t, i+1, trace.SpanCount(), "The trace should have all of its spans in a single batch")
+
+		expected := expectedSpanIds[i]
+		got := collectSpanIds(trace)
+
+		// might have received out of order, sort for comparison
+		sort.Slice(got, func(i, j int) bool {
+			bytesA := got[i]
+			a := binary.BigEndian.Uint64(bytesA[:])
+			bytesB := got[j]
+			b := binary.BigEndian.Uint64(bytesB[:])
+			return a < b
+		})
+
+		require.EqualValues(t, expected, got)
+	}
+}
+
+func collectSpanIds(trace ptrace.Traces) []pcommon.SpanID {
+	var spanIDs []pcommon.SpanID
+
+	for i := 0; i < trace.ResourceSpans().Len(); i++ {
+		ilss := trace.ResourceSpans().At(i).ScopeSpans()
+
+		for j := 0; j < ilss.Len(); j++ {
+			ils := ilss.At(j)
+
+			for k := 0; k < ils.Spans().Len(); k++ {
+				span := ils.Spans().At(k)
+				spanIDs = append(spanIDs, span.SpanID())
+			}
+		}
+	}
+
+	return spanIDs
+}
+
+func findTrace(t *testing.T, a []ptrace.Traces, traceID pcommon.TraceID) ptrace.Traces {
+	for _, batch := range a {
+		id := batch.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID()
+		if traceID == id {
+			return batch
+		}
+	}
+	t.Fatalf("Trace was not received. TraceId %s", traceID)
+	return ptrace.Traces{}
+}
+
+func generateIdsAndBatches(numIds int) ([]pcommon.TraceID, []ptrace.Traces) {
+	traceIds := make([]pcommon.TraceID, numIds)
+	spanID := 0
+	var tds []ptrace.Traces
+	for i := 0; i < numIds; i++ {
+		traceID := [16]byte{}
+		binary.BigEndian.PutUint64(traceID[:8], 1)
+		binary.BigEndian.PutUint64(traceID[8:], uint64(i+1))
+		traceIds[i] = pcommon.TraceID(traceID)
+		// Send each span in a separate batch
+		for j := 0; j <= i; j++ {
+			td := simpleTraces()
+			span := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+			span.SetTraceID(traceIds[i])
+
+			spanID++
+			span.SetSpanID(uInt64ToSpanID(uint64(spanID)))
+			tds = append(tds, td)
+		}
+	}
+
+	return traceIds, tds
+}
+
+// uInt64ToSpanID converts the uint64 representation of a SpanID to pcommon.SpanID.
+func uInt64ToSpanID(id uint64) pcommon.SpanID {
+	spanID := [8]byte{}
+	binary.BigEndian.PutUint64(spanID[:], id)
+	return pcommon.SpanID(spanID)
+}
+
+type mockPolicyEvaluator struct {
+	NextDecision    sampling.Decision
+	NextError       error
+	EvaluationCount int
+}
+
+var _ sampling.PolicyEvaluator = (*mockPolicyEvaluator)(nil)
+
+func (m *mockPolicyEvaluator) Evaluate(pcommon.TraceID, *sampling.TraceData) (sampling.Decision, error) {
+	m.EvaluationCount++
+	return m.NextDecision, m.NextError
+}
+
+type manualTTicker struct {
+	Started bool
+}
+
+var _ timeutils.TTicker = (*manualTTicker)(nil)
+
+func (t *manualTTicker) Start(time.Duration) {
+	t.Started = true
+}
+
+func (t *manualTTicker) OnTick() {
+}
+
+func (t *manualTTicker) Stop() {
+}
+
+type syncIDBatcher struct {
+	sync.Mutex
+	openBatch idbatcher.Batch
+	batchPipe chan idbatcher.Batch
+}
+
+var _ idbatcher.Batcher = (*syncIDBatcher)(nil)
+
+func newSyncIDBatcher(numBatches uint64) idbatcher.Batcher {
+	batches := make(chan idbatcher.Batch, numBatches)
+	for i := uint64(0); i < numBatches; i++ {
+		batches <- nil
+	}
+	return &syncIDBatcher{
+		batchPipe: batches,
+	}
+}
+
+func (s *syncIDBatcher) AddToCurrentBatch(id pcommon.TraceID) {
+	s.Lock()
+	s.openBatch = append(s.openBatch, id)
+	s.Unlock()
+}
+
+func (s *syncIDBatcher) CloseCurrentAndTakeFirstBatch() (idbatcher.Batch, bool) {
+	s.Lock()
+	defer s.Unlock()
+	firstBatch := <-s.batchPipe
+	s.batchPipe <- s.openBatch
+	s.openBatch = nil
+	return firstBatch, true
+}
+
+func (s *syncIDBatcher) Stop() {
+}
+
+func simpleTraces() ptrace.Traces {
+	return simpleTracesWithID(pcommon.TraceID([16]byte{1, 2, 3, 4}))
+}
+
+func simpleTracesWithID(traceID pcommon.TraceID) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(traceID)
+	return traces
+}

--- a/processor/signoztailsampler/testdata/tail_sampling_config.yaml
+++ b/processor/signoztailsampler/testdata/tail_sampling_config.yaml
@@ -1,0 +1,107 @@
+tail_sampling:
+  decision_wait: 10s
+  num_traces: 100
+  expected_new_traces_per_sec: 10
+  policies:
+    [
+        {
+          name: test-policy-1,
+          type: always_sample
+        },
+        {
+          name: test-policy-2,
+          type: latency,
+          latency: {threshold_ms: 5000}
+        },
+        {
+          name: test-policy-3,
+          type: numeric_attribute,
+          numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+        },
+        {
+          name: test-policy-4,
+          type: probabilistic,
+          probabilistic: {hash_salt: "custom-salt", sampling_percentage: 0.1}
+        },
+        {
+          name: test-policy-5,
+          type: status_code,
+          status_code: {status_codes: [ERROR, UNSET]}
+        },
+        {
+          name: test-policy-6,
+          type: string_attribute,
+          string_attribute: {key: key2, values: [value1, value2]}
+        },
+        {
+          name: test-policy-7,
+          type: rate_limiting,
+          rate_limiting: {spans_per_second: 35}
+       },
+       {
+          name: test-policy-8,
+          type: span_count,
+          span_count: {min_spans: 2}
+       },
+       {
+          name: test-policy-9,
+          type: trace_state,
+          trace_state: { key: key3, values: [ value1, value2 ] }
+       },
+       {
+          name: and-policy-1,
+          type: and,
+          and: {
+            and_sub_policy:
+            [
+              {
+                name: test-and-policy-1,
+                type: numeric_attribute,
+                numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+              },
+              {
+                  name: test-and-policy-2,
+                  type: string_attribute,
+                  string_attribute: { key: key2, values: [ value1, value2 ] }
+              },
+            ]
+          }
+       },
+      {
+        name: composite-policy-1,
+        type: composite,
+        composite:
+          {
+            max_total_spans_per_second: 1000,
+            policy_order: [ test-composite-policy-1, test-composite-policy-2, test-composite-policy-3 ],
+            composite_sub_policy:
+              [
+                {
+                  name: test-composite-policy-1,
+                  type: numeric_attribute,
+                  numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+                },
+                {
+                  name: test-composite-policy-2,
+                  type: string_attribute,
+                  string_attribute: { key: key2, values: [ value1, value2 ] }
+                },
+                {
+                  name: test-composite-policy-3,
+                  type: always_sample
+                }
+              ],
+            rate_allocation:
+              [
+                {
+                  policy: test-composite-policy-1,
+                  percent: 50
+                },
+                {
+                  policy: test-composite-policy-2,
+                  percent: 25
+                }
+              ]
+          }
+      },
+    ]


### PR DESCRIPTION
This PR:
 - copy folder of tail sampling processor from contrib for further customization
 - removed go.mod and go.sum to reduce dep issues

