### PR TITLE
Increase split size for metric writer

### DIFF
--- a/exporter/clickhousemetricsexporter/exporter.go
+++ b/exporter/clickhousemetricsexporter/exporter.go
@@ -43,7 +43,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-const maxBatchByteSize = 3000000
+const maxBatchByteSize = 128000000
 
 // PrwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint.
 type PrwExporter struct {


### PR DESCRIPTION
This change increases maxBatchByteSize to reduce the number of writes for big batches.