### PR TITLE
schema_migrator: Don't fail when ClickHouse is listening on IPv6

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -307,7 +307,7 @@ func (m *MigrationManager) HostAddrs() ([]string, error) {
 	}
 
 	hostAddrs := make(map[string]struct{})
-	query := "SELECT DISTINCT host_address, port FROM system.clusters WHERE host_address NOT IN ['localhost', '127.0.0.1'] AND cluster = $1"
+	query := "SELECT DISTINCT host_address, port FROM system.clusters WHERE host_address NOT IN ['localhost', '127.0.0.1', '::1'] AND cluster = $1"
 	rows, err := m.conn.Query(context.Background(), query, m.clusterName)
 	if err != nil {
 		return nil, errors.Join(ErrFailedToGetHostAddrs, err)


### PR DESCRIPTION
My ClickHouse DB is listening on IPv6 and that causes migration to fail.

```
{"L":"info","timestamp":"2024-10-19T00:03:31.343Z","C":"schema_migrator/manager.go:328","M":"Connecting to new host","host":"::1:9000"}
{"L":"info","timestamp":"2024-10-19T00:03:31.343Z","C":"schema_migrator/manager.go:811","M":"Updating migration entry","query":"ALTER TABLE signoz_logs.schema_migrations_v2 ON CLUSTER default UPDATE status = $1, error = $2, updated_at = $3 WHERE migration_id = $4","status":"failed","error":"failed to get conn\ndial tcp: address ::1:9000: too many colons in address","migration_id":1}
Error: failed to bootstrap migrations: failed to create schema_migrations_v2 table
failed to get conn
dial tcp: address ::1:9000: too many colons in address
code: 60, message: There was an error on [localhost:9000]: Code: 60. DB::Exception: Could not find table: schema_migrations_v2. (UNKNOWN_TABLE) (version 24.9.2.42 (official build))
```

This PR fixes that.

Note that this won't fix if someone is using IPv6 for remotes.
