### PR TITLE
Write to new v4 table with nearest hour unix precision

### DIFF
--- a/exporter/clickhousemetricsexporter/clickhouse.go
+++ b/exporter/clickhousemetricsexporter/clickhouse.go
@@ -48,6 +48,7 @@ const (
 	DISTRIBUTED_TIME_SERIES_TABLE_V3 = "distributed_time_series_v3"
 	DISTRIBUTED_TIME_SERIES_TABLE_V4 = "distributed_time_series_v4"
 	DISTRIBUTED_SAMPLES_TABLE        = "distributed_samples_v2"
+	TIME_SERIES_TABLE                = "time_series_v2"
 	temporalityLabel                 = "__temporality__"
 	envLabel                         = "env"
 )

--- a/exporter/clickhousemetricsexporter/config.go
+++ b/exporter/clickhousemetricsexporter/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	ResourceToTelemetrySettings resourcetotelemetry.Settings `mapstructure:"resource_to_telemetry_conversion"`
 
 	WatcherInterval time.Duration `mapstructure:"watcher_interval"`
+
+	WriteTSToV4 bool `mapstructure:"write_ts_to_v4"`
 }
 
 // RemoteWriteQueue allows to configure the remote write queue.

--- a/exporter/clickhousemetricsexporter/config_test.go
+++ b/exporter/clickhousemetricsexporter/config_test.go
@@ -83,6 +83,7 @@ func Test_loadConfig(t *testing.T) {
 			},
 			ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 			WatcherInterval:             30 * time.Second,
+			WriteTSToV4:                 false,
 		})
 }
 

--- a/exporter/clickhousemetricsexporter/exporter.go
+++ b/exporter/clickhousemetricsexporter/exporter.go
@@ -86,6 +86,7 @@ func NewPrwExporter(cfg *Config, set exporter.CreateSettings) (*PrwExporter, err
 		MaxOpenConns:         75,
 		MaxTimeSeriesInQuery: 50,
 		WatcherInterval:      cfg.WatcherInterval,
+		WriteTSToV4:          cfg.WriteTSToV4,
 	}
 	ch, err := NewClickHouse(params)
 	if err != nil {

--- a/exporter/clickhousemetricsexporter/factory.go
+++ b/exporter/clickhousemetricsexporter/factory.go
@@ -129,5 +129,6 @@ func createDefaultConfig() component.Config {
 			NumConsumers: 5,
 		},
 		WatcherInterval: 30 * time.Second,
+		WriteTSToV4:     false,
 	}
 }

--- a/migrationmanager/migrators/metrics/migrations/000003_ts_v4.down.sql
+++ b/migrationmanager/migrators/metrics/migrations/000003_ts_v4.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS signoz_metrics.time_series_v4 ON CLUSTER {{.SIGNOZ_CLUSTER}};
+
+DROP TABLE IF EXISTS signoz_metrics.distributed_time_series_v4 ON CLUSTER {{.SIGNOZ_CLUSTER}};

--- a/migrationmanager/migrators/metrics/migrations/000003_ts_v4.up.sql
+++ b/migrationmanager/migrators/metrics/migrations/000003_ts_v4.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS signoz_metrics.time_series_v4 ON CLUSTER {{.SIGNOZ_CLUSTER}} (
+    env LowCardinality(String) DEFAULT 'default',
+    temporality LowCardinality(String) DEFAULT 'Unspecified',
+    metric_name LowCardinality(String),
+    description LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    unit LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    type LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    is_monotonic Bool DEFAULT false CODEC(ZSTD(1)),
+    fingerprint UInt64 CODEC(Delta, ZSTD),
+    unix_milli Int64 CODEC(Delta, ZSTD),
+    labels String CODEC(ZSTD(5)),
+    INDEX idx_labels labels TYPE ngrambf_v1(4, 1024, 3, 0) GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree
+        PARTITION BY toDate(unix_milli / 1000)
+        ORDER BY (env, temporality, metric_name, fingerprint, unix_milli)
+        TTL toDateTime(unix_milli/1000) + INTERVAL 2592000 SECOND DELETE;
+
+CREATE TABLE IF NOT EXISTS signoz_metrics.distributed_time_series_v4 ON CLUSTER {{.SIGNOZ_CLUSTER}} AS signoz_metrics.time_series_v4 ENGINE = Distributed("{{.SIGNOZ_CLUSTER}}", signoz_metrics, time_series_v4, cityHash64(env, temporality, metric_name, fingerprint, unix_milli));

--- a/migrationmanager/migrators/metrics/migrations/000003_ts_v4.up.sql
+++ b/migrationmanager/migrators/metrics/migrations/000003_ts_v4.up.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS signoz_metrics.time_series_v4 ON CLUSTER {{.SIGNOZ_CL
 ENGINE = ReplacingMergeTree
         PARTITION BY toDate(unix_milli / 1000)
         ORDER BY (env, temporality, metric_name, fingerprint, unix_milli)
-        TTL toDateTime(unix_milli/1000) + INTERVAL 2592000 SECOND DELETE;
+        TTL toDateTime(unix_milli/1000) + INTERVAL 2592000 SECOND DELETE
+        SETTINGS ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS signoz_metrics.distributed_time_series_v4 ON CLUSTER {{.SIGNOZ_CLUSTER}} AS signoz_metrics.time_series_v4 ENGINE = Distributed("{{.SIGNOZ_CLUSTER}}", signoz_metrics, time_series_v4, cityHash64(env, temporality, metric_name, fingerprint, unix_milli));

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -80,6 +80,9 @@ func newTracesReceiver(config Config, set receiver.CreateSettings, unmarshalers 
 		return nil, errUnrecognizedEncoding
 	}
 
+	// set sarama library's logger to get detailed logs from the library
+	sarama.Logger = zap.NewStdLog(set.Logger)
+	
 	c := sarama.NewConfig()
 	c = setSaramaConsumerFetchConfig(c, &config)
 	c.ClientID = config.ClientID
@@ -175,6 +178,9 @@ func newMetricsReceiver(config Config, set receiver.CreateSettings, unmarshalers
 		return nil, errUnrecognizedEncoding
 	}
 
+	// set sarama library's logger to get detailed logs from the library
+	sarama.Logger = zap.NewStdLog(set.Logger)
+
 	c := sarama.NewConfig()
 	c = setSaramaConsumerFetchConfig(c, &config)
 	c.ClientID = config.ClientID
@@ -264,6 +270,9 @@ func (c *kafkaMetricsConsumer) Shutdown(context.Context) error {
 }
 
 func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshalers map[string]LogsUnmarshaler, nextConsumer consumer.Logs) (*kafkaLogsConsumer, error) {
+	// set sarama library's logger to get detailed logs from the library
+	sarama.Logger = zap.NewStdLog(set.Logger)
+	
 	c := sarama.NewConfig()
 	c = setSaramaConsumerFetchConfig(c, &config)
 	c.ClientID = config.ClientID


### PR DESCRIPTION
## What we do today

We maintain two tables in the metrics database

1. samples
2. time_series

The `samples` table contains the metric value and timestamp it was collected at. The `time_series` table contains the metric_name + tags (referred to as timeseries) and the first instance of the timestamp at which the new series was created.

## Why we do what we do

### Two tables

One way to model the schema is to have a single table with all the data.

- value
- timestamp
- tags (either map or pairwise array or json encoded string)

The speed of the query is dependent on the amount of data it has to read. Reading labels from map/array/json encoded string is slow since it has to read the full labels and unpack it (map is just an array underneath). So the more rows you have the slower the query will be. One important characteristic of the timeseries data is that it doesn't change very often. We can have one set of labels for a metric that reports for days, weeks or even months. So we maintain a separate table for timeseries and samples. This improves the speed of the query since we only have to read the labels once and then join them with the samples table.

### Conditional insert to time series table

If there is no change in the labels then we don't need to insert a new row in the time series table. We can just use the existing row. The collector maintains a lookup table of timeseries and their ids. If the timeseries is not in the lookup table then it inserts a new row in the time series table and updates the lookup table. If the timeseries is in the lookup table then the row is not inserted in the time series table.

## Issues with the current implementation

1. The stale timeseries are not deleted from the time series table. 
    - The tag key and value suggestion in the UI will show stale tags.
    - The growing size of the table with stale time series will slow down the query.

2. We don't know the last time a timeseries was seen (commonly known as active time series). This is important to know if we want to delete the stale timeseries.

## This PR
Insert the time series with the hour precision regardless of the prior existence of the same time series. We want to test
- how effective the ReplacingMergeTree engine is and how much space it saves. 
- how does this compare to the current implementation

This is disabled by default. We will do this exercise for a selected set of users in production and asses its effectiveness. 