### PR TITLE
Use parent context for write* operations

### DIFF
--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -421,7 +421,7 @@ func (s *storage) pushTraceData(ctx context.Context, td ptrace.Traces) error {
 				}
 			}
 		}
-		err := s.Writer.WriteBatchOfSpans(batchOfSpans)
+		err := s.Writer.WriteBatchOfSpans(ctx, batchOfSpans)
 		if err != nil {
 			zap.S().Error("Error in writing spans to clickhouse: ", err)
 			return err

--- a/exporter/clickhousetracesexporter/clickhouse_factory.go
+++ b/exporter/clickhousetracesexporter/clickhouse_factory.go
@@ -15,6 +15,7 @@
 package clickhousetracesexporter
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -39,7 +40,7 @@ type Factory struct {
 
 // Writer writes spans to storage.
 type Writer interface {
-	WriteBatchOfSpans(span []*Span) error
+	WriteBatchOfSpans(ctx context.Context, span []*Span) error
 }
 
 type writerMaker func(WriterOptions) (Writer, error)

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -90,9 +90,7 @@ func NewSpanWriter(options WriterOptions) *SpanWriter {
 	return writer
 }
 
-func (w *SpanWriter) writeIndexBatch(batchSpans []*Span) error {
-
-	ctx := context.Background()
+func (w *SpanWriter) writeIndexBatch(ctx context.Context, batchSpans []*Span) error {
 	var statement driver.Batch
 	var err error
 
@@ -164,9 +162,7 @@ func (w *SpanWriter) writeIndexBatch(batchSpans []*Span) error {
 	return err
 }
 
-func (w *SpanWriter) writeTagBatch(batchSpans []*Span) error {
-
-	ctx := context.Background()
+func (w *SpanWriter) writeTagBatch(ctx context.Context, batchSpans []*Span) error {
 	var tagKeyStatement driver.Batch
 	var tagStatement driver.Batch
 	var err error
@@ -298,9 +294,7 @@ func (w *SpanWriter) writeTagBatch(batchSpans []*Span) error {
 	return err
 }
 
-func (w *SpanWriter) writeErrorBatch(batchSpans []*Span) error {
-
-	ctx := context.Background()
+func (w *SpanWriter) writeErrorBatch(ctx context.Context, batchSpans []*Span) error {
 	var statement driver.Batch
 	var err error
 
@@ -357,8 +351,7 @@ func stringToBool(s string) bool {
 	return false
 }
 
-func (w *SpanWriter) writeModelBatch(batchSpans []*Span) error {
-	ctx := context.Background()
+func (w *SpanWriter) writeModelBatch(ctx context.Context, batchSpans []*Span) error {
 	var statement driver.Batch
 	var err error
 
@@ -380,6 +373,9 @@ func (w *SpanWriter) writeModelBatch(batchSpans []*Span) error {
 		usageMap := span.TraceModel
 		usageMap.TagMap = map[string]string{}
 		serialized, err = json.Marshal(span.TraceModel)
+		if err != nil {
+			return err
+		}
 		serializedUsage, err := json.Marshal(usageMap)
 
 		if err != nil {
@@ -413,27 +409,27 @@ func (w *SpanWriter) writeModelBatch(batchSpans []*Span) error {
 }
 
 // WriteBatchOfSpans writes the encoded batch of spans
-func (w *SpanWriter) WriteBatchOfSpans(batch []*Span) error {
+func (w *SpanWriter) WriteBatchOfSpans(ctx context.Context, batch []*Span) error {
 	if w.spansTable != "" {
-		if err := w.writeModelBatch(batch); err != nil {
+		if err := w.writeModelBatch(ctx, batch); err != nil {
 			w.logger.Error("Could not write a batch of spans to model table: ", zap.Error(err))
 			return err
 		}
 	}
 	if w.indexTable != "" {
-		if err := w.writeIndexBatch(batch); err != nil {
+		if err := w.writeIndexBatch(ctx, batch); err != nil {
 			w.logger.Error("Could not write a batch of spans to index table: ", zap.Error(err))
 			return err
 		}
 	}
 	if w.errorTable != "" {
-		if err := w.writeErrorBatch(batch); err != nil {
+		if err := w.writeErrorBatch(ctx, batch); err != nil {
 			w.logger.Error("Could not write a batch of spans to error table: ", zap.Error(err))
 			return err
 		}
 	}
 	if w.attributeTable != "" && w.attributeKeyTable != "" {
-		if err := w.writeTagBatch(batch); err != nil {
+		if err := w.writeTagBatch(ctx, batch); err != nil {
 			w.logger.Error("Could not write a batch of spans to tag/tagKey tables: ", zap.Error(err))
 			return err
 		}


### PR DESCRIPTION
The traces table latency goes as high as minutes because it doesn't respect the parent context cancellation. The other two exporters do and will have a maximum of `timeout` latency. Without this change, the timeout setting is useless https://github.com/SigNoz/signoz-otel-collector/blob/59f483969686b9f9c5a214696d2ca87eed3f45f6/exporter/clickhousetracesexporter/factory.go#L32-L34