### PR TITLE
metering: Add metric metering

### DIFF
--- a/pkg/metering/v1/metrics.go
+++ b/pkg/metering/v1/metrics.go
@@ -1,0 +1,84 @@
+package v1
+
+import (
+	"github.com/SigNoz/signoz-otel-collector/pkg/metering"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+type metrics struct {
+	Logger *zap.Logger
+	Sizer  metering.Sizer
+}
+
+func NewMetrics(logger *zap.Logger) metering.Metrics {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &metrics{
+		Logger: logger,
+		Sizer:  metering.NewJSONSizer(logger),
+	}
+}
+
+func (meter *metrics) Size(md pmetric.Metrics) int {
+	// Note: We will never use this function unless our billing mechanism changes
+	// The metrics limits should have been samples count based, however, we rolled out with size
+	// and many have a guestimated and set the size limits. So we will keep this as pmetric json size for now
+	bytes, err := (&pmetric.JSONMarshaler{}).MarshalMetrics(md)
+	if err != nil {
+		meter.Logger.Error("cannot marshal metrics", zap.Error(err))
+		return 0
+	}
+
+	return len(bytes)
+}
+
+func (meter *metrics) Count(md pmetric.Metrics) int {
+	count := 0
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		resourceMetric := md.ResourceMetrics().At(i)
+
+		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
+			scopeMetrics := resourceMetric.ScopeMetrics().At(j)
+
+			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
+				metric := scopeMetrics.Metrics().At(k)
+
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					count += metric.Gauge().DataPoints().Len()
+				case pmetric.MetricTypeSum:
+					count += metric.Sum().DataPoints().Len()
+				case pmetric.MetricTypeHistogram:
+					subCount := 0
+					// each bucket is treated as separate sample
+					for i := 0; i < metric.Histogram().DataPoints().Len(); i++ {
+						subCount += metric.Histogram().DataPoints().At(i).BucketCounts().Len()
+					}
+					count += subCount
+				case pmetric.MetricTypeSummary:
+					subCount := 0
+					for i := 0; i < metric.Summary().DataPoints().Len(); i++ {
+						subCount += metric.Summary().DataPoints().At(i).QuantileValues().Len()
+					}
+					count += subCount
+				case pmetric.MetricTypeExponentialHistogram:
+					// we haven't enabled this metric type on Cloud since we don't know how to bill this
+					// If we use the following logic, it will explode the samples count
+					// However, for the sake of completeness, following the same logic as ExplicitBucketHistogram
+					// TODO(srikanthccv): Update this when we support this metric type on Cloud
+					subCount := 0
+					for i := 0; i < metric.ExponentialHistogram().DataPoints().Len(); i++ {
+						// each bucket of positive and negative is treated as separate sample
+						subCount += metric.ExponentialHistogram().DataPoints().At(i).Negative().BucketCounts().Len() +
+							metric.ExponentialHistogram().DataPoints().At(i).Positive().BucketCounts().Len()
+					}
+					count += subCount
+				}
+			}
+		}
+	}
+	return count
+}

--- a/pkg/metering/v1/metrics_test.go
+++ b/pkg/metering/v1/metrics_test.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/SigNoz/signoz-otel-collector/pkg/pdatagen/pmetricsgen"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func TestMetrics(t *testing.T) {
+	meter := NewMetrics(zap.NewNop())
+
+	md := pmetric.NewMetrics()
+	md.ResourceMetrics().AppendEmpty()
+
+	assert.Equal(t, 0, meter.Size(md))
+}
+
+func TestMetrics_CountGaugeMetrics(t *testing.T) {
+	md := pmetricsgen.Generate(pmetricsgen.GenerationConfig{
+		GaugeMetricsCount:   10,
+		GaugeDataPointCount: 10,
+	})
+
+	meter := NewMetrics(zap.NewNop())
+
+	// 10 metrics * 10 data points = 100
+	assert.Equal(t, 100, meter.Count(md))
+}
+
+func TestMetrics_CountSumMetrics(t *testing.T) {
+	md := pmetricsgen.Generate(pmetricsgen.GenerationConfig{
+		SumMetricsCount:   10,
+		SumDataPointCount: 6,
+	})
+
+	meter := NewMetrics(zap.NewNop())
+
+	// 10 metrics * 6 data points = 60
+	assert.Equal(t, 60, meter.Count(md))
+}
+
+func TestMetrics_CountHistogramMetrics(t *testing.T) {
+	md := pmetricsgen.Generate(pmetricsgen.GenerationConfig{
+		HistogramMetricsCount:   1,
+		HistogramDataPointCount: 6,
+		HistogramBucketCount:    20,
+	})
+
+	meter := NewMetrics(zap.NewNop())
+
+	// 6 data points * 20 buckets = 120
+	assert.Equal(t, 120, meter.Count(md))
+}
+
+func TestMetrics_CountExponentialHistogramMetrics(t *testing.T) {
+	md := pmetricsgen.Generate(pmetricsgen.GenerationConfig{
+		ExponentialHistogramMetricsCount:   1,
+		ExponentialHistogramDataPointCount: 6,
+		ExponentialHistogramBucketCount:    20,
+	})
+
+	meter := NewMetrics(zap.NewNop())
+
+	// 6 data points * 20 buckets = 120
+	// 120 negative + 120 positive = 240
+	assert.Equal(t, 240, meter.Count(md))
+}
+
+func TestMetrics_CountSummaryMetrics(t *testing.T) {
+	md := pmetricsgen.Generate(pmetricsgen.GenerationConfig{
+		SummaryMetricsCount:   1,
+		SummaryDataPointCount: 6,
+		SummaryQuantileCount:  3,
+	})
+
+	meter := NewMetrics(zap.NewNop())
+
+	assert.Equal(t, 18, meter.Count(md))
+}

--- a/pkg/metering/v1/metrics_test.go
+++ b/pkg/metering/v1/metrics_test.go
@@ -15,7 +15,7 @@ func TestMetrics(t *testing.T) {
 	md := pmetric.NewMetrics()
 	md.ResourceMetrics().AppendEmpty()
 
-	assert.Equal(t, 0, meter.Size(md))
+	assert.Equal(t, 0, meter.Count(md))
 }
 
 func TestMetrics_CountGaugeMetrics(t *testing.T) {

--- a/pkg/pdatagen/pmetricsgen/data.go
+++ b/pkg/pdatagen/pmetricsgen/data.go
@@ -1,0 +1,116 @@
+package pmetricsgen
+
+import (
+	"math/rand/v2"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type GenerationConfig struct {
+	GaugeMetricsCount                  int
+	GaugeDataPointCount                int
+	SumMetricsCount                    int
+	SumDataPointCount                  int
+	HistogramMetricsCount              int
+	HistogramDataPointCount            int
+	HistogramBucketCount               int
+	ExponentialHistogramMetricsCount   int
+	ExponentialHistogramDataPointCount int
+	ExponentialHistogramBucketCount    int
+	SummaryMetricsCount                int
+	SummaryDataPointCount              int
+	SummaryQuantileCount               int
+}
+
+func Generate(cfg GenerationConfig) pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+	scopeMetrics.Metrics().EnsureCapacity(
+		cfg.GaugeMetricsCount +
+			cfg.SumMetricsCount +
+			cfg.HistogramMetricsCount +
+			cfg.ExponentialHistogramMetricsCount,
+	)
+
+	for i := 0; i < cfg.GaugeMetricsCount; i++ {
+		gaugeMetric := scopeMetrics.Metrics().AppendEmpty().SetEmptyGauge()
+		gaugeMetric.DataPoints().EnsureCapacity(cfg.GaugeDataPointCount)
+		for j := 0; j < cfg.GaugeDataPointCount; j++ {
+			dp := gaugeMetric.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dp.SetDoubleValue(rand.Float64())
+		}
+	}
+
+	for i := 0; i < cfg.SumMetricsCount; i++ {
+		sumMetric := scopeMetrics.Metrics().AppendEmpty().SetEmptySum()
+		sumMetric.DataPoints().EnsureCapacity(cfg.SumDataPointCount)
+		for j := 0; j < cfg.SumDataPointCount; j++ {
+			dp := sumMetric.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dp.SetDoubleValue(rand.Float64())
+		}
+	}
+
+	for i := 0; i < cfg.HistogramMetricsCount; i++ {
+		histogramMetric := scopeMetrics.Metrics().AppendEmpty().SetEmptyHistogram()
+		histogramMetric.DataPoints().EnsureCapacity(cfg.HistogramDataPointCount)
+		for j := 0; j < cfg.HistogramDataPointCount; j++ {
+			dp := histogramMetric.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			bucketsCounts := dp.BucketCounts()
+			bucketsCounts.EnsureCapacity(cfg.HistogramBucketCount)
+			for k := 0; k < cfg.HistogramBucketCount; k++ {
+				bucketsCounts.Append(rand.Uint64())
+			}
+			dp.ExplicitBounds().EnsureCapacity(cfg.HistogramBucketCount)
+			for k := 0; k < cfg.HistogramBucketCount; k++ {
+				dp.ExplicitBounds().Append(rand.Float64())
+			}
+		}
+	}
+
+	for i := 0; i < cfg.ExponentialHistogramMetricsCount; i++ {
+		exponentialHistogramMetric := scopeMetrics.Metrics().AppendEmpty().SetEmptyExponentialHistogram()
+		exponentialHistogramMetric.DataPoints().EnsureCapacity(cfg.ExponentialHistogramDataPointCount)
+		for j := 0; j < cfg.ExponentialHistogramDataPointCount; j++ {
+			dp := exponentialHistogramMetric.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dp.SetCount(rand.Uint64())
+			dp.SetSum(rand.Float64())
+			dp.SetMin(rand.Float64())
+			dp.SetMax(rand.Float64())
+			negative := dp.Negative().BucketCounts()
+			negative.EnsureCapacity(cfg.ExponentialHistogramBucketCount)
+			for k := 0; k < cfg.ExponentialHistogramBucketCount; k++ {
+				negative.Append(rand.Uint64())
+			}
+			positive := dp.Positive().BucketCounts()
+			positive.EnsureCapacity(cfg.ExponentialHistogramBucketCount)
+			for k := 0; k < cfg.ExponentialHistogramBucketCount; k++ {
+				positive.Append(rand.Uint64())
+			}
+		}
+	}
+
+	for i := 0; i < cfg.SummaryMetricsCount; i++ {
+		summaryMetric := scopeMetrics.Metrics().AppendEmpty().SetEmptySummary()
+		summaryMetric.DataPoints().EnsureCapacity(cfg.SummaryDataPointCount)
+		for j := 0; j < cfg.SummaryDataPointCount; j++ {
+			dp := summaryMetric.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			quantiles := dp.QuantileValues()
+			quantiles.EnsureCapacity(cfg.SummaryQuantileCount)
+			for k := 0; k < cfg.SummaryQuantileCount; k++ {
+				quantiles.AppendEmpty().SetQuantile(rand.Float64())
+			}
+			dp.SetCount(rand.Uint64())
+			dp.SetSum(rand.Float64())
+		}
+	}
+
+	return metrics
+}


### PR DESCRIPTION
Fixes https://github.com/SigNoz/engineering-pod/issues/2146


The `MetricCount` is not the count the user gets billed on if the data contains histograms. A sample is created from each bucket bound.