### PR TITLE
Add http.status_code to default external call dimensions

### DIFF
--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -161,7 +161,9 @@ func newProcessor(logger *zap.Logger, instanceID string, config component.Config
 	}
 	dbCallDimensions = append(dbCallDimensions, pConfig.Dimensions...)
 
-	var externalCallDimensions []Dimension
+	var externalCallDimensions = []Dimension{
+		{Name: tagHTTPStatusCode},
+	}
 	externalCallDimensions = append(externalCallDimensions, pConfig.Dimensions...)
 
 	if pConfig.DimensionsCacheSize <= 0 {


### PR DESCRIPTION
Dimension == attribute. We create external_call metrics based on the HTTP client's span data(i.e. span kind is CLIENT). These external metrics are helpful for users to see the outgoing calls from each service and their latencies and error percentages in the Services tab. Like any other metric data, a set of attributes are added by default, and the user can configure them under the spanmetrics processor config. This document gives a good idea about the component https://github.com/SigNoz/signoz-otel-collector/tree/main/processor/signozspanmetricsprocessor. 

The current issue is `http.status_code` is only added for the `signoz_calls` metrics but not for the external call metrics. For some users who rely on third-party APIs, it is also important to have the ability to filter by `http.status_code` instead of the span `status.code`. The reason is span `status.code` is an ERROR for 4XX from HTTP Client (OK for server) (read more here https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status), but this might not be the case for the user. By adding this dimension/attribute, we allow them to define what the error is for them.