### PR TITLE
fix: proper defer statement for log exporter

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -422,12 +422,12 @@ func newClickhouseClient(logger *zap.Logger, cfg *Config) (clickhouse.Conn, erro
 	}
 
 	// setting maxOpenIdleConnections = numConsumers + 1 to avoid `prepareBatch:clickhouse: acquire conn timeout` error
-	// maxOpenIdleConnections := cfg.QueueSettings.NumConsumers + 1
+	maxOpenIdleConnections := cfg.QueueSettings.NumConsumers + 1
 
 	options := &clickhouse.Options{
 		Addr:         []string{dsnURL.Host},
-		MaxOpenConns: cfg.QueueSettings.NumConsumers - 1,
-		// MaxIdleConns: maxOpenIdleConnections,
+		MaxOpenConns: cfg.QueueSettings.NumConsumers + 5,
+		MaxIdleConns: maxOpenIdleConnections,
 	}
 
 	if dsnURL.Query().Get("username") != "" {

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -426,7 +426,7 @@ func newClickhouseClient(logger *zap.Logger, cfg *Config) (clickhouse.Conn, erro
 
 	options := &clickhouse.Options{
 		Addr:         []string{dsnURL.Host},
-		MaxOpenConns: cfg.QueueSettings.NumConsumers + 5,
+		MaxOpenConns: maxOpenIdleConnections + 5,
 		MaxIdleConns: maxOpenIdleConnections,
 	}
 

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -139,12 +139,12 @@ func (e *clickhouseLogsExporter) pushLogsData(ctx context.Context, ld plog.Logs)
 		return errors.New("shutdown has been called")
 	default:
 		start := time.Now()
-		statement, err = e.db.PrepareBatch(ctx, e.insertLogsSQL)
+		statement, err = e.db.PrepareBatch(ctx, e.insertLogsSQL, driver.WithReleaseConnection())
 		if err != nil {
 			return fmt.Errorf("PrepareBatch:%w", err)
 		}
 
-		tagStatement, err = e.db.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.%s", databaseName, DISTRIBUTED_TAG_ATTRIBUTES))
+		tagStatement, err = e.db.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.%s", databaseName, DISTRIBUTED_TAG_ATTRIBUTES), driver.WithReleaseConnection())
 		if err != nil {
 			return fmt.Errorf("PrepareTagBatch:%w", err)
 		}


### PR DESCRIPTION
The defer function was not executed properly in the previous implementation, because of which connections were kept on hold.

Now even if I use maxOpenConnection = numConsumers - 1, once it fails to acquire connection it will retry and it is eventually successful.

Fixes https://github.com/SigNoz/signoz-otel-collector/issues/222