### PR TITLE
fix: use default num consumers

### DIFF
--- a/exporter/clickhouselogsexporter/config.go
+++ b/exporter/clickhouselogsexporter/config.go
@@ -58,7 +58,7 @@ func (cfg *Config) Validate() (err error) {
 func (cfg *Config) enforcedQueueSettings() exporterhelper.QueueSettings {
 	return exporterhelper.QueueSettings{
 		Enabled:      true,
-		NumConsumers: 1,
+		NumConsumers: exporterhelper.NewDefaultQueueSettings().NumConsumers,
 		QueueSize:    cfg.QueueSettings.QueueSize,
 	}
 }

--- a/exporter/clickhouselogsexporter/config.go
+++ b/exporter/clickhouselogsexporter/config.go
@@ -25,9 +25,7 @@ import (
 type Config struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
-	// QueueSettings is a subset of exporterhelper.QueueSettings,
-	// because only QueueSize is user-settable.
-	QueueSettings QueueSettings `mapstructure:"sending_queue"`
+	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 
 	// DSN is the ClickHouse server Data Source Name.
 	// For tcp protocol reference: [ClickHouse/clickhouse-go#dsn](https://github.com/ClickHouse/clickhouse-go#dsn).
@@ -35,12 +33,6 @@ type Config struct {
 	DSN string `mapstructure:"dsn"`
 	// Docker Multi Node Cluster is a flag to enable the docker multi node cluster. Default is false.
 	DockerMultiNodeCluster bool `mapstructure:"docker_multi_node_cluster" default:"false"`
-}
-
-// QueueSettings is a subset of exporterhelper.QueueSettings.
-type QueueSettings struct {
-	// QueueSize set the length of the sending queue
-	QueueSize int `mapstructure:"queue_size"`
 }
 
 var (
@@ -53,12 +45,4 @@ func (cfg *Config) Validate() (err error) {
 		err = multierr.Append(err, errConfigNoDSN)
 	}
 	return err
-}
-
-func (cfg *Config) enforcedQueueSettings() exporterhelper.QueueSettings {
-	return exporterhelper.QueueSettings{
-		Enabled:      true,
-		NumConsumers: exporterhelper.NewDefaultQueueSettings().NumConsumers,
-		QueueSize:    cfg.QueueSettings.QueueSize,
-	}
 }

--- a/exporter/clickhouselogsexporter/config_test.go
+++ b/exporter/clickhouselogsexporter/config_test.go
@@ -57,8 +57,10 @@ func TestLoadConfig(t *testing.T) {
 			RandomizationFactor: 0.7,
 			Multiplier:          1.3,
 		},
-		QueueSettings: QueueSettings{
-			QueueSize: 100,
+		QueueSettings: exporterhelper.QueueSettings{
+			Enabled:      true,
+			NumConsumers: 10,
+			QueueSize:    100,
 		},
 	})
 }

--- a/exporter/clickhouselogsexporter/factory.go
+++ b/exporter/clickhouselogsexporter/factory.go
@@ -66,7 +66,7 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
-		QueueSettings:   QueueSettings{QueueSize: exporterhelper.NewDefaultQueueSettings().QueueSize},
+		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
 	}
 }
@@ -91,7 +91,7 @@ func createLogsExporter(
 		exporter.pushLogsData,
 		exporterhelper.WithShutdown(exporter.Shutdown),
 		exporterhelper.WithTimeout(c.TimeoutSettings),
-		exporterhelper.WithQueue(c.enforcedQueueSettings()),
+		exporterhelper.WithQueue(c.QueueSettings),
 		exporterhelper.WithRetry(c.RetrySettings),
 	)
 }


### PR DESCRIPTION
Have kept the same logic as we need to keep the queueSize configurable.

fixes #181 