### PR TITLE
Log warn for empty batch instead of error

### DIFF
--- a/exporter/clickhousemetricsexporter/helper.go
+++ b/exporter/clickhousemetricsexporter/helper.go
@@ -15,7 +15,6 @@
 package clickhousemetricsexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 
 import (
-	"errors"
 	"log"
 	"math"
 	"sort"
@@ -249,9 +248,9 @@ func getPromMetricName(metric pmetric.Metric, ns string) string {
 }
 
 // batchTimeSeries splits series into multiple batch write requests.
-func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int) ([]*prompb.WriteRequest, error) {
+func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int) []*prompb.WriteRequest {
 	if len(tsMap) == 0 {
-		return nil, errors.New("invalid tsMap: cannot be empty map")
+		return nil
 	}
 
 	var requests []*prompb.WriteRequest
@@ -278,7 +277,7 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int) 
 		requests = append(requests, wrapped)
 	}
 
-	return requests, nil
+	return requests
 }
 
 // convertTimeStamp converts OTLP timestamp in ns to timestamp in ms

--- a/exporter/clickhousemetricsexporter/helper_test.go
+++ b/exporter/clickhousemetricsexporter/helper_test.go
@@ -340,39 +340,30 @@ func Test_batchTimeSeries(t *testing.T) {
 		tsMap               map[string]*prompb.TimeSeries
 		maxBatchByteSize    int
 		numExpectedRequests int
-		returnErr           bool
 	}{
 		{
 			"no_timeseries",
 			tsMap1,
 			100,
-			-1,
-			true,
+			0,
 		},
 		{
 			"normal_case",
 			tsMap2,
 			300,
 			1,
-			false,
 		},
 		{
 			"two_requests",
 			tsMap3,
 			300,
 			2,
-			false,
 		},
 	}
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			requests, err := batchTimeSeries(tt.tsMap, tt.maxBatchByteSize)
-			if tt.returnErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
+			requests := batchTimeSeries(tt.tsMap, tt.maxBatchByteSize)
 			assert.Equal(t, tt.numExpectedRequests, len(requests))
 		})
 	}


### PR DESCRIPTION
Certain OTEL SDKs are sending empty data points. This isn't an error we can act on so skipping with warning. 