### PR TITLE
(feat) return a default topic when tenant_id is not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 .vscode
 .DS_Store

--- a/exporter/signozkafkaexporter/kafka_exporter.go
+++ b/exporter/signozkafkaexporter/kafka_exporter.go
@@ -39,10 +39,8 @@ func (ke kafkaErrors) Error() string {
 }
 
 func (e *kafkaTracesProducer) tracesPusher(ctx context.Context, td ptrace.Traces) error {
-	kafkaTopicPrefix, err := getKafkaTopicFromClientMetadata(client.FromContext(ctx).Metadata)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
+	kafkaTopicPrefix := getKafkaTopicPrefixFromClientMetadata(client.FromContext(ctx).Metadata)
+
 	kafkaTopic := fmt.Sprintf("%s_traces", kafkaTopicPrefix)
 	messages, err := e.marshaler.Marshal(td, kafkaTopic)
 	if err != nil {
@@ -74,10 +72,8 @@ type kafkaMetricsProducer struct {
 }
 
 func (e *kafkaMetricsProducer) metricsDataPusher(ctx context.Context, md pmetric.Metrics) error {
-	kafkaTopicPrefix, err := getKafkaTopicFromClientMetadata(client.FromContext(ctx).Metadata)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
+	kafkaTopicPrefix := getKafkaTopicPrefixFromClientMetadata(client.FromContext(ctx).Metadata)
+
 	kafkaTopic := fmt.Sprintf("%s_metrics", kafkaTopicPrefix)
 	messages, err := e.marshaler.Marshal(md, kafkaTopic)
 	if err != nil {
@@ -111,10 +107,8 @@ type kafkaLogsProducer struct {
 func (e *kafkaLogsProducer) logsDataPusher(ctx context.Context, ld plog.Logs) error {
 	e.normalizeLogData(&ld)
 
-	kafkaTopicPrefix, err := getKafkaTopicFromClientMetadata(client.FromContext(ctx).Metadata)
-	if err != nil {
-		return consumererror.NewPermanent(err)
-	}
+	kafkaTopicPrefix := getKafkaTopicPrefixFromClientMetadata(client.FromContext(ctx).Metadata)
+
 	kafkaTopic := fmt.Sprintf("%s_logs", kafkaTopicPrefix)
 	messages, err := e.marshaler.Marshal(ld, kafkaTopic)
 	if err != nil {

--- a/exporter/signozkafkaexporter/utils.go
+++ b/exporter/signozkafkaexporter/utils.go
@@ -5,16 +5,16 @@ import (
 )
 
 const (
-	DefaultKafkaTopic = "default"
+	DefaultKafkaTopicPrefix = "default"
 )
 
 // getKafkaTopicFromClientMetadata returns the kafka topic from client metadata
-func getKafkaTopicFromClientMetadata(md client.Metadata) (string, error) {
+func getKafkaTopicPrefixFromClientMetadata(md client.Metadata) string {
 	// return default topic if no tenant id is found in client metadata
 	signozTenantId := md.Get("signoz_tenant_id")
 	if len(signozTenantId) != 0 {
-		return signozTenantId[0], nil
+		return signozTenantId[0]
 	}
 
-	return DefaultKafkaTopic, nil
+	return DefaultKafkaTopicPrefix
 }

--- a/exporter/signozkafkaexporter/utils.go
+++ b/exporter/signozkafkaexporter/utils.go
@@ -1,17 +1,20 @@
 package signozkafkaexporter
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/collector/client"
+)
+
+const (
+	DefaultKafkaTopic = "default"
 )
 
 // getKafkaTopicFromClientMetadata returns the kafka topic from client metadata
 func getKafkaTopicFromClientMetadata(md client.Metadata) (string, error) {
 	// return default topic if no tenant id is found in client metadata
 	signozTenantId := md.Get("signoz_tenant_id")
-	if len(signozTenantId) == 0 {
-		return "", fmt.Errorf("signoz_tenant_id not found in client metadata")
+	if len(signozTenantId) != 0 {
+		return signozTenantId[0], nil
 	}
-	return signozTenantId[0], nil
+
+	return DefaultKafkaTopic, nil
 }


### PR DESCRIPTION
#### Features

- Return a default topic name when `signoz_tenant_id` is missing in the metadata


#### Refactors

- Change name of the function `getKafkaTopicPrefixFromClientMetadata` to reflect what it is actually doing.