### PR TITLE
exit when ClickHouse client creation fails

### DIFF
--- a/exporter/clickhousemetricsexporter/exporter.go
+++ b/exporter/clickhousemetricsexporter/exporter.go
@@ -84,7 +84,7 @@ func NewPrwExporter(cfg *Config, set component.ExporterCreateSettings) (*PrwExpo
 	}
 	ch, err := NewClickHouse(params)
 	if err != nil {
-		zap.S().Error("couldn't create instance of clickhouse")
+		log.Fatalf("Error creating clickhouse client: %v", err)
 	}
 
 	collector := usage.NewUsageCollector(ch.GetDBConn().(clickhouse.Conn),


### PR DESCRIPTION
Exit without panic if the ClickHouse connection is failed to establish. This usually happens when the URL is misconfigured or similar network-related issues. Part of https://github.com/SigNoz/signoz/issues/1639