### PR TITLE
feat: drop logs older than TTL

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -133,7 +133,7 @@ func (e *clickhouseLogsExporter) getLogsTTLSeconds(ctx context.Context) (int, er
 		return delTTL, err
 	}
 	if len(dbResp) == 0 {
-		return -1, nil
+		return delTTL, fmt.Errorf("ttl not found")
 	}
 
 	deleteTTLExp := regexp.MustCompile(`toIntervalSecond\(([0-9]*)\)`)
@@ -155,9 +155,6 @@ func (e *clickhouseLogsExporter) removeOldLogs(ctx context.Context, ld plog.Logs
 	ttL, err := e.getLogsTTLSeconds(ctx)
 	if err != nil {
 		return err
-	}
-	if ttL == -1 {
-		return fmt.Errorf("ttl not found")
 	}
 
 	// if logs contains timestamp before acceptedDateTime, it will be rejected

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -151,11 +151,11 @@ func (e *clickhouseLogsExporter) removeOldLogs(ctx context.Context, acceptedDate
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		logs := ld.ResourceLogs().At(i)
 		for j := 0; j < logs.ScopeLogs().Len(); j++ {
-			xyz := func(log plog.LogRecord) bool {
+			removeLog := func(log plog.LogRecord) bool {
 				t := log.Timestamp().AsTime()
 				return t.Unix() < acceptedDateTime.Unix()
 			}
-			logs.ScopeLogs().At(j).LogRecords().RemoveIf(xyz)
+			logs.ScopeLogs().At(j).LogRecords().RemoveIf(removeLog)
 		}
 	}
 }

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -132,6 +132,9 @@ func (e *clickhouseLogsExporter) getLogsTTLSeconds(ctx context.Context) (int, er
 	if err != nil {
 		return delTTL, err
 	}
+	if len(dbResp) == 0 {
+		return -1, nil
+	}
 
 	deleteTTLExp := regexp.MustCompile(`toIntervalSecond\(([0-9]*)\)`)
 

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -148,13 +148,13 @@ func (e *clickhouseLogsExporter) getLogsTTLSeconds(ctx context.Context) (int, er
 }
 
 func (e *clickhouseLogsExporter) removeOldLogs(ctx context.Context, acceptedDateTime time.Time, ld plog.Logs) {
+	removeLog := func(log plog.LogRecord) bool {
+		t := log.Timestamp().AsTime()
+		return t.Unix() < acceptedDateTime.Unix()
+	}
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		logs := ld.ResourceLogs().At(i)
 		for j := 0; j < logs.ScopeLogs().Len(); j++ {
-			removeLog := func(log plog.LogRecord) bool {
-				t := log.Timestamp().AsTime()
-				return t.Unix() < acceptedDateTime.Unix()
-			}
 			logs.ScopeLogs().At(j).LogRecords().RemoveIf(removeLog)
 		}
 	}


### PR DESCRIPTION
Fixes #272 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Improved log management by adding methods to retrieve logs TTL and remove old logs based on a timestamp.
    - Enhanced data pushing to Clickhouse with retry logic and TTL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->