### PR TITLE
clickhousetraces: Support specifying cluster

### DIFF
--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -54,7 +54,7 @@ func newExporter(cfg component.Config, logger *zap.Logger) (*storage, error) {
 
 	id := uuid.New()
 
-	f := ClickHouseNewFactory(id, configClickHouse.Migrations, configClickHouse.Datasource, configClickHouse.DockerMultiNodeCluster, configClickHouse.QueueConfig.NumConsumers)
+	f := ClickHouseNewFactory(id, *configClickHouse)
 
 	err := f.Initialize(logger)
 	if err != nil {

--- a/exporter/clickhousetracesexporter/clickhouse_factory.go
+++ b/exporter/clickhousetracesexporter/clickhouse_factory.go
@@ -52,7 +52,7 @@ var (
 )
 
 // NewFactory creates a new Factory.
-func ClickHouseNewFactory(exporterId uuid.UUID, migrations string, datasource string, dockerMultiNodeCluster bool, numConsumers int) *Factory {
+func ClickHouseNewFactory(exporterId uuid.UUID, config Config) *Factory {
 	writeLatencyDistribution := view.Distribution(100, 250, 500, 750, 1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 256000, 512000)
 
 	writeLatencyView := &view.View{
@@ -65,7 +65,7 @@ func ClickHouseNewFactory(exporterId uuid.UUID, migrations string, datasource st
 
 	view.Register(writeLatencyView)
 	return &Factory{
-		Options: NewOptions(exporterId, migrations, datasource, dockerMultiNodeCluster, numConsumers, primaryNamespace, archiveNamespace),
+		Options: NewOptions(exporterId, config, primaryNamespace, archiveNamespace),
 		// makeReader: func(db *clickhouse.Conn, operationsTable, indexTable, spansTable string) (spanstore.Reader, error) {
 		// 	return store.NewTraceReader(db, operationsTable, indexTable, spansTable), nil
 		// },

--- a/exporter/clickhousetracesexporter/config.go
+++ b/exporter/clickhousetracesexporter/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
 	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
+	ClusterName string `mapstructure:"cluster_name" default:"cluster"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/clickhousetracesexporter/options.go
+++ b/exporter/clickhousetracesexporter/options.go
@@ -38,7 +38,6 @@ const (
 	DefaultDurationSortTable        string   = "durationSort"
 	DefaultDurationSortMVTable      string   = "durationSortMV"
 	defaultArchiveSpansTable        string   = "signoz_archive_spans"
-	defaultClusterName              string   = "cluster"
 	defaultDependencyGraphTable     string   = "dependency_graph_minutes"
 	defaultDependencyGraphServiceMV string   = "dependency_graph_minutes_service_calls_mv"
 	defaultDependencyGraphDbMV      string   = "dependency_graph_minutes_db_calls_mv"
@@ -128,11 +127,13 @@ type Options struct {
 }
 
 // NewOptions creates a new Options struct.
-func NewOptions(exporterId uuid.UUID, migrations string, datasource string, dockerMultiNodeCluster bool, numConsumers int, primaryNamespace string, otherNamespaces ...string) *Options {
+func NewOptions(exporterId uuid.UUID, config Config, primaryNamespace string, otherNamespaces ...string) *Options {
 
+	datasource := config.Datasource
 	if datasource == "" {
 		datasource = defaultDatasource
 	}
+	migrations := config.Migrations
 	if migrations == "" {
 		migrations = defaultMigrations
 	}
@@ -153,13 +154,13 @@ func NewOptions(exporterId uuid.UUID, migrations string, datasource string, dock
 			AttributeKeyTable:          defaultAttributeKeyTable,
 			DurationSortTable:          DefaultDurationSortTable,
 			DurationSortMVTable:        DefaultDurationSortMVTable,
-			Cluster:                    defaultClusterName,
+			Cluster:                    config.ClusterName,
 			DependencyGraphTable:       defaultDependencyGraphTable,
 			DependencyGraphServiceMV:   defaultDependencyGraphServiceMV,
 			DependencyGraphDbMV:        defaultDependencyGraphDbMV,
 			DependencyGraphMessagingMV: DependencyGraphMessagingMV,
-			DockerMultiNodeCluster:     dockerMultiNodeCluster,
-			NumConsumers:               numConsumers,
+			DockerMultiNodeCluster:     config.DockerMultiNodeCluster,
+			NumConsumers:               config.QueueConfig.NumConsumers,
 			Encoding:                   defaultEncoding,
 			Connector:                  defaultConnector,
 			ExporterId:                 exporterId,


### PR DESCRIPTION
Currently `clickhousetraces` uses hardcoded cluster name `cluster` which doesn't allow to use different cluster.

This PR implements it as configuration option so any cluster can be specified.
