### PR TITLE
fix: use logs table instead of distributed

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -252,7 +252,7 @@ func (e *clickhouseLogsExporter) updateMinAcceptedTs() {
 	ctx := context.Background()
 	var delTTL uint64 = 0
 	var dbResp []DBResponseTTL
-	q := fmt.Sprintf("SELECT engine_full FROM system.tables WHERE name='%s' and database='%s'", DISTRIBUTED_LOGS_TABLE_V2, databaseName)
+	q := fmt.Sprintf("SELECT engine_full FROM system.tables WHERE name='%s' and database='%s'", LOGS_TABLE_V2, databaseName)
 	err := e.db.Select(ctx, &dbResp, q)
 	if err != nil {
 		e.logger.Error("error while fetching ttl", zap.Error(err))


### PR DESCRIPTION
use logs table instead of distributed


issue was not noticed much becuase the value was set to current time during the start of the collector.