### PR TITLE
Chore: signozawsfirehosereceiver cwlog ts unmarshaling

### DIFF
--- a/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
+++ b/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
@@ -4,6 +4,8 @@
 package cwlog // import "github.com/SigNoz/signoz-otel-collector/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog"
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -44,7 +46,11 @@ func newResourceLogsBuilder(logs plog.Logs, attrs resourceAttributes) *resourceL
 func (rlb *resourceLogsBuilder) AddLog(log cWLog) {
 	for _, event := range log.LogEvents {
 		logLine := rlb.rls.AppendEmpty()
-		logLine.SetTimestamp(pcommon.Timestamp(event.Timestamp))
+
+		// CW Log events include timestamp in millis
+		ts := pcommon.NewTimestampFromTime(time.UnixMilli(event.Timestamp))
+		logLine.SetTimestamp(ts)
+
 		logLine.Body().SetStr(event.Message)
 	}
 }

--- a/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
+++ b/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
@@ -4,7 +4,7 @@
 package cwlog // import "github.com/SigNoz/signoz-otel-collector/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwlog"
 
 import (
-	"time"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -47,10 +47,23 @@ func (rlb *resourceLogsBuilder) AddLog(log cWLog) {
 	for _, event := range log.LogEvents {
 		logLine := rlb.rls.AppendEmpty()
 
-		// CW Log events include timestamp in millis
-		ts := pcommon.NewTimestampFromTime(time.UnixMilli(event.Timestamp))
-		logLine.SetTimestamp(ts)
+		logLine.SetTimestamp(pcommon.Timestamp(toEpochNano(event.Timestamp)))
 
 		logLine.Body().SetStr(event.Message)
 	}
+}
+
+// convert `epoch` of any precision to nanos
+func toEpochNano(epoch int64) uint64 {
+	epochCopy := epoch
+	count := 0
+	if epoch == 0 {
+		count = 1
+	} else {
+		for epoch != 0 {
+			epoch /= 10
+			count++
+		}
+	}
+	return uint64(epochCopy) * uint64(math.Pow(10, float64(19-count)))
 }


### PR DESCRIPTION
Cloudwatch log records contain timestamps in milliseconds.
OTLP log model expects timestamp to be in nanoseconds.

The forked code (from awsfirehose) was setting plog timestamp from the millisecond value leading to incorrect timestamps in parsed log records.

This change fixes that by correctly parsing the timestamp

contributes to https://github.com/SigNoz/signoz/issues/6540