### PR TITLE
fix: don't drop actual duration sort table

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -423,14 +423,14 @@ var TracesMigrations = []SchemaMigrationRecord{
 				Database: "signoz_traces",
 				Table:    "distributed_durationSort",
 			},
-			DropTableOperation{
-				Database: "signoz_traces",
-				Table:    "durationSort",
-				// this is added so that we can avoid the following error
-				//1. Size (453.51 GB) is greater than max_[table/partition]_size_to_drop (50.00 GB)
-				// https://stackoverflow.com/questions/78162269/cannot-drop-large-materialized-view-in-clickhouse
-				Settings: TableSettings{{Name: "max_table_size_to_drop", Value: "0"}},
-			},
+			// DropTableOperation{
+			// 	Database: "signoz_traces",
+			// 	Table:    "durationSort",
+			// 	// this is added so that we can avoid the following error
+			// 	//1. Size (453.51 GB) is greater than max_[table/partition]_size_to_drop (50.00 GB)
+			// 	// https://stackoverflow.com/questions/78162269/cannot-drop-large-materialized-view-in-clickhouse
+			// 	Settings: TableSettings{{Name: "max_table_size_to_drop", Value: "0"}},
+			// },
 		},
 		DownItems: []Operation{},
 	},


### PR DESCRIPTION
don't drop actual duration sort table