### PR TITLE
fixes(signozfirehosereceiver): add prefixes to routes

### DIFF
--- a/config/configrouter/mux.go
+++ b/config/configrouter/mux.go
@@ -1,0 +1,65 @@
+package configrouter
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// MuxConfig is a configuration for the mux router.
+type MuxConfig struct {
+}
+
+// NewDefaultMuxConfig returns a new default mux config.
+func NewDefaultMuxConfig() *MuxConfig {
+	return &MuxConfig{}
+}
+
+// ToMuxRouter returns a new mux router.
+func (c *MuxConfig) ToMuxRouter(logger *zap.Logger) *mux.Router {
+	router := mux.NewRouter()
+	router.MethodNotAllowedHandler = methodNotAllowed()
+	router.NotFoundHandler = notFound()
+	router.StrictSlash(false)
+	router.Use(recovery(logger))
+
+	return router
+}
+
+// Recovers from panics and writes an error to the response writer.
+func recovery(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				err := recover()
+				if err != nil {
+					logger.Error("panic recovered", zap.Any("error", err))
+
+					newErr := status.Newf(codes.Internal, "something went wrong")
+					WriteError(w, newErr.Err(), http.StatusInternalServerError)
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// Returns a handler that returns a 405 status code and a message that the method is not allowed.
+func methodNotAllowed() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := status.Newf(codes.Unimplemented, "%v method not allowed, supported: [POST]", req.Method)
+		WriteError(w, err.Err(), http.StatusMethodNotAllowed)
+	})
+}
+
+// Returns a handler that returns a 404 status code and a message that the path is not found.
+func notFound() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := status.Newf(codes.NotFound, "%v path not found", req.URL.Path)
+		WriteError(w, err.Err(), http.StatusNotFound)
+	})
+}

--- a/config/configrouter/mux_test.go
+++ b/config/configrouter/mux_test.go
@@ -1,0 +1,104 @@
+package configrouter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+)
+
+func TestMuxConfig(t *testing.T) {
+	ctx := context.Background()
+
+	routerConfig := NewDefaultMuxConfig().ToMuxRouter(zap.NewNop())
+	routerConfig.HandleFunc("/panic", func(w http.ResponseWriter, r *http.Request) {
+		panic("test")
+	}).Methods(http.MethodGet)
+	routerConfig.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test"))
+	}).Methods(http.MethodGet)
+
+	serverConfig := confighttp.ServerConfig{
+		Endpoint: "localhost:0",
+	}
+
+	httpListener, err := serverConfig.ToListener(ctx)
+	require.NoError(t, err)
+
+	httpServer, err := serverConfig.ToServer(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), routerConfig)
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, httpServer.Serve(httpListener))
+	}()
+
+	defer func() {
+		require.NoError(t, httpServer.Shutdown(ctx))
+	}()
+
+	testCases := []struct {
+		name               string
+		body               io.Reader
+		path               string
+		method             string
+		expectedCode       int
+		expectedCodeInBody int64
+	}{
+		{
+			name:               "NotFound",
+			body:               strings.NewReader("[{}]"),
+			path:               "does-not-exist",
+			method:             http.MethodPost,
+			expectedCode:       http.StatusNotFound,
+			expectedCodeInBody: int64(codes.NotFound),
+		},
+		{
+			name:               "MethodNotAllowed",
+			body:               strings.NewReader("[{}]"),
+			path:               "test",
+			method:             http.MethodPost,
+			expectedCode:       http.StatusMethodNotAllowed,
+			expectedCodeInBody: int64(codes.Unimplemented),
+		},
+		{
+			name:               "Panic",
+			body:               strings.NewReader("[{}]"),
+			path:               "panic",
+			method:             http.MethodGet,
+			expectedCode:       http.StatusInternalServerError,
+			expectedCodeInBody: int64(codes.Internal),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(
+				tc.method,
+				fmt.Sprintf("http://%s/%s", httpListener.Addr().String(), tc.path),
+				tc.body,
+			)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			err = resp.Body.Close()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedCode, resp.StatusCode)
+			assert.Equal(t, tc.expectedCodeInBody, gjson.Get(string(body), "code").Int())
+		})
+	}
+}

--- a/config/configrouter/mux_test.go
+++ b/config/configrouter/mux_test.go
@@ -40,11 +40,11 @@ func TestMuxConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		require.NoError(t, httpServer.Serve(httpListener))
+		_ = httpServer.Serve(httpListener)
 	}()
 
 	defer func() {
-		_ = httpServer.Shutdown(ctx)
+		require.NoError(t, httpServer.Shutdown(ctx))
 	}()
 
 	testCases := []struct {

--- a/config/configrouter/mux_test.go
+++ b/config/configrouter/mux_test.go
@@ -44,7 +44,7 @@ func TestMuxConfig(t *testing.T) {
 	}()
 
 	defer func() {
-		require.NoError(t, httpServer.Shutdown(ctx))
+		_ = httpServer.Shutdown(ctx)
 	}()
 
 	testCases := []struct {

--- a/config/configrouter/writer.go
+++ b/config/configrouter/writer.go
@@ -1,0 +1,50 @@
+package configrouter
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Writes an error to the response writer.
+// If the error is a gRPC status, it will use the gRPC status code to determine the HTTP status code.
+func WriteError(w http.ResponseWriter, err error, statusCode int) {
+	var body []byte
+	if s, ok := status.FromError(err); ok {
+		body = bodyFromStatus(s)
+		statusCode = httpStatusCodeFromStatus(s, statusCode)
+	} else {
+		body = []byte(err.Error())
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(body)
+}
+
+// Returns the response body from a gRPC status.
+func bodyFromStatus(s *status.Status) []byte {
+	body, merr := json.Marshal(s.Proto())
+	if merr != nil {
+		return []byte(`{"code": 13, "message": "failed to marshal error message"}`)
+	}
+
+	return body
+}
+
+// Returns the HTTP status code from a gRPC status code.
+func httpStatusCodeFromStatus(s *status.Status, statusCode int) int {
+	switch s.Code() {
+	// Retryable
+	case codes.Canceled, codes.DeadlineExceeded, codes.Aborted, codes.OutOfRange, codes.Unavailable, codes.DataLoss:
+		return http.StatusServiceUnavailable
+	// Retryable
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	// Return the statusCode received
+	default:
+		return statusCode
+	}
+}

--- a/config/configrouter/writer_test.go
+++ b/config/configrouter/writer_test.go
@@ -1,0 +1,1 @@
+package configrouter

--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
+	github.com/tidwall/gjson v1.14.2
 	github.com/tilinna/clock v1.1.0
 	github.com/vjeantet/grok v1.0.1
 	github.com/xdg-go/scram v1.1.2
@@ -541,7 +542,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tg123/go-htpasswd v1.2.2 // indirect
-	github.com/tidwall/gjson v1.14.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect

--- a/receiver/signozawsfirehosereceiver/receiver.go
+++ b/receiver/signozawsfirehosereceiver/receiver.go
@@ -118,7 +118,7 @@ func (fmr *firehoseReceiver) Start(ctx context.Context, host component.Host) err
 	var err error
 
 	router := configrouter.NewDefaultMuxConfig().ToMuxRouter(fmr.settings.Logger)
-	router.HandleFunc("/", fmr.ServeHTTP)
+	router.HandleFunc("/firehose/"+fmr.config.RecordType, fmr.ServeHTTP)
 
 	fmr.server, err = fmr.config.ServerConfig.ToServer(ctx, host, fmr.settings.TelemetrySettings, router)
 	if err != nil {

--- a/receiver/signozawsfirehosereceiver/receiver.go
+++ b/receiver/signozawsfirehosereceiver/receiver.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SigNoz/signoz-otel-collector/config/configrouter"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/receiver"
@@ -115,7 +116,11 @@ func (fmr *firehoseReceiver) Start(ctx context.Context, host component.Host) err
 	}
 
 	var err error
-	fmr.server, err = fmr.config.ServerConfig.ToServer(ctx, host, fmr.settings.TelemetrySettings, fmr)
+
+	router := configrouter.NewDefaultMuxConfig().ToMuxRouter(fmr.settings.Logger)
+	router.HandleFunc("/", fmr.ServeHTTP)
+
+	fmr.server, err = fmr.config.ServerConfig.ToServer(ctx, host, fmr.settings.TelemetrySettings, router)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Description

- Add the prefix `/firehouse/<record-type>` in the http handler
- Add panic handler and default route handling 