### PR TITLE
Add TABLE operations

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/table.go
+++ b/cmd/signozschemamigrator/schema_migrator/table.go
@@ -1,0 +1,212 @@
+package schemamigrator
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TableEngine represents the engine of the table.
+type TableEngine interface {
+	ToSQL() string
+	EngineType() string
+	OnCluster(cluster string) TableEngine
+	WithReplication() TableEngine
+}
+
+// TableSetting represents the setting of the table.
+type TableSetting struct {
+	Name  string
+	Value string
+}
+
+func (t TableSetting) ToSQL() string {
+	return fmt.Sprintf("%s = %s", t.Name, t.Value)
+}
+
+type TableSettings []TableSetting
+
+func (t TableSettings) ToSQL() string {
+	parts := make([]string, len(t))
+	for i, setting := range t {
+		parts[i] = setting.ToSQL()
+	}
+	return strings.Join(parts, ", ")
+}
+
+// MergeTree represents the MergeTree engine of the table.
+type MergeTree struct {
+	Replicated  bool
+	OrderBy     string
+	PrimaryKey  string
+	PartitionBy string
+	SampleBy    string
+	TTL         string
+	Settings    TableSettings
+}
+
+func (m MergeTree) OnCluster(cluster string) TableEngine {
+	// no-op
+	return &m
+}
+
+func (m MergeTree) WithReplication() TableEngine {
+	m.Replicated = true
+	return &m
+}
+
+func (m MergeTree) EngineParams() string {
+	var sql strings.Builder
+	if m.PrimaryKey != "" {
+		sql.WriteString(" PRIMARY KEY ")
+		sql.WriteString(m.PrimaryKey)
+	}
+	if m.OrderBy != "" {
+		sql.WriteString(" ORDER BY ")
+		sql.WriteString(m.OrderBy)
+	}
+	if m.PartitionBy != "" {
+		sql.WriteString(" PARTITION BY ")
+		sql.WriteString(m.PartitionBy)
+	}
+	if m.SampleBy != "" {
+		sql.WriteString(" SAMPLE BY ")
+		sql.WriteString(m.SampleBy)
+	}
+	if m.TTL != "" {
+		sql.WriteString(" TTL ")
+		sql.WriteString(m.TTL)
+	}
+	if len(m.Settings) > 0 {
+		sql.WriteString(" SETTINGS ")
+		sql.WriteString(m.Settings.ToSQL())
+	}
+	return sql.String()
+}
+
+func (m MergeTree) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString(m.EngineType())
+	sql.WriteString(m.EngineParams())
+	return sql.String()
+}
+
+func (m MergeTree) EngineType() string {
+	if m.Replicated {
+		return "ReplicatedMergeTree"
+	}
+	return "MergeTree"
+}
+
+// Replacing represents the ReplacingMergeTree engine of the table.
+type ReplacingMergeTree struct {
+	MergeTree
+}
+
+func (r ReplacingMergeTree) OnCluster(cluster string) TableEngine {
+	return &r
+}
+
+func (r ReplacingMergeTree) WithReplication() TableEngine {
+	r.Replicated = true
+	return &r
+}
+
+func (r ReplacingMergeTree) EngineType() string {
+	if r.Replicated {
+		return "ReplicatedReplacingMergeTree"
+	}
+	return "ReplacingMergeTree"
+}
+
+func (r ReplacingMergeTree) ToSQL() string {
+	fmt.Println("ReplacingMergeTree.ToSQL")
+	var sql strings.Builder
+	sql.WriteString(r.EngineType())
+	sql.WriteString(r.EngineParams())
+	return sql.String()
+}
+
+// AggregatingMergeTree represents the AggregatingMergeTree engine of the table.
+type AggregatingMergeTree struct {
+	MergeTree
+}
+
+func (a AggregatingMergeTree) OnCluster(cluster string) TableEngine {
+	return &a
+}
+
+func (a AggregatingMergeTree) WithReplication() TableEngine {
+	a.Replicated = true
+	return &a
+}
+
+func (a AggregatingMergeTree) EngineType() string {
+	if a.Replicated {
+		return "ReplicatedAggregatingMergeTree"
+	}
+	return "AggregatingMergeTree"
+}
+
+func (a AggregatingMergeTree) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString(a.EngineType())
+	sql.WriteString(a.EngineParams())
+	return sql.String()
+}
+
+type SummingMergeTree struct {
+	MergeTree
+}
+
+func (s SummingMergeTree) OnCluster(cluster string) TableEngine {
+	return &s
+}
+
+func (s SummingMergeTree) WithReplication() TableEngine {
+	s.Replicated = true
+	return &s
+}
+
+func (s SummingMergeTree) EngineType() string {
+	if s.Replicated {
+		return "ReplicatedSummingMergeTree"
+	}
+	return "SummingMergeTree"
+}
+
+func (s SummingMergeTree) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString(s.EngineType())
+	sql.WriteString(s.EngineParams())
+	return sql.String()
+}
+
+// Distributed represents the Distributed engine of the table.
+type Distributed struct {
+	Cluster     string
+	Database    string
+	Table       string
+	ShardingKey string
+}
+
+func (d Distributed) OnCluster(cluster string) TableEngine {
+	d.Cluster = cluster
+	return &d
+}
+
+func (d Distributed) WithReplication() TableEngine {
+	// no-op
+	return &d
+}
+
+func (d Distributed) EngineType() string {
+	return "Distributed"
+}
+
+func (d Distributed) EngineParams() string {
+	return ""
+}
+
+func (d Distributed) ToSQL() string {
+	return fmt.Sprintf("Distributed('%s', %s, %s, %s)", d.Cluster, d.Database, d.Table, d.ShardingKey)
+}

--- a/cmd/signozschemamigrator/schema_migrator/table.go
+++ b/cmd/signozschemamigrator/schema_migrator/table.go
@@ -119,7 +119,6 @@ func (r ReplacingMergeTree) EngineType() string {
 }
 
 func (r ReplacingMergeTree) ToSQL() string {
-	fmt.Println("ReplacingMergeTree.ToSQL")
 	var sql strings.Builder
 	sql.WriteString(r.EngineType())
 	sql.WriteString(r.EngineParams())

--- a/cmd/signozschemamigrator/schema_migrator/table_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations.go
@@ -1,0 +1,205 @@
+package schemamigrator
+
+import "strings"
+
+type Projection struct {
+	Name  string
+	Query string
+}
+
+func (p Projection) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("PROJECTION ")
+	sql.WriteString(p.Name)
+	sql.WriteString(" (")
+	sql.WriteString(p.Query)
+	sql.WriteString(")")
+	return sql.String()
+}
+
+// CreateTableOperation is used to represent the CREATE TABLE statement in the SQL.
+type CreateTableOperation struct {
+	cluster     string
+	Database    string
+	Table       string
+	Columns     []Column
+	Indexes     []Index
+	Projections []Projection
+	Engine      TableEngine
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (c CreateTableOperation) OnCluster(cluster string) Operation {
+	c.cluster = cluster
+	c.Engine = c.Engine.OnCluster(cluster)
+	return &c
+}
+
+func (c CreateTableOperation) WithReplication() Operation {
+	c.Engine.WithReplication()
+	return &c
+}
+
+func (c CreateTableOperation) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, c.Database, c.Table
+}
+
+func (c CreateTableOperation) IsMutation() bool {
+	// Create table is not a mutation.
+	return false
+}
+
+func (c CreateTableOperation) IsIdempotent() bool {
+	// Create table is idempotent. It will not change the table if the table already exists.
+	return true
+}
+
+func (c CreateTableOperation) IsLightweight() bool {
+	// Create table is lightweight.
+	return true
+}
+
+func (c CreateTableOperation) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("CREATE TABLE IF NOT EXISTS ")
+	sql.WriteString(c.Database)
+	sql.WriteString(".")
+	sql.WriteString(c.Table)
+	if c.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(c.cluster)
+	}
+	columnParts := []string{}
+	for _, column := range c.Columns {
+		columnParts = append(columnParts, column.ToSQL())
+	}
+	sql.WriteString(" (")
+	sql.WriteString(strings.Join(columnParts, ", "))
+	for _, index := range c.Indexes {
+		sql.WriteString(", ")
+		sql.WriteString(index.ToSQL())
+	}
+	for _, projection := range c.Projections {
+		sql.WriteString(", ")
+		sql.WriteString(projection.ToSQL())
+	}
+	sql.WriteString(")")
+	sql.WriteString(" ENGINE = ")
+	sql.WriteString(c.Engine.ToSQL())
+	return sql.String()
+}
+
+type DropTableOperation struct {
+	cluster  string
+	Database string
+	Table    string
+}
+
+func (d DropTableOperation) OnCluster(cluster string) Operation {
+	d.cluster = cluster
+	return &d
+}
+
+func (d DropTableOperation) WithReplication() Operation {
+	// no-op
+	return &d
+}
+
+func (d DropTableOperation) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, d.Database, d.Table
+}
+
+func (d DropTableOperation) IsMutation() bool {
+	return true
+}
+
+func (d DropTableOperation) IsIdempotent() bool {
+	return true
+}
+
+func (d DropTableOperation) IsLightweight() bool {
+	return true
+}
+
+func (d DropTableOperation) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("DROP TABLE IF EXISTS ")
+	sql.WriteString(d.Database)
+	sql.WriteString(".")
+	sql.WriteString(d.Table)
+	if d.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(d.cluster)
+	}
+	return sql.String()
+}
+
+// CreateMaterializedViewOperation is used to represent the CREATE MATERIALIZED VIEW statement in the SQL.
+type CreateMaterializedViewOperation struct {
+	cluster   string
+	Database  string
+	ViewName  string
+	DestTable string
+	Columns   []Column
+	Query     string
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (c CreateMaterializedViewOperation) OnCluster(cluster string) Operation {
+	c.cluster = cluster
+	return &c
+}
+
+func (c CreateMaterializedViewOperation) WithReplication() Operation {
+	// no-op
+	return &c
+}
+
+func (c CreateMaterializedViewOperation) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, c.Database, c.ViewName
+}
+
+func (c CreateMaterializedViewOperation) IsMutation() bool {
+	// Create materialized view is not a mutation.
+	return false
+}
+
+func (c CreateMaterializedViewOperation) IsIdempotent() bool {
+	// Create materialized view is idempotent. It will not change the materialized view if the materialized view already exists.
+	return true
+}
+
+func (c CreateMaterializedViewOperation) IsLightweight() bool {
+	// Create materialized view is lightweight.
+	return true
+}
+
+func (c CreateMaterializedViewOperation) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("CREATE MATERIALIZED VIEW IF NOT EXISTS ")
+	sql.WriteString(c.Database)
+	sql.WriteString(".")
+	sql.WriteString(c.ViewName)
+	if c.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(c.cluster)
+	}
+	sql.WriteString(" TO ")
+	sql.WriteString(c.Database)
+	sql.WriteString(".")
+	sql.WriteString(c.DestTable)
+	if len(c.Columns) > 0 {
+		sql.WriteString(" (")
+		columnParts := []string{}
+		for _, column := range c.Columns {
+			columnParts = append(columnParts, column.ToSQL())
+		}
+		sql.WriteString(strings.Join(columnParts, ", "))
+		sql.WriteString(")")
+	}
+	sql.WriteString(" AS ")
+	sql.WriteString(c.Query)
+	return sql.String()
+}

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -1,0 +1,239 @@
+package schemamigrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTable(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "create-table-without-any-engine-params",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+				},
+				Engine: MergeTree{},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16) ENGINE = MergeTree",
+		},
+		{
+			name: "create-table-with-replacing-merge-tree-engine-params",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+				},
+				Engine: ReplacingMergeTree{
+					MergeTree{
+						OrderBy: "id",
+					},
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16) ENGINE = ReplacingMergeTree ORDER BY id",
+		},
+		{
+			name: "create-table-with-engine-param-order-by",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+				},
+				Engine: MergeTree{
+					OrderBy: "id",
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16) ENGINE = MergeTree ORDER BY id",
+		},
+		{
+			name: "create-table-with-engine-param-order-by-and-partition-by",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+					{
+						Name: "ts",
+						Type: DateTime64ColumnType{
+							Precision: 3,
+						},
+					},
+				},
+				Engine: MergeTree{
+					OrderBy:     "id",
+					PartitionBy: "toYYYYMM(ts)",
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16, ts DateTime64(3)) ENGINE = MergeTree ORDER BY id PARTITION BY toYYYYMM(ts)",
+		},
+		{
+			name: "create-table-with-engine-param-order-by-and-partition-by-and-ttl",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+					{
+						Name: "ts",
+						Type: DateTime64ColumnType{
+							Precision: 3,
+						},
+					},
+				},
+				Engine: MergeTree{
+					OrderBy:     "id",
+					PartitionBy: "toYYYYMM(ts)",
+					TTL:         "ts + INTERVAL 1 DAY",
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16, ts DateTime64(3)) ENGINE = MergeTree ORDER BY id PARTITION BY toYYYYMM(ts) TTL ts + INTERVAL 1 DAY",
+		},
+		{
+			name: "create-table-with-engine-param-order-by-and-partition-by-and-ttl-and-primary-key",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+					{
+						Name: "ts",
+						Type: DateTime64ColumnType{
+							Precision: 3,
+						},
+					},
+					{
+						Name: "value",
+						Type: ColumnTypeFloat64,
+					},
+				},
+				Engine: MergeTree{
+					OrderBy:     "id",
+					PartitionBy: "toYYYYMM(ts)",
+					TTL:         "ts + INTERVAL 1 DAY",
+					PrimaryKey:  "(id, ts)",
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16, ts DateTime64(3), value Float64) ENGINE = MergeTree PRIMARY KEY (id, ts) ORDER BY id PARTITION BY toYYYYMM(ts) TTL ts + INTERVAL 1 DAY",
+		},
+		{
+			name: "create-table-with-engine-param-order-by-and-partition-by-and-ttl-and-primary-key-and-ttl-and-sample-by",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+					{
+						Name: "ts",
+						Type: DateTime64ColumnType{
+							Precision: 3,
+						},
+					},
+				},
+				Engine: MergeTree{
+					OrderBy:     "id",
+					PartitionBy: "toYYYYMM(ts)",
+					TTL:         "ts + INTERVAL 1 DAY",
+					PrimaryKey:  "(id, ts)",
+					SampleBy:    "id",
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table (id Int16, ts DateTime64(3)) ENGINE = MergeTree PRIMARY KEY (id, ts) ORDER BY id PARTITION BY toYYYYMM(ts) SAMPLE BY id TTL ts + INTERVAL 1 DAY",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestCreateMaterializedView(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "create-materialized-view",
+			op: CreateMaterializedViewOperation{
+				Database:  "db",
+				ViewName:  "view",
+				DestTable: "dest_table",
+				Query:     "SELECT id, ts, value FROM db.table",
+			},
+			want: "CREATE MATERIALIZED VIEW IF NOT EXISTS db.view TO db.dest_table AS SELECT id, ts, value FROM db.table",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestCreateWithCluster(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "create-table-with-replacing-merge-tree-engine-params",
+			op: CreateTableOperation{
+				Database: "db",
+				Table:    "table",
+				Columns: []Column{
+					{
+						Name: "id",
+						Type: ColumnTypeInt16,
+					},
+				},
+				Engine: ReplacingMergeTree{
+					MergeTree{
+						OrderBy: "id",
+					},
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS db.table ON CLUSTER cluster (id Int16) ENGINE = ReplacingMergeTree ORDER BY id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := tc.op.OnCluster("cluster")
+			require.Equal(t, tc.want, op.ToSQL())
+		})
+	}
+}

--- a/cmd/signozschemamigrator/schema_migrator/table_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_test.go
@@ -1,0 +1,30 @@
+package schemamigrator
+
+import (
+	"testing"
+)
+
+func TestTableEngine(t *testing.T) {
+	testCases := []struct {
+		name    string
+		op      TableEngine
+		wantSQL string
+	}{
+		{
+			name: "create table",
+			op: ReplacingMergeTree{
+				MergeTree{
+					OrderBy: "(timestamp, resource_id)",
+				},
+			},
+			wantSQL: "ReplacingMergeTree ORDER BY (timestamp, resource_id)",
+		},
+	}
+
+	for _, tc := range testCases {
+		gotSQL := tc.op.ToSQL()
+		if gotSQL != tc.wantSQL {
+			t.Errorf("got %s, want %s", gotSQL, tc.wantSQL)
+		}
+	}
+}

--- a/cmd/signozschemamigrator/schema_migrator/table_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_test.go
@@ -19,6 +19,16 @@ func TestTableEngine(t *testing.T) {
 			},
 			wantSQL: "ReplacingMergeTree ORDER BY (timestamp, resource_id)",
 		},
+		{
+			name: "create table with distributed engine",
+			op: Distributed{
+				Database:    "default",
+				Table:       "logs",
+				Cluster:     "cluster",
+				ShardingKey: "rand()",
+			},
+			wantSQL: "Distributed('cluster', default, logs, rand())",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Support most of the operations mentioned in create table https://clickhouse.com/docs/en/sql-reference/statements/create/table

The `TableEngine` interface defines the funcs each table engine needs to implement. The following are supported table engines 

1. MergeTree
2. ReplacingMergeTree
3. AggregatingMergeTree
4. SummingMergeTree
and special distributed
5. Distributed

The operations on the table

1. CreateTableOperation
2. DropTableOperation
3. CreateMaterializedViewOperation

There are some operations we don't support not because they can't be supported but they aren't needed right now. They can be implemented where there is a need.
