### PR TITLE
feat: add default indices for top level keys

### DIFF
--- a/exporter/clickhouselogsexporter/migrations/000007_default_indexes.down.sql
+++ b/exporter/clickhouselogsexporter/migrations/000007_default_indexes.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster drop index IF EXISTS severity_number_idx;
+
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster drop index IF EXISTS severity_text_idx;
+
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster drop index IF EXISTS trace_flags_idx;

--- a/exporter/clickhouselogsexporter/migrations/000007_default_indexes.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/000007_default_indexes.up.sql
@@ -1,0 +1,12 @@
+-- This migration adds default indexes to top level keys of the log model
+
+-- https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber range 1-24 and 0 means it's not set
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS severity_number_idx (severity_number) TYPE set(25) GRANULARITY 4;
+
+-- https://opentelemetry.io/docs/specs/otel/logs/data-model/#displaying-severity 24 different values and empty means not set.
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS severity_text_idx (severity_text) TYPE set(25) GRANULARITY 4;
+
+
+-- No point in addding index for trace_id, span_id as they are not set as they are always unique
+-- trace_flags can be a set so adding a default bloom filter
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS trace_flags_idx (trace_flags) TYPE bloom_filter() GRANULARITY 4;

--- a/exporter/clickhouselogsexporter/migrations/000007_default_indexes.up.sql
+++ b/exporter/clickhouselogsexporter/migrations/000007_default_indexes.up.sql
@@ -7,6 +7,6 @@ ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS severity
 ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS severity_text_idx (severity_text) TYPE set(25) GRANULARITY 4;
 
 
--- No point in addding index for trace_id, span_id as they are not set as they are always unique
+-- No point in addding index for trace_id, span_id as they are not set and they are always unique
 -- trace_flags can be a set so adding a default bloom filter
 ALTER TABLE signoz_logs.logs ON CLUSTER cluster add index IF NOT EXISTS trace_flags_idx (trace_flags) TYPE bloom_filter() GRANULARITY 4;


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/2594

No point in addding index for trace_id, span_id as they are not set and they are always unique