### PR TITLE
feat: add labels index in resource_v2 table

### DIFF
--- a/migrationmanager/migrators/logs/migrations/000015_resource_label_index.down.sql
+++ b/migrationmanager/migrators/logs/migrations/000015_resource_label_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE signoz_logs.logs_v2_resource ON CLUSTER {{.SIGNOZ_CLUSTER}} DROP INDEX IF EXISTS idx_labels_v1;

--- a/migrationmanager/migrators/logs/migrations/000015_resource_label_index.up.sql
+++ b/migrationmanager/migrators/logs/migrations/000015_resource_label_index.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE signoz_logs.logs_v2_resource ON CLUSTER {{.SIGNOZ_CLUSTER}} ADD INDEX IF NOT EXISTS idx_labels_v1 labels TYPE ngrambf_v1(4, 1024, 3, 0) GRANULARITY 1;


### PR DESCRIPTION
Since we decided to go with case-sensitive for attributes and resources, the old index won't be triggered. So we are adding this.