### PR TITLE
Add TTL to top_level_operations table

### DIFF
--- a/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.down.sql
+++ b/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.down.sql
@@ -3,3 +3,6 @@ ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}}
 
 ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
     REMOVE TTL;
+
+ALTER TABLE signoz_traces.distributed_top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    DROP COLUMN IF EXISTS time;

--- a/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.down.sql
+++ b/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
+    DROP COLUMN IF EXISTS time;
+
+ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
+    REMOVE TTL;

--- a/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.up.sql
+++ b/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
+    ADD COLUMN IF NOT EXISTS time DateTime DEFAULT now() CODEC(ZSTD(1));
+
+ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
+    MODIFY TTL time + INTERVAL 1 MONTH;

--- a/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.up.sql
+++ b/migrationmanager/migrators/traces/migrations/000025_add_time_column_ttl_top_level.up.sql
@@ -3,3 +3,6 @@ ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}}
 
 ALTER TABLE signoz_traces.top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}} 
     MODIFY TTL time + INTERVAL 1 MONTH;
+
+ALTER TABLE signoz_traces.distributed_top_level_operations ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    ADD COLUMN IF NOT EXISTS time DateTime DEFAULT now() CODEC(ZSTD(1));


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/4265
Fixes https://github.com/SigNoz/signoz-otel-collector/issues/252
Currently, the `top_level_operations` doesn't have any table. This leads to a couple of issues

- The (test) services are kept in db forever.
- Incorrect top-level operations are kept forever without any cleanup. Assume some operation was identified as top-level operation due to incorrect/broken instrumentation. 