### PR TITLE
ci(github): updated label workflow, fix ci skip condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,20 +10,20 @@ on:
 
 jobs:
   test:
-    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ! ${{ github.event.pull_request.head.repo.fork && github.actor == 'dependabot[bot]' }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     uses: signoz/primus.workflows/.github/workflows/go-test.yaml@main
     secrets: inherit
     with:
       PRIMUS_REF: main
       GO_TEST_CONTEXT: ./...
   fmt:
-    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ! ${{ github.event.pull_request.head.repo.fork && github.actor == 'dependabot[bot]' }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     uses: signoz/primus.workflows/.github/workflows/go-fmt.yaml@main
     secrets: inherit
     with:
       PRIMUS_REF: main
   lint:
-    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ! ${{ github.event.pull_request.head.repo.fork && github.actor == 'dependabot[bot]' }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test') || ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     uses: signoz/primus.workflows/.github/workflows/go-lint.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/postci.yaml
+++ b/.github/workflows/postci.yaml
@@ -8,9 +8,10 @@ on:
       - synchronize
 
 jobs:
-  remove:
-    uses: signoz/primus.workflows/.github/workflows/github-remove-label.yaml@main
+  remove-label:
+    uses: signoz/primus.workflows/.github/workflows/github-label.yaml@main
     secrets: inherit
     with:
       PRIMUS_REF: main
+      GITHUB_LABEL_ACTION: remove
       GITHUB_LABEL_NAME: safe-to-test

--- a/.github/workflows/postci.yaml
+++ b/.github/workflows/postci.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 jobs:
-  remove-label:
+  remove:
     uses: signoz/primus.workflows/.github/workflows/github-label.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
#### CI

- use updated GitHub Label workflow
- fix CI condition to skip jobs for forks and dependabot, require label
