### PR TITLE
fix: resolve signoz tail sampler issues

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Install tools
         run: make install-ci

--- a/processor/signoztailsampler/and_helper.go
+++ b/processor/signoztailsampler/and_helper.go
@@ -15,9 +15,8 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func getNewAndPolicy(logger *zap.Logger, config *AndCfg) (sampling.PolicyEvaluator, error) {

--- a/processor/signoztailsampler/and_helper_test.go
+++ b/processor/signoztailsampler/and_helper_test.go
@@ -17,11 +17,10 @@ package tailsamplingprocessor
 import (
 	"testing"
 
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func TestAndHelper(t *testing.T) {

--- a/processor/signoztailsampler/composite_helper.go
+++ b/processor/signoztailsampler/composite_helper.go
@@ -15,9 +15,8 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func getNewCompositePolicy(logger *zap.Logger, config *CompositeCfg) (sampling.PolicyEvaluator, error) {

--- a/processor/signoztailsampler/composite_helper_test.go
+++ b/processor/signoztailsampler/composite_helper_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
 )
 
 func TestCompositeHelper(t *testing.T) {

--- a/processor/signoztailsampler/internal/timeutils/docs.go
+++ b/processor/signoztailsampler/internal/timeutils/docs.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idutils provides a set of helper functions to convert ids.
+//
+// Functions in big_endian_converter.go help converting uint64 ids to TraceID
+// and SpanID using big endian, and vice versa.
+package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"

--- a/processor/signoztailsampler/internal/timeutils/ticker_helper.go
+++ b/processor/signoztailsampler/internal/timeutils/ticker_helper.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
+
+import "time"
+
+// TTicker interface allows easier testing of Ticker related functionality
+type TTicker interface {
+	// start sets the frequency of the Ticker and starts the periodic calls to OnTick.
+	Start(d time.Duration)
+	// OnTick is called when the Ticker fires.
+	OnTick()
+	// Stop firing the Ticker.
+	Stop()
+}
+
+// Implements TTicker and abstracts underlying time ticker's functionality to make usage
+// simpler.
+type PolicyTicker struct {
+	Ticker     *time.Ticker
+	OnTickFunc func()
+	StopCh     chan struct{}
+}
+
+// Ensure PolicyTicker implements TTicker interface
+var _ TTicker = (*PolicyTicker)(nil)
+
+func (pt *PolicyTicker) Start(d time.Duration) {
+	pt.Ticker = time.NewTicker(d)
+	pt.StopCh = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-pt.Ticker.C:
+				pt.OnTick()
+			case <-pt.StopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (pt *PolicyTicker) OnTick() {
+	pt.OnTickFunc()
+}
+
+func (pt *PolicyTicker) Stop() {
+	if pt.StopCh == nil {
+		return
+	}
+	close(pt.StopCh)
+	pt.Ticker.Stop()
+}

--- a/processor/signoztailsampler/internal/timeutils/ticker_test.go
+++ b/processor/signoztailsampler/internal/timeutils/ticker_test.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutils
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testObj struct {
+	mu  sync.Mutex
+	foo int
+}
+
+func (to *testObj) IncrementFoo() {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+	to.foo++
+}
+
+func checkFooValue(to *testObj, expectedValue int) bool {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+	return to.foo == expectedValue
+}
+
+func TestPolicyTickerFails(t *testing.T) {
+	to := &testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	// Tickers with a duration <= 0 should panic
+	assert.Panics(t, func() { pTicker.Start(time.Duration(0)) })
+	assert.Panics(t, func() { pTicker.Start(time.Duration(-1)) })
+}
+
+func TestPolicyTickerStart(t *testing.T) {
+	to := &testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	// Make sure no ticks occur when we immediately stop the ticker
+	time.Sleep(100 * time.Millisecond)
+	assert.True(t, checkFooValue(to, 0), "Expected value: %d, actual: %d", 0, to.foo)
+	pTicker.Start(1 * time.Second)
+	pTicker.Stop()
+	assert.True(t, checkFooValue(to, 0), "Expected value: %d, actual: %d", 0, to.foo)
+}
+
+func TestPolicyTickerSucceeds(t *testing.T) {
+	// Start the ticker, make sure variable is incremented properly,
+	// also make sure stop works as expected.
+	to := &testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	expectedTicks := 4
+	defaultDuration := 500 * time.Millisecond
+	// Extra padding reduces the chance of a race happening here
+	padDuration := 200 * time.Millisecond
+	testSleepDuration := time.Duration(expectedTicks)*defaultDuration + padDuration
+
+	pTicker.Start(defaultDuration)
+	time.Sleep(testSleepDuration)
+	assert.True(t, checkFooValue(to, expectedTicks), "Expected value: %d, actual: %d", expectedTicks, to.foo)
+
+	pTicker.Stop()
+	// Since these tests are time sensitive they can be flaky. By getting the count
+	// after stopping, we can still test to make sure it's no longer being incremented,
+	// without requiring there by no OnTick calls between the sleep call and stopping.
+	time.Sleep(defaultDuration)
+	expectedTicks = to.foo
+
+	time.Sleep(testSleepDuration)
+	assert.True(t, checkFooValue(to, expectedTicks), "Expected value: %d, actual: %d", expectedTicks, to.foo)
+}

--- a/processor/signoztailsampler/processor.go
+++ b/processor/signoztailsampler/processor.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/idbatcher"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/timeutils"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component"
@@ -30,10 +33,6 @@ import (
 	"go.opentelemetry.io/collector/processor"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 // policy combines a sampling policy evaluator with the destinations to be

--- a/processor/signoztailsampler/processor.go
+++ b/processor/signoztailsampler/processor.go
@@ -185,7 +185,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 		// Sampled or not, remove the batches
 		trace.Lock()
 		allSpans := ptrace.NewTraces()
-		trace.ReceivedBatches.MoveTo(allSpans)
+		trace.ReceivedBatches.CopyTo(allSpans)
 		trace.Unlock()
 
 		if decision == sampling.Sampled {

--- a/processor/signoztailsampler/processor_test.go
+++ b/processor/signoztailsampler/processor_test.go
@@ -31,9 +31,9 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/idbatcher"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/sampling"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztailsampler/internal/timeutils"
 )
 
 const (


### PR DESCRIPTION
- signoztailsampler: copy `timeutils` internal package and update references
- signoztailsampler: use `CopyTo` instead of invalid MoveTo function for `ptrace.Traces`
- test-pipeline: use go-version `1.19`

This PR also resolves the `test-pipeline` failing issue.

Signed-off-by: Prashant Shahi <prashant@signoz.io>
