### PR TITLE
Remove span attribute precedence for conflicting attr

### DIFF
--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -1037,8 +1037,10 @@ func getDimensionValue(d dimension, spanAttr pcommon.Map, resourceAttr pcommon.M
 }
 
 func getDimensionValueWithResource(d dimension, spanAttr pcommon.Map, resourceAttr pcommon.Map) (v pcommon.Value, ok bool, foundInResource bool) {
-	// The more specific span attribute should take precedence.
 	if attr, exists := spanAttr.Get(d.name); exists {
+		if _, exists := resourceAttr.Get(d.name); exists {
+			return attr, true, true
+		}
 		return attr, true, false
 	}
 	if attr, exists := resourceAttr.Get(d.name); exists {

--- a/processor/signozspanmetricsprocessor/processor_test.go
+++ b/processor/signozspanmetricsprocessor/processor_test.go
@@ -58,9 +58,11 @@ const (
 	notInSpanAttrName0     = "shouldBeInMetric"
 	notInSpanAttrName1     = "shouldNotBeInMetric"
 	regionResourceAttrName = "region"
+	conflictResourceAttr   = "host.name"
 	DimensionsCacheSize    = 2
 
 	sampleRegion          = "us-east-1"
+	sampleConflictingHost = "conflicting-host"
 	sampleLatency         = float64(11)
 	sampleLatencyDuration = time.Duration(sampleLatency) * time.Millisecond
 )
@@ -609,6 +611,8 @@ func verifyConsumeMetricsInput(t testing.TB, input pmetric.Metrics, expectedTemp
 func verifyMetricLabels(dp metricDataPoint, t testing.TB, seenMetricIDs map[metricID]bool) {
 	mID := metricID{}
 	wantDimensions := map[string]pcommon.Value{
+		conflictResourceAttr:                    pcommon.NewValueStr(sampleConflictingHost),
+		resourcePrefix + conflictResourceAttr:   pcommon.NewValueStr(sampleConflictingHost),
 		stringAttrName:                          pcommon.NewValueStr("stringAttrValue"),
 		intAttrName:                             pcommon.NewValueInt(99),
 		doubleAttrName:                          pcommon.NewValueDouble(99.99),
@@ -700,6 +704,7 @@ func initServiceSpans(serviceSpans serviceSpans, spans ptrace.ResourceSpans) {
 	}
 
 	spans.Resource().Attributes().PutStr(regionResourceAttrName, sampleRegion)
+	spans.Resource().Attributes().PutStr(conflictResourceAttr, sampleConflictingHost)
 
 	ils := spans.ScopeSpans().AppendEmpty()
 	for _, span := range serviceSpans.spans {
@@ -716,6 +721,7 @@ func initSpan(span span, s ptrace.Span) {
 	s.SetEndTimestamp(pcommon.NewTimestampFromTime(now.Add(sampleLatencyDuration)))
 
 	s.Attributes().PutStr(stringAttrName, "stringAttrValue")
+	s.Attributes().PutStr(conflictResourceAttr, sampleConflictingHost)
 	s.Attributes().PutInt(intAttrName, 99)
 	s.Attributes().PutDouble(doubleAttrName, 99.99)
 	s.Attributes().PutBool(boolAttrName, true)


### PR DESCRIPTION
**Current:**

If an attribute appears in both `span.Attributes()` and `resource.Attributes()`, then `span.Attributes()` takes precedence. 

**Updated:**

If an attribute appears in both `span.Attributes()` and `resource.Attributes()`, then both are set and the Resource attributed is prefixed with `resource_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for dimension value retrieval to prioritize certain attributes, enhancing data accuracy.
- **Tests**
	- Updated tests to align with the new logic for handling resource attributes, ensuring reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->