### PR TITLE
signozkafkaexporter: use request id as record key + idempotent producers

### DIFF
--- a/exporter/signozkafkaexporter/config.go
+++ b/exporter/signozkafkaexporter/config.go
@@ -37,6 +37,9 @@ type Config struct {
 
 	// Authentication defines used authentication mechanism.
 	Authentication Authentication `mapstructure:"auth"`
+
+	// UseRequestIdAsRecordKey defines whether to use request id as record key or not.Defaults to false.
+	UseRequestIdAsRecordKey bool `mapstructure:"use_request_id_as_record_key"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.
@@ -75,6 +78,12 @@ type Producer struct {
 	// broker request. Defaults to 0 for unlimited. Similar to
 	// `queue.buffering.max.messages` in the JVM producer.
 	FlushMaxMessages int `mapstructure:"flush_max_messages"`
+
+	// maps to saramaconfig.Producer.Idempotent
+	EnableIdempotence bool `mapstructure:"enable_idempotence"`
+
+	// maps tp saramaconfig.Net.MaxOpenRequests
+	MaxOpenRequests int `mapstructure:"max_open_requests"`
 }
 
 // MetadataRetry defines retry configuration for Metadata.

--- a/exporter/signozkafkaexporter/config_test.go
+++ b/exporter/signozkafkaexporter/config_test.go
@@ -69,6 +69,8 @@ func TestLoadConfig(t *testing.T) {
 					MaxMessageBytes: 10000000,
 					RequiredAcks:    sarama.WaitForAll,
 					Compression:     "none",
+					EnableIdempotence: false,
+					MaxOpenRequests:   5,
 				},
 			},
 		},

--- a/exporter/signozkafkaexporter/factory.go
+++ b/exporter/signozkafkaexporter/factory.go
@@ -36,6 +36,10 @@ const (
 	defaultCompression = "none"
 	// default from sarama.NewConfig()
 	defaultFluxMaxMessages = 0
+	// default from sarama.NewConfig()
+	defaultIdempotence = false
+	// default from sarama.NewConfig()
+	defaultMaxOpenConnections = 5
 )
 
 // FactoryOption applies changes to kafkaExporterFactory.
@@ -104,11 +108,14 @@ func createDefaultConfig() component.Config {
 			},
 		},
 		Producer: Producer{
-			MaxMessageBytes:  defaultProducerMaxMessageBytes,
-			RequiredAcks:     defaultProducerRequiredAcks,
-			Compression:      defaultCompression,
-			FlushMaxMessages: defaultFluxMaxMessages,
+			MaxMessageBytes:   defaultProducerMaxMessageBytes,
+			RequiredAcks:      defaultProducerRequiredAcks,
+			Compression:       defaultCompression,
+			FlushMaxMessages:  defaultFluxMaxMessages,
+			EnableIdempotence: defaultIdempotence,
+			MaxOpenRequests:   defaultMaxOpenConnections,
 		},
+		UseRequestIdAsRecordKey: false,
 	}
 }
 

--- a/exporter/signozkafkaexporter/utils.go
+++ b/exporter/signozkafkaexporter/utils.go
@@ -1,8 +1,10 @@
 package signozkafkaexporter
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/Shopify/sarama"
 	"go.opentelemetry.io/collector/client"
 )
 
@@ -14,4 +16,25 @@ func getKafkaTopicFromClientMetadata(md client.Metadata) (string, error) {
 		return "", fmt.Errorf("signoz_tenant_id not found in client metadata")
 	}
 	return signozTenantId[0], nil
+}
+
+// getKafkaTopicFromClientMetadata returns the kafka topic from client metadata
+func getRequestIdFromClientMetadata(md client.Metadata) (string, error) {
+	// return default topic if no tenant id is found in client metadata
+	signozTenantId := md.Get("signoz_request_id")
+	if len(signozTenantId) == 0 {
+		return "", fmt.Errorf("signoz_request_id not found in client metadata")
+	}
+	return signozTenantId[0], nil
+}
+
+func setRequestIdAsKey(ctx context.Context, messages []*sarama.ProducerMessage) ([]*sarama.ProducerMessage, error) {
+	requestId, err := getRequestIdFromClientMetadata(client.FromContext(ctx).Metadata)
+	if err != nil {
+		return nil, err
+	}
+	for _, message := range messages {
+		message.Key = sarama.StringEncoder(requestId)
+	}
+	return messages, nil
 }


### PR DESCRIPTION
This PR adds the following changes - 
- use requestId as the record key
parse requestId from client metadata and use it as the kafka record's key - this key will be used to deduplicate data with kafka streams
- idempotent producers 
this PR also enables us to configure [idempotent producers](https://developer.confluent.io/patterns/event-processing/idempotent-writer/) by exposing the sarama library's relevant config