### PR TITLE
Do not replace service.instance.id from SDK

### DIFF
--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/collector/semconv/v1.13.0"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 
@@ -49,6 +48,8 @@ const (
 	tagHTTPStatusCodeStable = "http.response.status_code"
 	metricKeySeparator      = string(byte(0))
 	traceIDKey              = "trace_id"
+
+	signozID = "signoz.collector.id"
 
 	defaultDimensionsCacheSize = 1000
 	resourcePrefix             = "resource_"
@@ -834,7 +835,7 @@ func (p *processorImp) aggregateMetrics(traces ptrace.Traces) {
 		if !ok {
 			continue
 		}
-		resourceAttr.PutStr(semconv.AttributeServiceInstanceID, p.instanceID)
+		resourceAttr.PutStr(signozID, p.instanceID)
 		serviceName := serviceAttr.Str()
 		ilsSlice := rspans.ScopeSpans()
 		for j := 0; j < ilsSlice.Len(); j++ {

--- a/processor/signozspanmetricsprocessor/processor_test.go
+++ b/processor/signozspanmetricsprocessor/processor_test.go
@@ -36,7 +36,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processortest"
-	semconv "go.opentelemetry.io/collector/semconv/v1.13.0"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -828,10 +827,10 @@ func TestBuildKeyWithDimensions(t *testing.T) {
 		{
 			name: "resource attribute contains instance ID",
 			optionalDims: []dimension{
-				{name: semconv.AttributeServiceInstanceID},
+				{name: signozID},
 			},
 			resourceAttrMap: map[string]interface{}{
-				semconv.AttributeServiceInstanceID: testID,
+				signozID: testID,
 			},
 			wantKey: "ab\u0000c\u0000SPAN_KIND_UNSPECIFIED\u0000STATUS_CODE_UNSET\u0000test-instance-id",
 		},


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz-otel-collector/issues/283
Fixes https://github.com/SigNoz/signoz/issues/4338

In the past, we created our own ID `signoz.collector.id` for the uniqueness guarantees and then moved to use the `service.instance.id` from the collector `TelemetrySettings`. This conflicts with the `service.instance.id` coming from the Client SDK with the signoz-otel-collector. Users want to see their instance instead of the SigNoz deployment under the `service.instance.id` attribute. This is a reasonable ask. We will honour their settings and maintain our own attribute `signoz.collector.id` as we did earlier. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Updated the handling of instance IDs in metrics aggregation for improved identification and tracking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->