### PR TITLE
ci: update skip workflow conditions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,20 +10,26 @@ on:
 
 jobs:
   test:
-    if: (! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]') || (contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event.pull_request.head.repo.fork) || (github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+    if: |
+      (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test'))) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     uses: signoz/primus.workflows/.github/workflows/go-test.yaml@main
     secrets: inherit
     with:
       PRIMUS_REF: main
       GO_TEST_CONTEXT: ./...
   fmt:
-    if: (! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]') || (contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event.pull_request.head.repo.fork) || (github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+    if: |
+      (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test'))) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     uses: signoz/primus.workflows/.github/workflows/go-fmt.yaml@main
     secrets: inherit
     with:
       PRIMUS_REF: main
   lint:
-    if: (! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]') || (contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event.pull_request.head.repo.fork) || (github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+    if: |
+      (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test'))) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     uses: signoz/primus.workflows/.github/workflows/go-lint.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
 We will be deciding on whether to run the workflows based on the following conditions.
 
 1. For `pull_request` events:
- The PR is from the same repository (not a fork) AND
- The actor is not dependabot AND
- The PR doesn't have the 'safe-to-test' label

2. For `pull_request_target` events:
- The PR has the 'safe-to-test' label
