### PR TITLE
chore(schema-migrator): support for running sync/async in single container

### DIFF
--- a/cmd/signozschemamigrator/Dockerfile
+++ b/cmd/signozschemamigrator/Dockerfile
@@ -9,8 +9,9 @@ ARG USER_UID=10001
 USER ${USER_UID}
 
 # copy the binaries from the multi-stage build
-COPY .build/${TARGETOS}-${TARGETARCH}/signoz-schema-migrator /signoz-schema-migrator
+COPY .build/${TARGETOS}-${TARGETARCH}/signoz-schema-migrator /usr/local/bin/signoz-schema-migrator
+COPY cmd/signozschemamigrator/run.sh /run.sh
 
-# run the binary as the entrypoint and pass the default dsn as a flag
-ENTRYPOINT [ "/signoz-schema-migrator" ]
-CMD ["--dsn", "tcp://localhost:9000"]
+# run both sync and async schema migrations in sequence using script
+ENTRYPOINT [ "/run.sh" ]
+CMD ["all"]

--- a/cmd/signozschemamigrator/run.sh
+++ b/cmd/signozschemamigrator/run.sh
@@ -1,0 +1,65 @@
+#! /bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -euo pipefail
+
+# Default schema migrator args
+DEFAULT_CLICKHOUSE_DSN="${DEFAULT_CLICKHOUSE_DSN:-tcp://localhost:9000}"
+DEFAULT_SCHEMA_MIGRATOR_ARGS="--dsn ${DEFAULT_CLICKHOUSE_DSN} --up="
+
+# Function to show usage
+show_usage() {
+    cat << EOF
+Usage: $0 <sync|async|all> [additional_args]
+
+Arguments:
+    sync        Run synchronous migrations
+    async       Run asynchronous migrations
+    all         Run both sync and async migrations
+
+Additional arguments will be passed to the migrator. If none provided,
+default arguments will be used: ${DEFAULT_SCHEMA_MIGRATOR_ARGS}
+EOF
+}
+
+
+# Function to run migrations
+run_migration() {
+    local migration_type=$1
+    local additional_args=$2
+    echo "Running ${migration_type} migrations..."
+    if ! signoz-schema-migrator "${migration_type}" "${additional_args}"; then
+        echo "Error: ${migration_type} migration failed"
+        exit 1
+    fi
+}
+
+# Validate input arguments
+if [[ $# -eq 0 ]];
+    show_usage
+    exit 1
+fi
+
+migration_type=$1
+if [[ "$migration_type" != "sync" && "$migration_type" != "async" && "$migration_type" != "all" ]]; then
+    echo "Error: Invalid migration type: ${migration_type}"
+    show_usage
+    exit 1
+fi
+
+shift
+additional_args=$@
+
+if [[ "$additional_args" == "" ]]; then
+    additional_args="${DEFAULT_SCHEMA_MIGRATOR_ARGS}"
+fi
+
+# Main execution
+echo "Starting schema migrations with args: ${additional_args}"
+if [[ "$migration_type" == "all" ]]; then
+    run_migration "sync" "${additional_args}"
+    run_migration "async" "${additional_args}"
+else
+    run_migration "${migration_type}" "${additional_args}"
+fi
+echo "All migrations completed successfully"

--- a/cmd/signozschemamigrator/run.sh
+++ b/cmd/signozschemamigrator/run.sh
@@ -35,7 +35,7 @@ run_migration() {
 }
 
 # Validate input arguments
-if [[ $# -eq 0 ]];
+if [[ $# -eq 0 ]]; then
     show_usage
     exit 1
 fi
@@ -55,7 +55,7 @@ if [[ "$additional_args" == "" ]]; then
 fi
 
 # Main execution
-echo "Starting schema migrations with args: ${additional_args}"
+echo "Starting schema migrations with args: \"${additional_args}\""
 if [[ "$migration_type" == "all" ]]; then
     run_migration "sync" "${additional_args}"
     run_migration "async" "${additional_args}"


### PR DESCRIPTION
#### Summary

Currently, `async` migration does not run for SigNoz installation in Docker-Swarm.

With the changes from this PR, we can enable it.
For non-swarm deployments (Docker/K8s), we can also choose to use single container/job, or keep using the two containers.

#### Chores

- support for running sync/async migrations in a single container

#### Related Issues/PRs

- https://github.com/SigNoz/signoz/pull/6489
- https://github.com/SigNoz/signoz/issues/6477