### PR TITLE
Add logs DB creation/deletion in migrations

### DIFF
--- a/exporter/clickhouselogsexporter/README.md
+++ b/exporter/clickhouselogsexporter/README.md
@@ -28,6 +28,10 @@ The following settings can be optionally configured:
     - `max_interval` (default = 30s): The upper bound on backoff; ignored if `enabled` is `false`
     - `max_elapsed_time` (default = 300s): The maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
 
+### Environment variable configuration options
+* LOG_MIGRATIONS_FOLDER: folder containing migrations to be applied by the OTel exporter
+* LOG_MIGRATIONS: when set to "false", the migrations will not be applied by OTel exporter
+
 ## Example
 
 ```yaml

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -330,6 +330,11 @@ func newClickhouseClient(logger *zap.Logger, cfg *Config) (clickhouse.Conn, erro
 		return nil, err
 	}
 
+	// in cases where we want migrations to be handled outside the OTel collector(for RBAC, schema versioning, etc)
+	if strings.ToLower(os.Getenv("LOGS_MIGRATE")) == "false" {
+		return db, nil
+	}
+
 	q := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s ON CLUSTER %s;", databaseName, CLUSTER)
 	err = db.Exec(ctx, q)
 	if err != nil {

--- a/exporter/clickhouselogsexporter/migrations/000001_init_db.down.sql
+++ b/exporter/clickhouselogsexporter/migrations/000001_init_db.down.sql
@@ -5,3 +5,4 @@ DROP TABLE IF EXISTS signoz_logs.resource_keys_string_final_mv ON CLUSTER cluste
 DROP TABLE IF EXISTS signoz_logs.atrribute_keys_float64_final_mv ON CLUSTER cluster;
 DROP TABLE IF EXISTS signoz_logs.atrribute_keys_int64_final_mv ON CLUSTER cluster;
 DROP TABLE IF EXISTS signoz_logs.atrribute_keys_string_final_mv ON CLUSTER cluster;
+DROP DATABASE signoz_logs ON CLUSTER cluster;

--- a/exporter/clickhouselogsexporter/migrations/000001_init_db.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/000001_init_db.up.sql
@@ -1,4 +1,6 @@
 -- https://altinity.com/blog/2019/7/new-encodings-to-improve-clickhouse
+CREATE DATABASE IF NOT EXISTS signoz_logs ON CLUSTER cluster;
+
 CREATE TABLE IF NOT EXISTS signoz_logs.logs ON CLUSTER cluster (
 	timestamp UInt64 CODEC(DoubleDelta, LZ4),
 	observed_timestamp UInt64 CODEC(DoubleDelta, LZ4),

--- a/exporter/clickhouselogsexporter/migrations/000001_init_db.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/000001_init_db.up.sql
@@ -1,6 +1,4 @@
 -- https://altinity.com/blog/2019/7/new-encodings-to-improve-clickhouse
-CREATE DATABASE IF NOT EXISTS signoz_logs ON CLUSTER cluster;
-
 CREATE TABLE IF NOT EXISTS signoz_logs.logs ON CLUSTER cluster (
 	timestamp UInt64 CODEC(DoubleDelta, LZ4),
 	observed_timestamp UInt64 CODEC(DoubleDelta, LZ4),

--- a/exporter/clickhouselogsexporter/migrations/00000_db.down.sql
+++ b/exporter/clickhouselogsexporter/migrations/00000_db.down.sql
@@ -1,0 +1,1 @@
+DROP DATABASE signoz_logs ON CLUSTER cluster;

--- a/exporter/clickhouselogsexporter/migrations/00000_db.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/00000_db.up.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS signoz_logs ON CLUSTER cluster;


### PR DESCRIPTION
Having schema migrations managed outside OTel exporter has its advantages:
* OTel exporter can have RBAC such that  its restricted from creation of databases, tables, etc- to follow the priciple of least privilege
* Other Schema versioning tools could be used to avoid schema conflicts. Here's a detailed explanation of the problem : https://atlasgo.io/concepts/migration-directory-integrity . 
I'm looking at adding support for Clickhouse in Atlas so we can manage it efficiently and automate the process. 

This MR does the following:
* Adds logs database creation/deletion in migration directory
* Adds an environment variable to explicitly opt-out of collector applying migrations. This maintains backward compatibility so that existing setups aren't impacted.

 