### PR TITLE
fix: ingest bool attrs

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -342,8 +342,7 @@ func attributesToSlice(attributes pcommon.Map, forceStringValues bool) (response
 				response.FloatValues = append(response.FloatValues, v.Double())
 			case pcommon.ValueTypeBool:
 				// add boolValues in future if it is required
-				response.BoolKeys = append(response.BoolKeys, formatKey(k))
-				// store it as a string in clickhouse
+				// store it as a string in clickhouse for now
 				response.StringKeys = append(response.StringKeys, formatKey(k))
 				response.StringValues = append(response.StringValues, v.AsString())
 			default: // store it as string

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -343,6 +343,9 @@ func attributesToSlice(attributes pcommon.Map, forceStringValues bool) (response
 			case pcommon.ValueTypeBool:
 				// add boolValues in future if it is required
 				response.BoolKeys = append(response.BoolKeys, formatKey(k))
+				// store it as a string in clickhouse
+				response.StringKeys = append(response.StringKeys, formatKey(k))
+				response.StringValues = append(response.StringValues, v.AsString())
 			default: // store it as string
 				response.StringKeys = append(response.StringKeys, formatKey(k))
 				response.StringValues = append(response.StringValues, v.AsString())

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -199,6 +199,8 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 						attributes.IntValues,
 						attributes.FloatKeys,
 						attributes.FloatValues,
+						attributes.BoolKeys,
+						attributes.BoolValues,
 					)
 					if err != nil {
 						return fmt.Errorf("StatementAppend:%w", err)
@@ -253,6 +255,7 @@ type attributesToSliceResponse struct {
 	FloatKeys    []string
 	FloatValues  []float64
 	BoolKeys     []string
+	BoolValues   []bool
 }
 
 func getStringifiedBody(body pcommon.Value) string {
@@ -341,10 +344,8 @@ func attributesToSlice(attributes pcommon.Map, forceStringValues bool) (response
 				response.FloatKeys = append(response.FloatKeys, formatKey(k))
 				response.FloatValues = append(response.FloatValues, v.Double())
 			case pcommon.ValueTypeBool:
-				// add boolValues in future if it is required
-				// store it as a string in clickhouse for now
-				response.StringKeys = append(response.StringKeys, formatKey(k))
-				response.StringValues = append(response.StringValues, v.AsString())
+				response.BoolKeys = append(response.BoolKeys, formatKey(k))
+				response.BoolValues = append(response.BoolValues, v.Bool())
 			default: // store it as string
 				response.StringKeys = append(response.StringKeys, formatKey(k))
 				response.StringValues = append(response.StringValues, v.AsString())
@@ -378,8 +379,12 @@ const (
 							attributes_int64_key,
 							attributes_int64_value,
 							attributes_float64_key,
-							attributes_float64_value
+							attributes_float64_value,
+							attributes_bool_key,
+							attributes_bool_value
 							) VALUES (
+								?,
+								?,
 								?,
 								?,
 								?,

--- a/migrationmanager/migrators/logs/migrations/000008_add_bool.down.sql
+++ b/migrationmanager/migrators/logs/migrations/000008_add_bool.down.sql
@@ -1,9 +1,9 @@
-ALTER TABLE signoz_logs.logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_key;
+ALTER TABLE signoz_logs.logs ON CLUSTER {{.SIGNOZ_CLUSTER}} DROP column IF EXISTS attributes_bool_key;
 
-ALTER TABLE signoz_logs.logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_value;
+ALTER TABLE signoz_logs.logs ON CLUSTER {{.SIGNOZ_CLUSTER}} DROP column IF EXISTS attributes_bool_value;
 
-ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_key;
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} DROP column IF EXISTS attributes_bool_key;
 
-ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_value;
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} DROP column IF EXISTS attributes_bool_value;
 
-DROP TABLE IF EXISTS signoz_logs.attribute_keys_bool_final_mv ON CLUSTER cluster;
+DROP TABLE IF EXISTS signoz_logs.attribute_keys_bool_final_mv ON CLUSTER {{.SIGNOZ_CLUSTER}};

--- a/migrationmanager/migrators/logs/migrations/000008_add_bool.down.sql
+++ b/migrationmanager/migrators/logs/migrations/000008_add_bool.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_key;
+
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_value;
+
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_key;
+
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster DROP column IF EXISTS attributes_bool_value;
+
+DROP TABLE IF EXISTS signoz_logs.attribute_keys_bool_final_mv ON CLUSTER cluster;

--- a/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
+++ b/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
@@ -1,12 +1,12 @@
-ALTER TABLE signoz_logs.logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
 
-ALTER TABLE signoz_logs.logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
 
-ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
 
-ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS  attribute_keys_bool_final_mv ON CLUSTER cluster TO signoz_logs.logs_attribute_keys AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS  attribute_keys_bool_final_mv ON CLUSTER {{.SIGNOZ_CLUSTER}} TO signoz_logs.logs_attribute_keys AS
 SELECT
 distinct arrayJoin(attributes_bool_key) as name, 'Bool' datatype
 FROM signoz_logs.logs

--- a/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
+++ b/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
+
+ALTER TABLE signoz_logs.logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
+
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_key Array(String) CODEC(ZSTD(1));
+
+ALTER TABLE signoz_logs.distributed_logs ON CLUSTER cluster add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS  attribute_keys_bool_final_mv ON CLUSTER cluster TO signoz_logs.logs_attribute_keys AS
+SELECT
+distinct arrayJoin(attributes_bool_key) as name, 'Bool' datatype
+FROM signoz_logs.logs
+ORDER BY name;

--- a/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
+++ b/migrationmanager/migrators/logs/migrations/000008_add_bool.up.sql
@@ -6,7 +6,7 @@ ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add colu
 
 ALTER TABLE signoz_logs.distributed_logs ON CLUSTER {{.SIGNOZ_CLUSTER}} add column IF NOT EXISTS attributes_bool_value Array(Bool) CODEC(ZSTD(1));
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS  attribute_keys_bool_final_mv ON CLUSTER {{.SIGNOZ_CLUSTER}} TO signoz_logs.logs_attribute_keys AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS  signoz_logs.attribute_keys_bool_final_mv ON CLUSTER {{.SIGNOZ_CLUSTER}} TO signoz_logs.logs_attribute_keys AS
 SELECT
 distinct arrayJoin(attributes_bool_key) as name, 'Bool' datatype
 FROM signoz_logs.logs


### PR DESCRIPTION
Fixes #209 

* Previously we directly stored bool values as as string.
* When we added tag attributes support that time this bug got introduct when the attribute wasn't stored in with log line.
* Added changes so that the bool values are stored.

Suggestes and querying work as expected.