### PR TITLE
fix(Dockerfile): 🐛 remove overriding of TARGETOS and TARGETARCH

### DIFF
--- a/cmd/signozcollector/Dockerfile
+++ b/cmd/signozcollector/Dockerfile
@@ -5,8 +5,7 @@ FROM alpine:3.17
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 # define arguments and default values
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS TARGETARCH
 ARG USER_UID=10001
 
 # create a non-root user for running the collector


### PR DESCRIPTION
Fixes #155

Successfully tested [the built image](https://hub.docker.com/layers/coolboi567/signoz-otel-collector/test/images/sha256-ad2a08a487365c19255692c826cdb17cc02f70b2b8fac4eea59daea28e2695d4?context=explore) in ARM64 machine.

Signed-off-by: Prashant Shahi <prashant@signoz.io>
