### PR TITLE
fix: flush usage metrics after stopping the usage reader

### DIFF
--- a/usage/usage.go
+++ b/usage/usage.go
@@ -76,6 +76,7 @@ func (e *UsageCollector) Start() error {
 
 func (c *UsageCollector) Stop() error {
 	c.ir.Stop()
+	c.ir.Flush()
 	return nil
 }
 


### PR DESCRIPTION
flush usage metrics after stopping the usage reader


opened, this PR as I pushed dummy commits to the last PR.