### PR TITLE
feat: added flag to enable lb exporter collectors

### DIFF
--- a/constants/os_utils.go
+++ b/constants/os_utils.go
@@ -1,0 +1,14 @@
+package constants
+
+import "os"
+
+// AllowLbExporterConfig enables lb exporter capability in the collector instance
+var SupportLbExporterConfig = GetOrDefaultEnv("SUPPORT_LB_EXPORTER_CONFIG", "1")
+
+func GetOrDefaultEnv(key string, fallback string) string {
+	v := os.Getenv(key)
+	if len(v) == 0 {
+		return fallback
+	}
+	return v
+}

--- a/opamp/server_client.go
+++ b/opamp/server_client.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/SigNoz/signoz-otel-collector/constants"
 	"github.com/SigNoz/signoz-otel-collector/signozcol"
 	"github.com/oklog/ulid"
 	"github.com/open-telemetry/opamp-go/client"
@@ -93,6 +94,7 @@ func (s *serverClient) createAgentDescription() *protobufs.AgentDescription {
 		NonIdentifyingAttributes: []*protobufs.KeyValue{
 			keyVal("os.family", runtime.GOOS),
 			keyVal("host.name", hostname),
+			keyVal("capabilities.lbexporter", constants.SupportLbExporterConfig),
 		},
 	}
 }


### PR DESCRIPTION
This PR introduces an additional non-identity attribute `capabilities.lb` in opamp collector. 

The value can be 1 or 0 where 1 indicates - the collector is capable of supporting lb exporter config and 0 otherwise. 

When the support for lb exporter capability is enabled, the opamp server can use the collector as LB. but need not always set it so. 

By default, all collectors will support LB config. The SUPPORT_LB_EXPORTER_CONFIG env var can be used to disable the support (by setting this env var to 0). 

Typically at design time, the env var SUPPORT_LB_EXPORTER_CONFIG can be used to define LB capable collectors ( could be 0 to n) or (non-LB collectors). This would allow options to support multiple configurations depending on customer environment. 

