### PR TITLE
chore: summary metrics are always cumulative temporality

### DIFF
--- a/exporter/clickhousemetricsexporter/exporter.go
+++ b/exporter/clickhousemetricsexporter/exporter.go
@@ -203,7 +203,7 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 					case pmetric.MetricTypeExponentialHistogram:
 						temporality = metric.ExponentialHistogram().AggregationTemporality()
 					case pmetric.MetricTypeSummary:
-						temporality = pmetric.AggregationTemporalityUnspecified
+						temporality = pmetric.AggregationTemporalityCumulative
 					default:
 					}
 					metricName := getPromMetricName(metric, prwe.namespace)


### PR DESCRIPTION
For summary metrics, we were incorrectly setting the temporality as Unspecified. This was because there is no temporality field on the Summary point. It was clarified with this change https://github.com/open-telemetry/opentelemetry-proto/pull/591 that Summary metrics will always represent cumulative values. This change fixes it.