### PR TITLE
feat(kafka): apply backpressure

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2310,7 +2310,6 @@ github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -149,8 +149,10 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 		autocommitEnabled: c.autocommitEnabled,
 		messageMarking:    c.messageMarking,
 		baseConsumerGroupHandler: baseConsumerGroupHandler{
-			logger:        c.settings.Logger,
-			retryInterval: 1 * time.Second,
+			logger:          c.settings.Logger,
+			retryInterval:   1 * time.Second,
+			pausePartition:  make(chan int32),
+			resumePartition: make(chan int32),
 		},
 	}
 	go func() {
@@ -159,6 +161,18 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 		}
 	}()
 	<-consumerGroup.ready
+
+	select {
+	case p := <-consumerGroup.pausePartition:
+		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+	case p := <-consumerGroup.resumePartition:
+		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+	case <-ctx.Done():
+		return nil
+	}
+
 	return nil
 }
 
@@ -251,8 +265,10 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 		autocommitEnabled: c.autocommitEnabled,
 		messageMarking:    c.messageMarking,
 		baseConsumerGroupHandler: baseConsumerGroupHandler{
-			logger:        c.settings.Logger,
-			retryInterval: 1 * time.Second,
+			logger:          c.settings.Logger,
+			retryInterval:   1 * time.Second,
+			pausePartition:  make(chan int32),
+			resumePartition: make(chan int32),
 		},
 	}
 	go func() {
@@ -261,6 +277,18 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 		}
 	}()
 	<-metricsConsumerGroup.ready
+
+	select {
+	case p := <-metricsConsumerGroup.pausePartition:
+		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+	case p := <-metricsConsumerGroup.resumePartition:
+		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+	case <-ctx.Done():
+		return nil
+	}
+
 	return nil
 }
 
@@ -381,8 +409,10 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 		autocommitEnabled: c.autocommitEnabled,
 		messageMarking:    c.messageMarking,
 		baseConsumerGroupHandler: baseConsumerGroupHandler{
-			logger:        c.settings.Logger,
-			retryInterval: 1 * time.Second,
+			logger:          c.settings.Logger,
+			retryInterval:   1 * time.Second,
+			pausePartition:  make(chan int32),
+			resumePartition: make(chan int32),
 		},
 	}
 	go func() {
@@ -391,6 +421,18 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 		}
 	}()
 	<-logsConsumerGroup.ready
+
+	select {
+	case p := <-logsConsumerGroup.pausePartition:
+		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+	case p := <-logsConsumerGroup.resumePartition:
+		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+	case <-ctx.Done():
+		return nil
+	}
+
 	return nil
 }
 
@@ -416,8 +458,10 @@ func (c *kafkaLogsConsumer) Shutdown(context.Context) error {
 }
 
 type baseConsumerGroupHandler struct {
-	logger        *zap.Logger
-	retryInterval time.Duration
+	logger          *zap.Logger
+	retryInterval   time.Duration
+	pausePartition  chan int32
+	resumePartition chan int32
 }
 
 // wrap is now a method of BaseConsumerGroupHandler
@@ -433,16 +477,19 @@ func (b *baseConsumerGroupHandler) WithMemoryLimiter(ctx context.Context, claim 
 	defer ticker.Stop()
 
 	b.logger.Info("applying initial backpressure on Kafka due to high memory usage", zap.Int32("partition", claim.Partition()), zap.String("topic", claim.Topic()))
-	claim.Partition()
+	b.pausePartition <- claim.Partition()
 
 	for {
 		select {
 		case <-ticker.C:
 			err := consume()
 			if err == nil {
+				b.logger.Info("resuming normal operation", zap.Int32("partition", claim.Partition()), zap.String("topic", claim.Topic()))
+				b.resumePartition <- claim.Partition()
 				return nil
 			}
 			if !errors.Is(err, errHighMemoryUsage) {
+				b.resumePartition <- claim.Partition()
 				return err
 			}
 			b.logger.Info("continuing to apply backpressure on Kafka due to high memory usage", zap.Int32("partition", claim.Partition()), zap.String("topic", claim.Topic()))

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -162,18 +162,27 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 	}()
 	<-consumerGroup.ready
 
-	select {
-	case p := <-consumerGroup.pausePartition:
-		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-	case p := <-consumerGroup.resumePartition:
-		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
-	case <-ctx.Done():
-		return nil
-	}
+	go func() {
+		c.errorLoop(ctx, consumerGroup)
+	}()
 
 	return nil
+}
+
+func (c *kafkaTracesConsumer) errorLoop(ctx context.Context, tracesConsumerGroup *tracesConsumerGroupHandler) {
+	for {
+		select {
+		case p := <-tracesConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+		case p := <-tracesConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-ctx.Done():
+			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
+			return
+		}
+	}
 }
 
 func (c *kafkaTracesConsumer) consumeLoop(ctx context.Context, handler sarama.ConsumerGroupHandler) error {
@@ -278,18 +287,27 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 	}()
 	<-metricsConsumerGroup.ready
 
-	select {
-	case p := <-metricsConsumerGroup.pausePartition:
-		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-	case p := <-metricsConsumerGroup.resumePartition:
-		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
-	case <-ctx.Done():
-		return nil
-	}
+	go func() {
+		c.errorLoop(ctx, metricsConsumerGroup)
+	}()
 
 	return nil
+}
+
+func (c *kafkaMetricsConsumer) errorLoop(ctx context.Context, metricsConsumerGroup *metricsConsumerGroupHandler) {
+	for {
+		select {
+		case p := <-metricsConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+		case p := <-metricsConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-ctx.Done():
+			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
+			return
+		}
+	}
 }
 
 func (c *kafkaMetricsConsumer) consumeLoop(ctx context.Context, handler sarama.ConsumerGroupHandler) error {
@@ -422,18 +440,27 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 	}()
 	<-logsConsumerGroup.ready
 
-	select {
-	case p := <-logsConsumerGroup.pausePartition:
-		c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-		c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-	case p := <-logsConsumerGroup.resumePartition:
-		c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-		c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
-	case <-ctx.Done():
-		return nil
-	}
+	go func() {
+		c.errorLoop(ctx, logsConsumerGroup)
+	}()
 
 	return nil
+}
+
+func (c *kafkaLogsConsumer) errorLoop(ctx context.Context, logsConsumerGroup *logsConsumerGroupHandler) {
+	for {
+		select {
+		case p := <-logsConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
+			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
+		case p := <-logsConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
+			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-ctx.Done():
+			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
+			return
+		}
+	}
 }
 
 func (c *kafkaLogsConsumer) consumeLoop(ctx context.Context, handler sarama.ConsumerGroupHandler) error {

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -495,7 +495,7 @@ type baseConsumerGroupHandler struct {
 func (b *baseConsumerGroupHandler) WithMemoryLimiter(ctx context.Context, claim sarama.ConsumerGroupClaim, consume func() error) error {
 	// Execute f() immediately
 	err := consume()
-	if err == nil || !errors.Is(err, errHighMemoryUsage) {
+	if err == nil || !(err.Error() == errHighMemoryUsage.Error()) {
 		return err
 	}
 
@@ -515,7 +515,7 @@ func (b *baseConsumerGroupHandler) WithMemoryLimiter(ctx context.Context, claim 
 				b.resumePartition <- claim.Partition()
 				return nil
 			}
-			if !errors.Is(err, errHighMemoryUsage) {
+			if !(err.Error() == errHighMemoryUsage.Error()) {
 				b.resumePartition <- claim.Partition()
 				return err
 			}

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -172,12 +172,12 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 func (c *kafkaTracesConsumer) errorLoop(ctx context.Context, tracesConsumerGroup *tracesConsumerGroupHandler) {
 	for {
 		select {
-		case p := <-tracesConsumerGroup.pausePartition:
-			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-		case p := <-tracesConsumerGroup.resumePartition:
-			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-tracesConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.PauseAll()
+		case <-tracesConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.ResumeAll()
 		case <-ctx.Done():
 			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
 			return
@@ -297,12 +297,12 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 func (c *kafkaMetricsConsumer) errorLoop(ctx context.Context, metricsConsumerGroup *metricsConsumerGroupHandler) {
 	for {
 		select {
-		case p := <-metricsConsumerGroup.pausePartition:
-			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-		case p := <-metricsConsumerGroup.resumePartition:
-			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-metricsConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.PauseAll()
+		case <-metricsConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.ResumeAll()
 		case <-ctx.Done():
 			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
 			return
@@ -450,12 +450,12 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 func (c *kafkaLogsConsumer) errorLoop(ctx context.Context, logsConsumerGroup *logsConsumerGroupHandler) {
 	for {
 		select {
-		case p := <-logsConsumerGroup.pausePartition:
-			c.settings.Logger.Info("pausing partition", zap.Int32("partition", p))
-			c.consumerGroup.Pause(map[string][]int32{c.topics[0]: {p}})
-		case p := <-logsConsumerGroup.resumePartition:
-			c.settings.Logger.Info("resuming partition", zap.Int32("partition", p))
-			c.consumerGroup.Resume(map[string][]int32{c.topics[0]: {p}})
+		case <-logsConsumerGroup.pausePartition:
+			c.settings.Logger.Info("pausing consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.PauseAll()
+		case <-logsConsumerGroup.resumePartition:
+			c.settings.Logger.Info("resuming consumption", zap.String("topic", c.topics[0]))
+			c.consumerGroup.ResumeAll()
 		case <-ctx.Done():
 			c.settings.Logger.Info("Consumer Error loop stopped", zap.Error(ctx.Err()))
 			return

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -724,7 +724,7 @@ func (c *logsConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSess
 				return nil
 			}
 			start := time.Now()
-			c.logger.Info("Kafka message claimed",
+			c.logger.Debug("Kafka message claimed",
 				zap.String("value", string(message.Value)),
 				zap.Time("timestamp", message.Timestamp),
 				zap.String("topic", message.Topic),

--- a/receiver/signozkafkareceiver/kafka_receiver_test.go
+++ b/receiver/signozkafkareceiver/kafka_receiver_test.go
@@ -1036,8 +1036,9 @@ func (t testConsumerGroupSession) Context() context.Context {
 }
 
 type testConsumerGroup struct {
-	once sync.Once
-	err  error
+	once   sync.Once
+	err    error
+	paused bool
 }
 
 var _ sarama.ConsumerGroup = (*testConsumerGroup)(nil)
@@ -1058,7 +1059,7 @@ func (t *testConsumerGroup) Close() error {
 }
 
 func (t *testConsumerGroup) Pause(_ map[string][]int32) {
-	panic("implement me")
+	t.paused = true
 }
 
 func (t *testConsumerGroup) PauseAll() {
@@ -1066,7 +1067,7 @@ func (t *testConsumerGroup) PauseAll() {
 }
 
 func (t *testConsumerGroup) Resume(_ map[string][]int32) {
-	panic("implement me")
+	t.paused = false
 }
 
 func (t *testConsumerGroup) ResumeAll() {


### PR DESCRIPTION
#### Features

- Apply backpressure on kafka on memorylimiter error. Pause the consumption and retry in place. This relives kafka of continuous rebalancing and gives a predictable memory workload for the collector 