### PR TITLE
chore: use StringGetter interface instead of StandardStringGetter for HexToInt arg

### DIFF
--- a/processor/signoztransformprocessor/ottlfunctions/func_hex_to_int.go
+++ b/processor/signoztransformprocessor/ottlfunctions/func_hex_to_int.go
@@ -10,7 +10,7 @@ import (
 )
 
 type HexToIntArguments[K any] struct {
-	Target ottl.StandardStringGetter[K]
+	Target ottl.StringGetter[K]
 }
 
 func NewHexToIntFactory[K any]() ottl.Factory[K] {
@@ -27,7 +27,7 @@ func createHexToIntFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments)
 	return hexToInt(args.Target)
 }
 
-func hexToInt[K any](target ottl.StandardStringGetter[K]) (ottl.ExprFunc[K], error) {
+func hexToInt[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
 
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)


### PR DESCRIPTION
contributes to https://github.com/SigNoz/signoz/issues/4444