### PR TITLE
Add experimental support for APM latency with Exp Histogram

### DIFF
--- a/processor/signozspanmetricsprocessor/config.go
+++ b/processor/signozspanmetricsprocessor/config.go
@@ -83,6 +83,8 @@ type Config struct {
 
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the configured MetricsExporter.
 	MetricsFlushInterval time.Duration `mapstructure:"metrics_flush_interval"`
+
+	EnableExpHistogram bool `mapstructure:"enable_exp_histogram"`
 }
 
 // GetAggregationTemporality converts the string value given in the config into a AggregationTemporality.

--- a/processor/signozspanmetricsprocessor/factory.go
+++ b/processor/signozspanmetricsprocessor/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 		DimensionsCacheSize:    defaultDimensionsCacheSize,
 		skipSanitizeLabel:      dropSanitizationFeatureGate.IsEnabled(),
 		MetricsFlushInterval:   60 * time.Second,
+		EnableExpHistogram:     false,
 	}
 }
 


### PR DESCRIPTION
Follow up https://github.com/SigNoz/signoz-otel-collector/pull/279#issuecomment-1934619152. This is more accurate (i.e. as close to latency from traces) and faster. 

- Not enabled by default
- The default max size is 160, and it supports high-resolution tail latency distribution covering 1ms-100s (we need to bump the size if we want more); to achieve the same in explicit bucket histogram we need to define 160 buckets. Which makes the queries slower and samples by 10x of the current samples. 

The query would change

<details><summary>From</summary>

```sql
SELECT
    service_name,
    ts,
    histogramQuantile(arrayMap(x -> toFloat64(x), groupArray(le)), groupArray(value), 0.99) AS value
FROM
(
    SELECT
        service_name,
        le,
        ts,
        sum(rate_value) AS value
    FROM
    (
        SELECT
            service_name,
            le,
            ts,
            If((value - lagInFrame(value, 1, 0) OVER rate_window) < 0, nan, If((ts - lagInFrame(ts, 1, toDate('1970-01-01')) OVER rate_window) >= 86400, nan, (value - lagInFrame(value, 1, 0) OVER rate_window) / (ts - lagInFrame(ts, 1, toDate('1970-01-01')) OVER rate_window))) AS rate_value
        FROM
        (
            SELECT
                fingerprint,
                service_name,
                le,
                toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), toIntervalSecond(60)) AS ts,
                max(value) AS value
            FROM signoz_metrics.distributed_samples_v2
            INNER JOIN
            (
                SELECT
                    JSONExtractString(labels, 'service_name') AS service_name,
                    JSONExtractString(labels, 'le') AS le,
                    fingerprint
                FROM signoz_metrics.time_series_v2
                WHERE (metric_name = 'signoz_latency_bucket') AND (temporality IN ['Cumulative', 'Unspecified'])
            ) AS filtered_time_series USING (fingerprint)
            WHERE (metric_name = 'signoz_latency_bucket')
            GROUP BY
                fingerprint,
                service_name,
                le,
                ts
            ORDER BY
                fingerprint ASC,
                service_name ASC,
                le ASC,
                ts ASC
        )
        WINDOW rate_window AS (PARTITION BY fingerprint, service_name, le ORDER BY fingerprint ASC, service_name ASC, le ASC, ts ASC)
    )
    WHERE isNaN(rate_value) = 0
    GROUP BY
        GROUPING SETS (
            (service_name, le, ts),
            (service_name, le))
    ORDER BY
        service_name ASC,
        le ASC,
        ts ASC
)
GROUP BY
    service_name,
    ts
ORDER BY
    service_name ASC,
    ts ASC
```
</details>

<details><summary>To</summary>


```sql
SELECT
    service_name,
    toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), toIntervalSecond(60)) AS ts,
    quantilesDDMerge(0.01, 0.99)(sketch)[1] AS value
FROM signoz_metrics.distributed_exp_hist
INNER JOIN
(
    SELECT
        JSONExtractString(labels, 'service_name') AS service_name,
        JSONExtractString(labels, 'le') AS le,
        fingerprint
    FROM signoz_metrics.time_series_v2
    WHERE (metric_name = 'signoz_latency')
) AS filtered_time_series USING (fingerprint)
WHERE (metric_name = 'signoz_latency')
GROUP BY
    service_name,
    ts
ORDER BY
    service_name ASC,
    ts ASC
```
</details>
