### PR TITLE
chore: add indices for attributes

### DIFF
--- a/migrationmanager/migrators/traces/migrations/000030_add_attributes_indices.down.sql
+++ b/migrationmanager/migrators/traces/migrations/000030_add_attributes_indices.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE signoz_traces.signoz_index_v2 ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    DROP INDEX IF EXISTS idx_stringTagMapKeys,
+    DROP INDEX IF EXISTS idx_stringTagMapValues,
+
+    DROP INDEX IF EXISTS idx_numberTagMapKeys,
+    DROP INDEX IF EXISTS idx_numberTagMapValues,
+
+    DROP INDEX IF EXISTS idx_boolTagMapKeys;

--- a/migrationmanager/migrators/traces/migrations/000030_add_attributes_indices.up.sql
+++ b/migrationmanager/migrators/traces/migrations/000030_add_attributes_indices.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE signoz_traces.signoz_index_v2 ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    ADD INDEX IF NOT EXISTS idx_stringTagMapKeys mapKeys(stringTagMap) TYPE tokenbf_v1(1024, 2, 0) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_stringTagMapValues mapValues(stringTagMap) TYPE ngrambf_v1(4, 5000, 2, 0) GRANULARITY 1,
+
+    ADD INDEX IF NOT EXISTS idx_numberTagMapValues mapKeys(numberTagMap) TYPE tokenbf_v1(1024, 2, 0) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_numberTagMapValues mapValues(numberTagMap) TYPE bloom_filter(0.01) GRANULARITY 1,
+
+    ADD INDEX IF NOT EXISTS idx_boolTagMapKeys mapKeys(boolTagMap) TYPE tokenbf_v1(1024, 2, 0) GRANULARITY 1;


### PR DESCRIPTION
indices on `stringTagMap`, `numberTagMap` and `boolTagMap` do not exist today