### PR TITLE
ci(postci): use PR author instead of github.actor

### DIFF
--- a/.github/workflows/postci.yaml
+++ b/.github/workflows/postci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   remove:
-    if: github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.fork || github.event.pull_request.user.login == 'dependabot[bot]'
     uses: signoz/primus.workflows/.github/workflows/github-label.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
#### CI

- postci) use PR author instead of github.actor