### PR TITLE
chore: scrape normalized_query_hash as string value instead of uint64 from system.query_log table

### DIFF
--- a/receiver/clickhousesystemtablesreceiver/query_log.go
+++ b/receiver/clickhousesystemtablesreceiver/query_log.go
@@ -56,7 +56,7 @@ type QueryLog struct {
 	FormattedQuery string `ch:"formatted_query"`
 	QueryKind      string `ch:"query_kind"`
 	// Identical hash value without the values of literals for similar queries.
-	NormalizedQueryHash uint64 `ch:"normalized_query_hash"`
+	NormalizedQueryHash string `ch:"normalized_query_hash"`
 
 	// Names of the databases present in the query.
 	Databases []string `ch:"databases"`
@@ -224,7 +224,7 @@ func scrapeQueryLogTable(
 			query,
 			formatted_query,
 			query_kind,
-			normalized_query_hash,
+			toString(normalized_query_hash) as normalized_query_hash,
 			databases,
 			tables,
 			columns,


### PR DESCRIPTION
Right now the clickhousesystemtablesreceiver scrapes normalized_query_hash column from system.query_log table as a uint64 value, but the value ends up in int64 fields which leads to integer overflow (the logs table supports only int64 values and [pdata also stores uints as ints](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/pcommon/value.go#L159) )

Since the query hash is used only for equality comparisons, it should be scraped as a string value to preserve the original value

fixes https://github.com/SigNoz/signoz-otel-collector/issues/319