### PR TITLE
fix: tagAttributes table fix for instrumentation scope

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -255,7 +255,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 
 				scopeAttributes := attributesToSlice(scope.Attributes(), true)
 
-				err := addAttrsToTagStatement(tagStatement, "scope", resources)
+				err := addAttrsToTagStatement(tagStatement, "scope", scopeAttributes)
 				if err != nil {
 					return err
 				}

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -255,7 +255,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 
 				scopeAttributes := attributesToSlice(scope.Attributes(), true)
 
-				err := addAttrsToTagStatement(tagStatement, "instrumentation_scope", resources)
+				err := addAttrsToTagStatement(tagStatement, "scope", resources)
 				if err != nil {
 					return err
 				}

--- a/migrationmanager/migrators/logs/migrations/000013_rename_instrumentation_scope.down.sql
+++ b/migrationmanager/migrators/logs/migrations/000013_rename_instrumentation_scope.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE signoz_logs.tag_attributes ON CLUSTER {{.SIGNOZ_CLUSTER}} modify column tagType Enum8('tag', 'resource', 'instrumentation_scope') CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.distributed_tag_attributes ON CLUSTER {{.SIGNOZ_CLUSTER}} modify column tagType Enum8('tag', 'resource', 'instrumentation_scope') CODEC(ZSTD(1));

--- a/migrationmanager/migrators/logs/migrations/000013_rename_instrumentation_scope.up.sql
+++ b/migrationmanager/migrators/logs/migrations/000013_rename_instrumentation_scope.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE signoz_logs.tag_attributes ON CLUSTER {{.SIGNOZ_CLUSTER}} modify column tagType Enum8('tag', 'resource', 'scope') CODEC(ZSTD(1));
+ALTER TABLE signoz_logs.distributed_tag_attributes ON CLUSTER {{.SIGNOZ_CLUSTER}} modify column tagType Enum8('tag', 'resource', 'scope') CODEC(ZSTD(1));


### PR DESCRIPTION
No migration is required as 

`tagType Enum8('tag' = 1, 'resource' = 2, 'instrumentation_scope' = 3) CODEC(ZSTD(1))`

is changed to 

`tagType Enum8('tag' = 1, 'resource' = 2, 'scope' = 3) CODEC(ZSTD(1))`