### PR TITLE
fix: add ttl for keys table

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/column.go
+++ b/cmd/signozschemamigrator/schema_migrator/column.go
@@ -240,14 +240,15 @@ func (a AggregateFunction) String() string {
 // Settings is the settings of the column.
 // Comment is the comment of the column.
 type Column struct {
-	Name     string
-	Type     ColumnType
-	Codec    string
-	Alias    string
-	Default  string
-	TTL      string
-	Settings ColumnSettings
-	Comment  string
+	Name         string
+	Type         ColumnType
+	Codec        string
+	Alias        string
+	Default      string
+	Materialized string
+	TTL          string
+	Settings     ColumnSettings
+	Comment      string
 }
 
 func (c Column) ToSQL() string {
@@ -262,6 +263,10 @@ func (c Column) ToSQL() string {
 	if c.Default != "" {
 		sql.WriteString(" DEFAULT ")
 		sql.WriteString(c.Default)
+	}
+	if c.Materialized != "" {
+		sql.WriteString(" MATERIALIZED ")
+		sql.WriteString(c.Materialized)
 	}
 	if c.Codec != "" {
 		sql.WriteString(" CODEC(")

--- a/cmd/signozschemamigrator/schema_migrator/column_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations.go
@@ -433,7 +433,7 @@ func (a AlterTableMaterializeColumn) ToSQL() string {
 		sql.WriteString(" ON CLUSTER ")
 		sql.WriteString(a.cluster)
 	}
-	sql.WriteString(" MATERIALIZE COLUMN IF EXISTS ")
+	sql.WriteString(" MATERIALIZE COLUMN ")
 	sql.WriteString(a.Column.Name)
 	if a.Partition != "" {
 		sql.WriteString(" IN PARTITION ")

--- a/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
@@ -449,12 +449,12 @@ func TestAlterTableMaterializeColumn(t *testing.T) {
 		{
 			name: "materialize-column",
 			op:   AlterTableMaterializeColumn{Database: "db", Table: "table", Column: Column{Name: "col"}},
-			want: "ALTER TABLE db.table MATERIALIZE COLUMN IF EXISTS col",
+			want: "ALTER TABLE db.table MATERIALIZE COLUMN col",
 		},
 		{
 			name: "materialize-column-with-cluster",
 			op:   AlterTableMaterializeColumn{Database: "db", Table: "table", Column: Column{Name: "col"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE COLUMN IF EXISTS col",
+			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE COLUMN col",
 		},
 	}
 

--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -156,16 +156,16 @@ ORDER BY name ASC`,
 				Database: "signoz_logs",
 				Table:    "logs_attribute_keys",
 				TTL:      "timestamp + INTERVAL 15 DAY",
-				Settings: TableSettings{
-					{Name: "materialize_ttl_after_modify", Value: "0"},
+				Settings: ModifyTTLSettings{
+					MaterializeTTLAfterModify: true,
 				},
 			},
 			AlterTableModifyTTL{
 				Database: "signoz_logs",
 				Table:    "logs_resource_keys",
 				TTL:      "timestamp + INTERVAL 15 DAY",
-				Settings: TableSettings{
-					{Name: "materialize_ttl_after_modify", Value: "0"},
+				Settings: ModifyTTLSettings{
+					MaterializeTTLAfterModify: true,
 				},
 			},
 		},

--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -131,4 +131,64 @@ ORDER BY name ASC`,
 		},
 		DownItems: []Operation{},
 	},
+	{
+		MigrationID: 1002,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_attribute_keys",
+				Column: Column{
+					Name:    "timestamp",
+					Type:    DateTimeColumnType{},
+					Default: "toDateTime(now())",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_resource_keys",
+				Column: Column{
+					Name:    "timestamp",
+					Type:    DateTimeColumnType{},
+					Default: "toDateTime(now())",
+				},
+			},
+			AlterTableModifyTTL{
+				Database: "signoz_logs",
+				Table:    "logs_attribute_keys",
+				TTL:      "timestamp + INTERVAL 15 DAY",
+				Settings: TableSettings{
+					{Name: "materialize_ttl_after_modify", Value: "0"},
+				},
+			},
+			AlterTableModifyTTL{
+				Database: "signoz_logs",
+				Table:    "logs_resource_keys",
+				TTL:      "timestamp + INTERVAL 15 DAY",
+				Settings: TableSettings{
+					{Name: "materialize_ttl_after_modify", Value: "0"},
+				},
+			},
+		},
+		DownItems: []Operation{},
+	},
+	{
+		MigrationID: 1003,
+		UpItems: []Operation{
+			AlterTableMaterializeColumn{
+				Database: "signoz_logs",
+				Table:    "logs_attribute_keys",
+				Column: Column{
+					Name: "timestamp",
+				},
+			},
+			AlterTableMaterializeColumn{
+				Database: "signoz_logs",
+				Table:    "logs_resource_keys",
+				Column: Column{
+					Name: "timestamp",
+				},
+			},
+		},
+		DownItems: []Operation{},
+	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -157,7 +157,7 @@ ORDER BY name ASC`,
 				Table:    "logs_attribute_keys",
 				TTL:      "timestamp + INTERVAL 15 DAY",
 				Settings: ModifyTTLSettings{
-					MaterializeTTLAfterModify: true,
+					MaterializeTTLAfterModify: false,
 				},
 			},
 			AlterTableModifyTTL{
@@ -165,7 +165,7 @@ ORDER BY name ASC`,
 				Table:    "logs_resource_keys",
 				TTL:      "timestamp + INTERVAL 15 DAY",
 				Settings: ModifyTTLSettings{
-					MaterializeTTLAfterModify: true,
+					MaterializeTTLAfterModify: false,
 				},
 			},
 		},

--- a/cmd/signozschemamigrator/schema_migrator/table_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations.go
@@ -340,7 +340,7 @@ func (a AlterTableModifyTTL) ShouldWaitForDistributionQueue() (bool, string, str
 }
 
 func (a AlterTableModifyTTL) IsMutation() bool {
-	if a.Settings.MaterializeTTLAfterModify {
+	if !a.Settings.MaterializeTTLAfterModify {
 		// we are not considering this as a mutation
 		return false
 	}
@@ -353,7 +353,7 @@ func (a AlterTableModifyTTL) IsIdempotent() bool {
 }
 
 func (a AlterTableModifyTTL) IsLightweight() bool {
-	if a.Settings.MaterializeTTLAfterModify {
+	if !a.Settings.MaterializeTTLAfterModify {
 		return true
 	}
 	return false
@@ -371,7 +371,7 @@ func (a AlterTableModifyTTL) ToSQL() string {
 	}
 	sql.WriteString(" MODIFY TTL ")
 	sql.WriteString(a.TTL)
-	if a.Settings.MaterializeTTLAfterModify {
+	if !a.Settings.MaterializeTTLAfterModify {
 		sql.WriteString(" SETTINGS ")
 		sql.WriteString("materialize_ttl_after_modify = 0")
 	}

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -359,7 +359,7 @@ func TestAlterTableModifyTTL(t *testing.T) {
 				Table:    "table",
 				TTL:      "ts + INTERVAL 1 DAY",
 			},
-			want: "ALTER TABLE db.table MODIFY TTL ts + INTERVAL 1 DAY",
+			want: "ALTER TABLE db.table MODIFY TTL ts + INTERVAL 1 DAY SETTINGS materialize_ttl_after_modify = 0",
 		},
 		{
 			name: "alter-table-modify-ttl-with-cluster",
@@ -369,7 +369,7 @@ func TestAlterTableModifyTTL(t *testing.T) {
 				TTL:      "ts + INTERVAL 1 DAY",
 				cluster:  "cluster",
 			},
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY TTL ts + INTERVAL 1 DAY",
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY TTL ts + INTERVAL 1 DAY SETTINGS materialize_ttl_after_modify = 0",
 		},
 	}
 

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -313,3 +313,69 @@ func TestCreateWithCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateTable(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "truncate-table",
+			op: TruncateTableOperation{
+				Database: "db",
+				Table:    "table",
+			},
+			want: "TRUNCATE TABLE IF EXISTS db.table",
+		},
+		{
+			name: "truncate-table-with-cluster",
+			op: TruncateTableOperation{
+				Database: "db",
+				Table:    "table",
+				cluster:  "cluster",
+			},
+			want: "TRUNCATE TABLE IF EXISTS db.table ON CLUSTER cluster",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}
+
+func TestAlterTableModifyTTL(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "alter-table-modify-ttl",
+			op: AlterTableModifyTTL{
+				Database: "db",
+				Table:    "table",
+				TTL:      "ts + INTERVAL 1 DAY",
+			},
+			want: "ALTER TABLE db.table MODIFY TTL ts + INTERVAL 1 DAY",
+		},
+		{
+			name: "alter-table-modify-ttl-with-cluster",
+			op: AlterTableModifyTTL{
+				Database: "db",
+				Table:    "table",
+				TTL:      "ts + INTERVAL 1 DAY",
+				cluster:  "cluster",
+			},
+			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY TTL ts + INTERVAL 1 DAY",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/SigNoz/engineering-pod/issues/2135

* adds ttl to the keys table of attributes and resource.
* also materializes the column to add ts to the old rows.

Wrote the TruncateTableOperation, it's not used but still kept it in the code.