### PR TITLE
fix: use string values for resource labels

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -270,7 +270,8 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 
 			resourcesMap := attributesToMap(res.Attributes(), true)
 
-			serializedRes, err := json.Marshal(res.Attributes().AsRaw())
+			// we are using resourcesMap.StringData here as we are want everything to be string values.
+			serializedRes, err := json.Marshal(resourcesMap.StringData)
 			if err != nil {
 				return fmt.Errorf("couldn't serialize log resource JSON: %w", err)
 			}


### PR DESCRIPTION
Since we already store resource attributes as strings the query sent by user is correct but and the query builder also builds the correct query but since the label value doesn't contains `'` it fails. This pr fixes that issue.

The same goes for an array of strings.

TLDR :- 

resources {
"arr": ["a", "b", "c"],
"num" : 123 
}

will be stored as
`{"arr":"[\"a\",\"b\",\"c\"]","num":"123"}`
Fix for https://github.com/SigNoz/signoz/issues/6307