### PR TITLE
fix: write int64 tag attributes for old schema

### DIFF
--- a/exporter/clickhouselogsexporter/config.go
+++ b/exporter/clickhouselogsexporter/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	DSN string `mapstructure:"dsn"`
 	// Docker Multi Node Cluster is a flag to enable the docker multi node cluster. Default is false.
 	DockerMultiNodeCluster bool `mapstructure:"docker_multi_node_cluster" default:"false"`
+	UseNewSchema           bool `mapstructure:"use_new_schema" default:"false"`
 }
 
 var (

--- a/exporter/clickhouselogsexporter/config_test.go
+++ b/exporter/clickhouselogsexporter/config_test.go
@@ -37,7 +37,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Exporters), 2)
+	assert.Equal(t, len(cfg.Exporters), 3)
 
 	defaultCfg := factory.CreateDefaultConfig()
 	defaultCfg.(*Config).DSN = "tcp://127.0.0.1:9000/?dial_timeout=5s"
@@ -64,4 +64,8 @@ func TestLoadConfig(t *testing.T) {
 			QueueSize:    100,
 		},
 	})
+
+	defaultCfg.(*Config).UseNewSchema = true
+	r2 := cfg.Exporters[component.NewIDWithName(component.MustNewType(typeStr), "new_schema")]
+	assert.Equal(t, r2, defaultCfg)
 }

--- a/exporter/clickhouselogsexporter/testdata/config.yaml
+++ b/exporter/clickhouselogsexporter/testdata/config.yaml
@@ -19,6 +19,9 @@ exporters:
       multiplier: 1.3
     sending_queue:
       queue_size: 100
+  clickhouselogsexporter/new_schema:
+    dsn: tcp://127.0.0.1:9000/?dial_timeout=5s
+    use_new_schema: true
 
 service:
   pipelines:


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz-otel-collector/issues/372

* with the new schema we stored in64 tag attributes as float64 which broke the suggestions api for old users with int64 keys.
* this PR fixes this issue and also adds a new config option.