### PR TITLE
Chore/change resourcemap index

### DIFF
--- a/migrationmanager/migrators/traces/migrations/000031_change_resource_index.down.sql
+++ b/migrationmanager/migrators/traces/migrations/000031_change_resource_index.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE signoz_traces.signoz_index_v2 ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    DROP INDEX IF EXISTS idx_resourceTagMapKeys,
+    DROP INDEX IF EXISTS idx_resourceTagMapValues,
+
+    ADD INDEX IF NOT EXISTS idx_resourceTagsMapKeys mapKeys(resourceTagsMap) TYPE bloom_filter(0.01) GRANULARITY 64,
+    ADD INDEX IF NOT EXISTS idx_resourceTagsMapValues mapValues(resourceTagsMap) TYPE bloom_filter(0.01) GRANULARITY 64;
+
+

--- a/migrationmanager/migrators/traces/migrations/000031_change_resource_index.up.sql
+++ b/migrationmanager/migrators/traces/migrations/000031_change_resource_index.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE signoz_traces.signoz_index_v2 ON CLUSTER {{.SIGNOZ_CLUSTER}}
+    DROP INDEX IF EXISTS idx_resourceTagsMapKeys,
+    DROP INDEX IF EXISTS idx_resourceTagsMapValues,
+
+    ADD INDEX IF NOT EXISTS idx_resourceTagMapKeys mapKeys(resourceTagsMap) TYPE tokenbf_v1(1024, 2, 0) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_resourceTagMapValues mapValues(resourceTagsMap) TYPE ngrambf_v1(4, 5000, 2, 0) GRANULARITY 1;

--- a/migrationmanager/migrators/traces/migrations/000031_change_resource_index.up.sql
+++ b/migrationmanager/migrators/traces/migrations/000031_change_resource_index.up.sql
@@ -1,6 +1,3 @@
 ALTER TABLE signoz_traces.signoz_index_v2 ON CLUSTER {{.SIGNOZ_CLUSTER}}
-    DROP INDEX IF EXISTS idx_resourceTagsMapKeys,
-    DROP INDEX IF EXISTS idx_resourceTagsMapValues,
-
     ADD INDEX IF NOT EXISTS idx_resourceTagMapKeys mapKeys(resourceTagsMap) TYPE tokenbf_v1(1024, 2, 0) GRANULARITY 1,
     ADD INDEX IF NOT EXISTS idx_resourceTagMapValues mapValues(resourceTagsMap) TYPE ngrambf_v1(4, 5000, 2, 0) GRANULARITY 1;


### PR DESCRIPTION
change the type of index for resource attributes from `bloom_filter` to `tokenbf_v1` for keys and `ngrambf_v1` for values. This is tested and implemented in logs already.