### PR TITLE
Add ALTER COLUMN operations

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/column_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations.go
@@ -1,0 +1,446 @@
+package schemamigrator
+
+import (
+	"strings"
+)
+
+// AlterTableAddColumn is used to add a column to a table.
+// It is used to represent the ALTER TABLE ADD COLUMN statement in the SQL.
+type AlterTableAddColumn struct {
+	cluster string
+
+	Database string
+	Table    string
+	Column   Column
+	// Should be used carefully, this is to be used when the column is to be added after a specific column
+	// If not specified, the column will be added at the end
+	After *Column
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableAddColumn) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableAddColumn) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableAddColumn) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableAddColumn) IsMutation() bool {
+	// Adding a column is not a mutation. It simply updates the metadata of the table.
+	return false
+}
+
+func (a AlterTableAddColumn) IsIdempotent() bool {
+	// Adding a column is idempotent. It will not change the table if the column already exists.
+	return true
+}
+
+func (a AlterTableAddColumn) IsLightweight() bool {
+	// Adding a column is lightweight. It simply updates the metadata of the table.
+	return true
+}
+
+func (a AlterTableAddColumn) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" ADD COLUMN IF NOT EXISTS ")
+	sql.WriteString(a.Column.ToSQL())
+	if a.After != nil {
+		sql.WriteString(" AFTER ")
+		sql.WriteString(a.After.Name)
+	}
+	return sql.String()
+}
+
+// AlterTableDropColumn is used to drop a column from a table.
+// It is used to represent the ALTER TABLE DROP COLUMN statement in the SQL.
+type AlterTableDropColumn struct {
+	cluster  string
+	Database string
+	Table    string
+	Column   Column
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableDropColumn) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableDropColumn) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableDropColumn) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return true, a.Database, a.Table
+}
+
+func (a AlterTableDropColumn) IsMutation() bool {
+	// Dropping a column is a mutation. It will remove the column from the table.
+	return true
+}
+
+func (a AlterTableDropColumn) IsIdempotent() bool {
+	// Dropping a column is idempotent. It will not change the table if the column does not exist.
+	return true
+}
+
+func (a AlterTableDropColumn) IsLightweight() bool {
+	// Dropping a column is lightweight. It removes the data from the disk
+	// which is a lightweight operation.
+	return true
+}
+
+func (a AlterTableDropColumn) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" DROP COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	return sql.String()
+}
+
+// AlterTableModifyColumn is used to modify a column in a table.
+// It is used to represent the ALTER TABLE MODIFY COLUMN statement in the SQL.
+type AlterTableModifyColumn struct {
+	cluster string
+
+	Database string
+	Table    string
+	Column   Column
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableModifyColumn) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableModifyColumn) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableModifyColumn) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableModifyColumn) IsMutation() bool {
+	// If the column type or ttl is modified, it is a mutation.
+	// This is because the column data will be re-written.
+	return a.Column.Type != nil || a.Column.TTL != ""
+}
+
+func (a AlterTableModifyColumn) IsIdempotent() bool {
+	// Modifying a column is idempotent. It will not change the table if the column does not exist.
+	return true
+}
+
+func (a AlterTableModifyColumn) IsLightweight() bool {
+	// If the column type or ttl is modified, it is a mutation that
+	// re-writes the column data.
+	return a.Column.Type != nil || a.Column.TTL != ""
+}
+
+func (a AlterTableModifyColumn) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	if a.Column.Type != nil {
+		sql.WriteString(" ")
+		sql.WriteString(a.Column.Type.String())
+	}
+	if a.Column.Default != "" {
+		sql.WriteString(" DEFAULT ")
+		sql.WriteString(a.Column.Default)
+	}
+	if a.Column.Codec != "" {
+		sql.WriteString(" CODEC(")
+		sql.WriteString(a.Column.Codec)
+		sql.WriteString(")")
+	}
+	if a.Column.TTL != "" {
+		sql.WriteString(" TTL ")
+		sql.WriteString(a.Column.TTL)
+	}
+	if a.Column.Settings != nil {
+		sql.WriteString(" SETTINGS ")
+		sql.WriteString(a.Column.Settings.String())
+	}
+	return sql.String()
+}
+
+// AlterTableModifyColumnRemove is used to remove one of the column properties
+// See https://clickhouse.com/docs/en/sql-reference/statements/alter/column#modify-column-remove
+type AlterTableModifyColumnRemove struct {
+	cluster string
+
+	Database string
+	Table    string
+	Column   Column
+	Property ColumnProperty
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableModifyColumnRemove) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+// WithReplication is a no-op for this operation.
+func (a AlterTableModifyColumnRemove) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableModifyColumnRemove) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableModifyColumnRemove) IsMutation() bool {
+	// Removing a column property is not a mutation. It simply updates the metadata of the table.
+	return false
+}
+
+func (a AlterTableModifyColumnRemove) IsIdempotent() bool {
+	// Removing a column property is idempotent. It will not change the table if the property does not exist.
+	return false
+}
+
+func (a AlterTableModifyColumnRemove) IsLightweight() bool {
+	// Removing a column property is lightweight. It simply updates the metadata of the table.
+	return true
+}
+
+func (a AlterTableModifyColumnRemove) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	sql.WriteString(" REMOVE ")
+	sql.WriteString(string(a.Property))
+	return sql.String()
+}
+
+// AlterTableModifyColumnModifySettings is used to modify the settings of a column.
+// It is used to represent the ALTER TABLE MODIFY COLUMN SETTINGS statement in the SQL.
+type AlterTableModifyColumnModifySettings struct {
+	cluster string
+
+	Database string
+	Table    string
+	Column   Column
+	Settings ColumnSettings
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableModifyColumnModifySettings) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableModifyColumnModifySettings) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableModifyColumnModifySettings) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableModifyColumnModifySettings) IsMutation() bool {
+	// Modifying the settings of a column is not a mutation. It simply updates the metadata of the table.
+	return false
+}
+
+func (a AlterTableModifyColumnModifySettings) IsIdempotent() bool {
+	// Modifying the settings of a column is idempotent. It will not change the table if the settings do not exist.
+	return true
+}
+
+func (a AlterTableModifyColumnModifySettings) IsLightweight() bool {
+	// Modifying the settings of a column is lightweight. It simply updates the metadata of the table.
+	return true
+}
+
+func (a AlterTableModifyColumnModifySettings) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	sql.WriteString(" MODIFY SETTING ")
+	sql.WriteString(a.Settings.String())
+	return sql.String()
+}
+
+// AlterTableModifyColumnResetSettings is used to reset the settings of a column.
+// It is used to represent the ALTER TABLE MODIFY COLUMN RESET SETTINGS statement in the SQL.
+type AlterTableModifyColumnResetSettings struct {
+	cluster string
+
+	Database string
+	Table    string
+	Column   Column
+	Settings ColumnSettings
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableModifyColumnResetSettings) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableModifyColumnResetSettings) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableModifyColumnResetSettings) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableModifyColumnResetSettings) IsMutation() bool {
+	// Resetting the settings of a column is not a mutation. It simply updates the metadata of the table.
+	return false
+}
+
+func (a AlterTableModifyColumnResetSettings) IsIdempotent() bool {
+	// Resetting the settings of a column is idempotent. It will not change the table if the settings do not exist.
+	return true
+}
+
+func (a AlterTableModifyColumnResetSettings) IsLightweight() bool {
+	// Resetting the settings of a column is lightweight. It simply updates the metadata of the table.
+	return true
+}
+
+func (a AlterTableModifyColumnResetSettings) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	sql.WriteString(" RESET SETTING ")
+	sql.WriteString(strings.Join(a.Settings.Names(), ", "))
+	return sql.String()
+}
+
+// AlterTableMaterializeColumn is used to materialize a column.
+// It is used to represent the ALTER TABLE MATERIALIZE COLUMN statement in the SQL.
+type AlterTableMaterializeColumn struct {
+	cluster string
+
+	Database    string
+	Table       string
+	Column      Column
+	Partition   string
+	PartitionID string
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableMaterializeColumn) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableMaterializeColumn) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableMaterializeColumn) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableMaterializeColumn) IsMutation() bool {
+	// Materializing a column is a mutation. It will create a new column.
+	return true
+}
+
+func (a AlterTableMaterializeColumn) IsIdempotent() bool {
+	// Materializing a column is idempotent. It will not change the table if the column already exists.
+	return true
+}
+
+func (a AlterTableMaterializeColumn) IsLightweight() bool {
+	// Materializing a column is not lightweight. It will rewrite the column data with materialized data.
+	return false
+}
+
+func (a AlterTableMaterializeColumn) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MATERIALIZE COLUMN IF EXISTS ")
+	sql.WriteString(a.Column.Name)
+	if a.Partition != "" {
+		sql.WriteString(" IN PARTITION ")
+		sql.WriteString(a.Partition)
+	} else if a.PartitionID != "" {
+		sql.WriteString(" IN PARTITION ")
+		sql.WriteString(a.PartitionID)
+	}
+	return sql.String()
+}

--- a/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
@@ -1,0 +1,440 @@
+package schemamigrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlterTableAddColumn(t *testing.T) {
+
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "col-with-name-and-type-and-cluster",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: ColumnTypeString,
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String",
+		},
+		{
+			name: "col-with-name-and-type-without-cluster",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: ColumnTypeString,
+				},
+			},
+			want: "ALTER TABLE db.table ADD COLUMN IF NOT EXISTS col String",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeString,
+					Default: "'default'",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String DEFAULT 'default'",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-int-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeInt64,
+					Default: "1",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Int64 DEFAULT 1",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-float-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeFloat64,
+					Default: "1.1",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Float64 DEFAULT 1.1",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-bool-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeBool,
+					Default: "true",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Bool DEFAULT true",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-date-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeDate,
+					Default: "'2021-01-01'",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Date DEFAULT '2021-01-01'",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-uuid-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeUUID,
+					Default: "uuid_nil()", // no such function in clickhouse but shows any expression can be passed as default value
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col UUID DEFAULT uuid_nil()",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-default-ip-value",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ColumnTypeIPv4,
+					Default: "'127.0.0.1'",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col IPv4 DEFAULT '127.0.0.1'",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-array-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: ArrayColumnType{ColumnTypeInt32},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Int32)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-array-type-with-default",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ArrayColumnType{ColumnTypeInt32},
+					Default: "[1, 2, 3]",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Int32) DEFAULT [1, 2, 3]",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-array-type-with-default-and-array-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    ArrayColumnType{ArrayColumnType{ColumnTypeInt32}},
+					Default: "[[1, 2, 3], [4, 5, 6]]",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Array(Int32)) DEFAULT [[1, 2, 3], [4, 5, 6]]",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-map-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: MapColumnType{ColumnTypeInt32, ColumnTypeString},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Map(Int32, String)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-map-type-with-default",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    MapColumnType{ColumnTypeInt32, ColumnTypeString},
+					Default: "{1: 'a', 2: 'b'}",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Map(Int32, String) DEFAULT {1: 'a', 2: 'b'}",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-tuple-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: TupleColumnType{[]ColumnType{ColumnTypeBool, ColumnTypeString}},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Tuple(Bool, String)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-low-cardinality-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: LowCardinalityColumnType{ColumnTypeString},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col LowCardinality(String)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-low-cardinality-type-with-default",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    LowCardinalityColumnType{ColumnTypeString},
+					Default: "'default'",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col LowCardinality(String) DEFAULT 'default'",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-nullable-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: NullableColumnType{ColumnTypeString},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Nullable(String)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-nullable-type-with-default",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    NullableColumnType{ColumnTypeString},
+					Default: "'default'",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Nullable(String) DEFAULT 'default'",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-simple-aggregate-function-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: SimpleAggregateFunction{"Sum", []ColumnType{ColumnTypeInt32}},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32)",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-simple-aggregate-function-type-with-default",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:    "col",
+					Type:    SimpleAggregateFunction{"Sum", []ColumnType{ColumnTypeInt32}},
+					Default: "1",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32) DEFAULT 1",
+		},
+		{
+			name: "col-with-name-and-type-and-cluster-and-aggregate-function-type",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name: "col",
+					Type: AggregateFunction{"Sum", []ColumnType{ColumnTypeInt32}},
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col AggregateFunction(Sum, Int32)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableDropColumn(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "drop-column",
+			op:   AlterTableDropColumn{Database: "db", Table: "table", Column: Column{Name: "col"}},
+			want: "ALTER TABLE db.table DROP COLUMN IF EXISTS col",
+		},
+		{
+			name: "drop-column-with-cluster",
+			op:   AlterTableDropColumn{Database: "db", Table: "table", Column: Column{Name: "col"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster DROP COLUMN IF EXISTS col",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableModifyColumn(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "modify-column-type",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Type: ColumnTypeIPv4}},
+			want: "ALTER TABLE db.table MODIFY COLUMN IF EXISTS col IPv4",
+		},
+		{
+			name: "modify-column-type-with-cluster",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Type: ColumnTypeIPv4}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col IPv4",
+		},
+		{
+			name: "modify-column-type-with-default",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Type: ColumnTypeIPv4, Default: "'127.0.0.1'"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col IPv4 DEFAULT '127.0.0.1'",
+		},
+		{
+			name: "modify-column-default",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Default: "'127.0.0.1'"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col DEFAULT '127.0.0.1'",
+		},
+		{
+			name: "modify-column-compression-codec",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Codec: "ZSTD"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col CODEC(ZSTD)",
+		},
+		{
+			name: "modify-column-ttl",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", TTL: "d + INTERVAL 1 DAY"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col TTL d + INTERVAL 1 DAY",
+		},
+		{
+			name: "modify-column-settings",
+			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Settings: ColumnSettings{ColumnSetting{Name: "min_compress_block_size", Value: "16777216"}}}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col SETTINGS min_compress_block_size = 16777216",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableModifyColumnRemove(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "remove-column-property-ttl",
+			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyTTL}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE TTL",
+		},
+		{
+			name: "remove-column-property-codec",
+			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyCodec}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE CODEC",
+		},
+		{
+			name: "remove-column-property-default",
+			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyDefault}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE DEFAULT",
+		},
+		{
+			name: "remove-column-property-settings",
+			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertySettings}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE SETTINGS",
+		},
+		{
+			name: "remove-column-property-materialized",
+			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyMaterialized}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE MATERIALIZED",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableMaterializeColumn(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "materialize-column",
+			op:   AlterTableMaterializeColumn{Database: "db", Table: "table", Column: Column{Name: "col"}},
+			want: "ALTER TABLE db.table MATERIALIZE COLUMN IF EXISTS col",
+		},
+		{
+			name: "materialize-column-with-cluster",
+			op:   AlterTableMaterializeColumn{Database: "db", Table: "table", Column: Column{Name: "col"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE COLUMN IF EXISTS col",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}

--- a/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
@@ -26,6 +26,19 @@ func TestAlterTableAddColumn(t *testing.T) {
 			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String",
 		},
 		{
+			name: "col-with-name-and-type-and-cluster-and-codec",
+			op: AlterTableAddColumn{
+				Database: "db",
+				Table:    "table",
+				Column: Column{
+					Name:  "col",
+					Type:  ColumnTypeString,
+					Codec: "ZSTD(5)",
+				},
+			}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String CODEC(ZSTD(5))",
+		},
+		{
 			name: "col-with-name-and-type-without-cluster",
 			op: AlterTableAddColumn{
 				Database: "db",


### PR DESCRIPTION
Covers the column manipulations mentioned in https://clickhouse.com/docs/en/sql-reference/statements/alter/column to be written declaratively in migration.

1. [ADD COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#add-column) - AlterTableAddColumn
2. [DROP COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#drop-column) - AlterTableDropColumn
3. [RENAME COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#rename-column) - this operation is not supported. Renaming the column is a two-step process. See [here](https://www.notion.so/signoz/CH-Mutations-aware-schema-migrations-80a19988fd5a4558afa1e5d5de5cc57e?pvs=4#a63ad5338acb4388a66c0b3293ffdac9)
4. [CLEAR COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#clear-column) - we don't need this now but can be added later. 
5. [COMMENT COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#comment-column) - same
6. [MODIFY COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#modify-column) - AlterTableModifyColumn
7. [MODIFY COLUMN REMOVE](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#modify-column-remove) - AlterTableModifyColumnRemove
8. [MODIFY COLUMN MODIFY SETTING](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#modify-column-modify-setting) - AlterTableModifyColumnModifySettings
9. [MODIFY COLUMN RESET SETTING](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#modify-column-reset-setting) - AlterTableModifyColumnResetSettings
10. [MATERIALIZE COLUMN](https://clickhouse.com/docs/en/sql-reference/statements/alter/column#materialize-column) - AlterTableMaterializeColumn