### PR TITLE
fix: move fingerpint package to utils for it to be used by others

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	driver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/SigNoz/signoz-otel-collector/exporter/clickhouselogsexporter/logsv2"
 	"github.com/SigNoz/signoz-otel-collector/usage"
 	"github.com/SigNoz/signoz-otel-collector/utils"
+	"github.com/SigNoz/signoz-otel-collector/utils/fingerprint"
 	"github.com/google/uuid"
 	"github.com/segmentio/ksuid"
 	"go.opencensus.io/stats"
@@ -332,7 +332,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 					}
 					fp, exists := resourcesSeen[int64(lBucketStart)][resourceJson]
 					if !exists {
-						fp = logsv2.CalculateFingerprint(res.Attributes().AsRaw(), logsv2.ResourceHierarchy())
+						fp = fingerprint.CalculateFingerprint(res.Attributes().AsRaw(), fingerprint.ResourceHierarchy())
 						resourcesSeen[int64(lBucketStart)][resourceJson] = fp
 					}
 

--- a/utils/fingerprint/fingerprint.go
+++ b/utils/fingerprint/fingerprint.go
@@ -1,4 +1,4 @@
-package logsv2
+package fingerprint
 
 import (
 	"fmt"

--- a/utils/fingerprint/fingerprint_test.go
+++ b/utils/fingerprint/fingerprint_test.go
@@ -1,4 +1,4 @@
-package logsv2
+package fingerprint
 
 import (
 	"testing"

--- a/utils/fingerprint/hash.go
+++ b/utils/fingerprint/hash.go
@@ -1,4 +1,4 @@
-package logsv2
+package fingerprint
 
 import (
 	"fmt"


### PR DESCRIPTION
Since I am using this package in traces, creating an individual PR to move this to utils so that it can be common.