### PR TITLE
chore: support for orgId in opamp

### DIFF
--- a/conf/manager.yaml
+++ b/conf/manager.yaml
@@ -1,1 +1,2 @@
 server_endpoint: ws://127.0.0.1:4320/v1/opamp
+org_id: 3135a17c-9f4a-441b-b726-e0c6174a3244

--- a/opamp/config.go
+++ b/opamp/config.go
@@ -12,6 +12,7 @@ import (
 type AgentManagerConfig struct {
 	ServerEndpoint string `yaml:"server_endpoint"`
 	ID             string `yaml:"id,omitempty"`
+	OrgID          string `yaml:"org_id,omitempty"`
 }
 
 func ParseAgentManagerConfig(configLocation string) (*AgentManagerConfig, error) {
@@ -31,6 +32,9 @@ func ParseAgentManagerConfig(configLocation string) (*AgentManagerConfig, error)
 	if config.ID == "" {
 		// generate ulid if not provided
 		config.ID = ulid.MustNew(ulid.Now(), nil).String()
+	}
+	if config.OrgID == "" {
+		return nil, fmt.Errorf("org_id is required")
 	}
 
 	return &config, nil

--- a/opamp/server_client.go
+++ b/opamp/server_client.go
@@ -36,6 +36,7 @@ type serverClient struct {
 	configManager         *agentConfigManager
 	managerConfig         AgentManagerConfig
 	instanceId            ulid.ULID
+	orgId                 string
 	receivedInitialConfig bool
 	mux                   sync.Mutex
 }
@@ -65,6 +66,7 @@ func NewServerClient(args *NewServerClientOpts) (Client, error) {
 		configManager: configManager,
 		managerConfig: *args.Config,
 		mux:           sync.Mutex{},
+		orgId:         args.Config.OrgID,
 	}
 	svrClient.createInstanceId()
 
@@ -101,6 +103,7 @@ func (s *serverClient) createAgentDescription() *protobufs.AgentDescription {
 		IdentifyingAttributes: []*protobufs.KeyValue{
 			keyVal("service.name", "signoz-otel-collector"),
 			keyVal("service.version", constants.Version),
+			keyVal("orgId", s.orgId),
 		},
 		NonIdentifyingAttributes: []*protobufs.KeyValue{
 			keyVal("os.family", runtime.GOOS),


### PR DESCRIPTION
Fixes https://github.com/SigNoz/platform-pod/issues/515 and needs to be deployed along with https://github.com/SigNoz/signoz/pull/7327 


Please not this is a breaking change where the orgId needs to be present in the config for it be connected to the correct orgID.

During the first message if there is an error it doesn't try to reconnect, this is something that needs to be fixed.