### PR TITLE
fix: opamp client: ignore non-running collector in ensureRunning when reloading collector config

### DIFF
--- a/opamp/server_client.go
+++ b/opamp/server_client.go
@@ -233,6 +233,13 @@ func (s *serverClient) onRemoteConfigHandler(ctx context.Context, remoteConfig *
 
 // reload is the callback function that is called when the agent configuration file changes
 func (s *serverClient) reload(contents []byte) error {
+	s.reloadMux.Lock()
+	s.isReloading = true
+	defer func() {
+		s.isReloading = false
+		s.reloadMux.Unlock()
+	}()
+
 	collectorConfigPath := s.configManager.agentConfig.path
 	rollbackPath := fmt.Sprintf("%s.rollback", collectorConfigPath)
 


### PR DESCRIPTION
Right now, if ensureRunning happens to catch a stopped collector svc while a config reload is in progress, it triggers process level shutdown.

Fixes https://github.com/SigNoz/signoz/issues/4181