### PR TITLE
fix: add development flag for schemamigrator

### DIFF
--- a/cmd/signozschemamigrator/main.go
+++ b/cmd/signozschemamigrator/main.go
@@ -57,10 +57,12 @@ func main() {
 	var dsn string
 	var replicationEnabled bool
 	var clusterName string
+	var development bool
 
 	cmd.PersistentFlags().StringVar(&dsn, "dsn", "", "Clickhouse DSN")
 	cmd.PersistentFlags().BoolVar(&replicationEnabled, "replication", false, "Enable replication")
 	cmd.PersistentFlags().StringVar(&clusterName, "cluster-name", "cluster", "Cluster name to use while running migrations")
+	cmd.PersistentFlags().BoolVar(&development, "dev", false, "Development mode")
 
 	registerSyncMigrate(cmd)
 	registerAsyncMigrate(cmd)
@@ -84,6 +86,7 @@ func registerSyncMigrate(cmd *cobra.Command) {
 			dsn := cmd.Flags().Lookup("dsn").Value.String()
 			replicationEnabled := strings.ToLower(cmd.Flags().Lookup("replication").Value.String()) == "true"
 			clusterName := cmd.Flags().Lookup("cluster-name").Value.String()
+			development := strings.ToLower(cmd.Flags().Lookup("dev").Value.String()) == "true"
 
 			logger.Info("Running migrations in sync mode", zap.String("dsn", dsn), zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
 
@@ -135,6 +138,7 @@ func registerSyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithConn(conn),
 				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
+				schema_migrator.WithDevelopment(development),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create migration manager: %w", err)
@@ -180,6 +184,7 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 			dsn := cmd.Flags().Lookup("dsn").Value.String()
 			replicationEnabled := strings.ToLower(cmd.Flags().Lookup("replication").Value.String()) == "true"
 			clusterName := cmd.Flags().Lookup("cluster-name").Value.String()
+			development := strings.ToLower(cmd.Flags().Lookup("dev").Value.String()) == "true"
 
 			logger.Info("Running migrations in async mode", zap.String("dsn", dsn), zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
 
@@ -231,6 +236,7 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithConn(conn),
 				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
+				schema_migrator.WithDevelopment(development),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create migration manager: %w", err)

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -74,6 +74,7 @@ type MigrationManager struct {
 	replicationEnabled bool
 	logger             *zap.Logger
 	backoff            *backoff.ExponentialBackOff
+	development        bool
 }
 
 type Option func(*MigrationManager)
@@ -101,6 +102,12 @@ func NewMigrationManager(opts ...Option) (*MigrationManager, error) {
 func WithClusterName(clusterName string) Option {
 	return func(mgr *MigrationManager) {
 		mgr.clusterName = clusterName
+	}
+}
+
+func WithDevelopment(development bool) Option {
+	return func(mgr *MigrationManager) {
+		mgr.development = development
 	}
 }
 
@@ -290,6 +297,9 @@ func (m *MigrationManager) RunSquashedMigrations(ctx context.Context) error {
 
 // HostAddrs returns the addresses of the all hosts in the cluster.
 func (m *MigrationManager) HostAddrs() ([]string, error) {
+	if m.development {
+		return nil, nil
+	}
 	m.addrsMux.Lock()
 	defer m.addrsMux.Unlock()
 	if len(m.addrs) != 0 {


### PR DESCRIPTION

add development flag for schemamigrator which will return empty values for HostAddrs.


```
go run cmd/signozschemamigrator/main.go --dsn http://localhost:9000 --replication=true --dev=true sync
```