### PR TITLE
Add INDEX operations

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/index_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations.go
@@ -1,0 +1,264 @@
+package schemamigrator
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Index is used to represent an index in the SQL.
+type Index struct {
+	Name        string // name of the index; ex: idx_name
+	Expression  string // expression of the index; ex: traceID
+	Type        string // type of the index; ex: tokenbf_v1(1024, 2, 0)
+	Granularity int    // granularity of the index; ex: 1
+}
+
+func (i Index) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("INDEX ")
+	sql.WriteString(i.Name)
+	sql.WriteString(" ")
+	sql.WriteString(i.Expression)
+	sql.WriteString(" TYPE ")
+	sql.WriteString(i.Type)
+	sql.WriteString(" GRANULARITY ")
+	sql.WriteString(strconv.Itoa(i.Granularity))
+	return sql.String()
+}
+
+// AlterTableAddIndex is used to add an index to a table.
+// It is used to represent the ALTER TABLE ADD INDEX statement in the SQL.
+type AlterTableAddIndex struct {
+	cluster string
+
+	Database string
+	Table    string
+	Index    Index
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableAddIndex) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableAddIndex) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableAddIndex) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableAddIndex) IsMutation() bool {
+	// Adding an index is not a mutation. It will create a new index.
+	return false
+}
+
+func (a AlterTableAddIndex) IsIdempotent() bool {
+	// Adding an index is idempotent. It will not change the table if the index already exists.
+	return true
+}
+
+func (a AlterTableAddIndex) IsLightweight() bool {
+	// Adding an index is lightweight. It will create a new index for the new data.
+	return true
+}
+
+func (a AlterTableAddIndex) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" ADD INDEX IF NOT EXISTS ")
+	sql.WriteString(a.Index.Name)
+	sql.WriteString(" ")
+	sql.WriteString(a.Index.Expression)
+	sql.WriteString(" TYPE ")
+	sql.WriteString(a.Index.Type)
+	sql.WriteString(" GRANULARITY ")
+	sql.WriteString(strconv.Itoa(a.Index.Granularity))
+	return sql.String()
+}
+
+// AlterTableDropIndex is used to drop an index from a table.
+// It is used to represent the ALTER TABLE DROP INDEX statement in the SQL.
+type AlterTableDropIndex struct {
+	cluster  string
+	Database string
+	Table    string
+	Index    Index
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableDropIndex) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableDropIndex) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableDropIndex) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableDropIndex) IsMutation() bool {
+	// Dropping an index is a mutation. It will remove the index from the table.
+	return true
+}
+
+func (a AlterTableDropIndex) IsIdempotent() bool {
+	// Dropping an index is idempotent. It will not change the table if the index does not exist.
+	return true
+}
+
+func (a AlterTableDropIndex) IsLightweight() bool {
+	// Dropping an index is lightweight. It will remove the index from the table.
+	return true
+}
+
+func (a AlterTableDropIndex) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" DROP INDEX IF EXISTS ")
+	sql.WriteString(a.Index.Name)
+	return sql.String()
+}
+
+// AlterTableMaterializeIndex is used to materialize an index on a table.
+// It is used to represent the ALTER TABLE MATERIALIZE INDEX statement in the SQL.
+type AlterTableMaterializeIndex struct {
+	cluster   string
+	Database  string
+	Table     string
+	Index     Index
+	Partition string
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableMaterializeIndex) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableMaterializeIndex) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableMaterializeIndex) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableMaterializeIndex) IsMutation() bool {
+	// Materializing an index is a mutation. It will create a new index for the new data.
+	return true
+}
+
+func (a AlterTableMaterializeIndex) IsIdempotent() bool {
+	// Materializing an index is idempotent. It will not change the table if the index already exists.
+	return true
+}
+
+func (a AlterTableMaterializeIndex) IsLightweight() bool {
+	// Materializing an index is not lightweight. It will create a complete index for all the data in the table.
+	return false
+}
+
+func (a AlterTableMaterializeIndex) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" MATERIALIZE INDEX IF EXISTS ")
+	sql.WriteString(a.Index.Name)
+	if a.Partition != "" {
+		sql.WriteString(" IN PARTITION ")
+		sql.WriteString(a.Partition)
+	}
+	return sql.String()
+}
+
+// AlterTableClearIndex is used to clear an index from a table.
+// It is used to represent the ALTER TABLE CLEAR INDEX statement in the SQL.
+type AlterTableClearIndex struct {
+	cluster   string
+	Database  string
+	Table     string
+	Index     Index
+	Partition string
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableClearIndex) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableClearIndex) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableClearIndex) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableClearIndex) IsMutation() bool {
+	// Clearing an index is a mutation. It will remove the index from the table.
+	return true
+}
+
+func (a AlterTableClearIndex) IsIdempotent() bool {
+	// Clearing an index is idempotent. It will not change the table if the index does not exist.
+	return true
+}
+
+func (a AlterTableClearIndex) IsLightweight() bool {
+	// Clearing an index is not lightweight. It will remove the index from the table.
+	return false
+}
+
+func (a AlterTableClearIndex) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" CLEAR INDEX IF EXISTS ")
+	sql.WriteString(a.Index.Name)
+	if a.Partition != "" {
+		sql.WriteString(" IN PARTITION ")
+		sql.WriteString(a.Partition)
+	}
+	return sql.String()
+}

--- a/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
@@ -1,0 +1,112 @@
+package schemamigrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlterTableAddIndex(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "add-index",
+			op:   AlterTableAddIndex{Database: "db", Table: "table", Index: Index{Name: "idx", Expression: "mapKeys(numberTagMap)", Type: "bloom_filter", Granularity: 1}},
+			want: "ALTER TABLE db.table ADD INDEX IF NOT EXISTS idx mapKeys(numberTagMap) TYPE bloom_filter GRANULARITY 1",
+		},
+		{
+			name: "add-index-on-cluster",
+			op:   AlterTableAddIndex{Database: "db", Table: "table", Index: Index{Name: "idx", Expression: "mapKeys(numberTagMap)", Type: "bloom_filter", Granularity: 1}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster ADD INDEX IF NOT EXISTS idx mapKeys(numberTagMap) TYPE bloom_filter GRANULARITY 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableDropIndex(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "drop-index",
+			op:   AlterTableDropIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}},
+			want: "ALTER TABLE db.table DROP INDEX IF EXISTS idx",
+		},
+		{
+			name: "drop-index-on-cluster",
+			op:   AlterTableDropIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster DROP INDEX IF EXISTS idx",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableMaterializeIndex(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "materialize-index",
+			op:   AlterTableMaterializeIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}},
+			want: "ALTER TABLE db.table MATERIALIZE INDEX IF EXISTS idx",
+		},
+		{
+			name: "materialize-index-on-cluster",
+			op:   AlterTableMaterializeIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE INDEX IF EXISTS idx",
+		},
+		{
+			name: "materialize-index-in-partition",
+			op:   AlterTableMaterializeIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}, Partition: "partition"},
+			want: "ALTER TABLE db.table MATERIALIZE INDEX IF EXISTS idx IN PARTITION partition",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableClearIndex(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "clear-index",
+			op:   AlterTableClearIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}},
+			want: "ALTER TABLE db.table CLEAR INDEX IF EXISTS idx",
+		},
+		{
+			name: "clear-index-on-cluster",
+			op:   AlterTableClearIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
+			want: "ALTER TABLE db.table ON CLUSTER cluster CLEAR INDEX IF EXISTS idx",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}


### PR DESCRIPTION
Covers the index manipulations mentioned in https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index to be written declaratively in migration.

- [ADD INDEX](https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index#add-index) - AlterTableAddIndex
- [DROP INDEX](https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index#drop-index) - AlterTableDropIndex
- [MATERIALIZE INDEX](https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index#materialize-index) - AlterTableMaterializeIndex
- [CLEAR INDEX](https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index#clear-index) - AlterTableClearIndex