### PR TITLE
add wget to container

### DIFF
--- a/cmd/signozotelcollector/Dockerfile
+++ b/cmd/signozotelcollector/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:bookworm-slim
 
 # add ca-certificates in case you need them
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 # define arguments and default values
 ARG TARGETOS TARGETARCH

--- a/cmd/signozotelcollector/Dockerfile.multi-arch
+++ b/cmd/signozotelcollector/Dockerfile.multi-arch
@@ -8,7 +8,7 @@ ARG ARCH
 ARG USER_UID=10001
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates && \
+    apt-get install -y ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*
 
 USER ${USER_UID}


### PR DESCRIPTION
In the documents for setting up ECS infra monitoring, a healthcheck option is used.

https://signoz.io/docs/userguide/collecting-ecs-sidecar-infra/

The healthcheck option uses wget.  Previous releases used alpine as the base image and alpine has wget through busybox.  This PR is to add wget to the container so that the ECS healthcheck works without error.