### PR TITLE
fix: tests do not require db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 .DS_Store
 .idea
 ./config/default-config.yaml
+*.rollback
+signoz-collector

--- a/opamp/testdata/coll-config-path-changed.yaml
+++ b/opamp/testdata/coll-config-path-changed.yaml
@@ -1,32 +1,36 @@
-receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-processors:
-  batch:
-    send_batch_size: 10000
-    timeout: 10s
-extensions:
-  zpages: {}
 exporters:
-  clickhousetraces:
-    datasource: tcp://localhost:9000/?database=signoz_traces
-    migrations: exporter/clickhousetracesexporter/migrations
-  clickhousemetricswrite:
-    endpoint: tcp://localhost:9000/?database=signoz_metrics
-    resource_to_telemetry_conversion:
-      enabled: true
-  prometheus:
-    endpoint: "0.0.0.0:8889"
+    logging: null
+    prometheus:
+        endpoint: 0.0.0.0:8889
+extensions:
+    zpages: {}
+processors:
+    batch:
+        send_batch_size: 100000 # changed
+        timeout: 10s
+receivers:
+    otlp:
+        protocols:
+            grpc: null
+            http: null
 service:
-  extensions: [zpages]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [clickhousetraces]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [clickhousemetricswrite]
+    extensions:
+        - zpages
+    pipelines:
+        metrics:
+            exporters:
+                - logging
+            processors:
+                - batch
+            receivers:
+                - otlp
+        traces:
+            exporters:
+                - logging
+            processors:
+                - batch
+            receivers:
+                - otlp
+    telemetry:
+        resource:
+            service.instance.id: opamp/testdata/coll-config-path.yaml

--- a/opamp/testdata/coll-config-path.yaml
+++ b/opamp/testdata/coll-config-path.yaml
@@ -1,11 +1,5 @@
 exporters:
-    clickhousemetricswrite:
-        endpoint: tcp://localhost:9000/?database=signoz_metrics
-        resource_to_telemetry_conversion:
-            enabled: false
-    clickhousetraces:
-        datasource: tcp://localhost:9000/?database=signoz_traces
-        migrations: exporter/clickhousetracesexporter/migrations
+    logging: null
     prometheus:
         endpoint: 0.0.0.0:8889
 extensions:
@@ -25,18 +19,18 @@ service:
     pipelines:
         metrics:
             exporters:
-                - clickhousemetricswrite
+                - logging
             processors:
                 - batch
             receivers:
                 - otlp
         traces:
             exporters:
-                - clickhousetraces
+                - logging
             processors:
                 - batch
             receivers:
                 - otlp
     telemetry:
         resource:
-            service.instance.id: 0ffab2a5-132e-4bef-bd3d-c6d6e7296cfd
+            service.instance.id: opamp/testdata/coll-config-path.yaml

--- a/signozcol/collector_test.go
+++ b/signozcol/collector_test.go
@@ -12,7 +12,7 @@ import (
 func TestCollectorNew(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-new",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -24,7 +24,7 @@ func TestCollectorNew(t *testing.T) {
 func TestCollectorRunInvalidPath(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/invalid.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-invalid-path",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -43,7 +43,7 @@ func TestCollectorRunInvalidPath(t *testing.T) {
 func TestCollectorRunValidPath(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-valid-path",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -62,7 +62,7 @@ func TestCollectorRunValidPath(t *testing.T) {
 func TestCollectorRunValidPathInvalidConfig(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/invalid_config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-valid-path-invalid-config",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -82,7 +82,7 @@ func TestCollectorRunValidPathInvalidConfig(t *testing.T) {
 func TestCollectorShutdown(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-shutdown",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -106,7 +106,7 @@ func TestCollectorShutdown(t *testing.T) {
 func TestCollectorRunMultipleTimes(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-run-multiple-times",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})
@@ -131,7 +131,7 @@ func TestCollectorRunMultipleTimes(t *testing.T) {
 func TestCollectorRestart(t *testing.T) {
 	coll := New(WrappedCollectorSettings{
 		ConfigPaths: []string{"testdata/config.yaml"},
-		Version:     "0.0.1",
+		Version:     "0.0.1-test-restart",
 		Desc:        "test",
 		LoggingOpts: []zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)},
 	})

--- a/signozcol/testdata/config.yaml
+++ b/signozcol/testdata/config.yaml
@@ -22,3 +22,6 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [logging]
+  telemetry:
+      resource:
+          service.instance.id: "signozcol/testdata/config.yaml"

--- a/signozcol/testdata/invalid_config.yaml
+++ b/signozcol/testdata/invalid_config.yaml
@@ -10,17 +10,18 @@ processors:
 extensions:
   zpages: {}
 exporters:
-  clickhousetraces:
-    datasource: tcp://localhost:9000/?database=signoz_traces
-    migrations: exporter/clickhousetracesexporter/migrations
+  logging:
 service:
   extensions: [zpages]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch_processor]
-      exporters: [clickhousetraces]
+      exporters: [logging]
     metrics:
       receivers: [otlp]
       processors: [batch_processor]
       exporters: [clickhousemetricswrite]
+  telemetry:
+      resource:
+          service.instance.id: signozcol/testdata/invalid_config.yaml


### PR DESCRIPTION
This change removes the usage of `clickhouse{traces,metricswrite}` exporters in tests. Otherwise, tests fail in when the connection is not available. There is nothing about the ClickHouse in these tests, so there is no point in starting up a container for DB during the CI run. 