### PR TITLE
fix: remove events and startTime span attributes

### DIFF
--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -464,13 +464,6 @@ func extractSpanAttributesFromSpanIndex(span *Span) []SpanAttribute {
 		NumberValue: float64(span.Kind),
 	})
 	spanAttributes = append(spanAttributes, SpanAttribute{
-		Key:         "startTime",
-		TagType:     "tag",
-		IsColumn:    true,
-		DataType:    "float64",
-		NumberValue: float64(span.StartTimeUnixNano),
-	})
-	spanAttributes = append(spanAttributes, SpanAttribute{
 		Key:         "durationNano",
 		TagType:     "tag",
 		IsColumn:    true,
@@ -538,13 +531,6 @@ func extractSpanAttributesFromSpanIndex(span *Span) []SpanAttribute {
 		IsColumn:    true,
 		DataType:    "string",
 		StringValue: span.PeerService,
-	})
-	spanAttributes = append(spanAttributes, SpanAttribute{
-		Key:         "events",
-		TagType:     "tag",
-		IsColumn:    true,
-		DataType:    "string",
-		StringValue: strings.Join(span.Events, ","),
 	})
 	spanAttributes = append(spanAttributes, SpanAttribute{
 		Key:         "httpMethod",


### PR DESCRIPTION
Removed events tag as span attributes because events is of array type and it's not supported currently.
Removed startTime tag as span attributes because user can filter via timestamp and startTime tag is not required