### PR TITLE
Use the options from dsn for new connections

### DIFF
--- a/cmd/signozschemamigrator/main.go
+++ b/cmd/signozschemamigrator/main.go
@@ -133,6 +133,7 @@ func registerSyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithClusterName(clusterName),
 				schema_migrator.WithReplicationEnabled(replicationEnabled),
 				schema_migrator.WithConn(conn),
+				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
 			)
 			if err != nil {
@@ -228,6 +229,7 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithClusterName(clusterName),
 				schema_migrator.WithReplicationEnabled(replicationEnabled),
 				schema_migrator.WithConn(conn),
+				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
 			)
 			if err != nil {


### PR DESCRIPTION
The connection string often includes critical information like username and password, which should be retained for future connection attempts. This modification ensures that the options specified in the --dsn argument are preserved and applied when establishing connections to other shards.