### PR TITLE
chore: add serviceName to log "Too many operations to track, ....",

### DIFF
--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -1175,11 +1175,14 @@ func concatDimensionValue(dest *bytes.Buffer, value string, prefixSep bool) {
 func (p *processorImp) buildKey(dest *bytes.Buffer, serviceName string, span ptrace.Span, optionalDims []dimension, resourceAttrs pcommon.Map) {
 	spanName := span.Name()
 	if len(p.serviceToOperations) > p.maxNumberOfServicesToTrack {
-		p.logger.Warn("Too many services to track, using overflow service name", zap.Int("maxNumberOfServicesToTrack", p.maxNumberOfServicesToTrack))
+		p.logger.Warn("Too many services to track, using overflow service name",
+			zap.Int("maxNumberOfServicesToTrack", p.maxNumberOfServicesToTrack))
 		serviceName = overflowServiceName
 	}
 	if len(p.serviceToOperations[serviceName]) > p.maxNumberOfOperationsToTrackPerService {
-		p.logger.Warn("Too many operations to track, using overflow operation name", zap.Int("maxNumberOfOperationsToTrackPerService", p.maxNumberOfOperationsToTrackPerService))
+		p.logger.Warn("Too many operations to track, using overflow operation name",
+			zap.Int("maxNumberOfOperationsToTrackPerService", p.maxNumberOfOperationsToTrackPerService),
+			zap.String("serviceName", serviceName))
 		spanName = overflowOperation
 	}
 	concatDimensionValue(dest, serviceName, false)


### PR DESCRIPTION
this makes troubleshooting easier and helps identify which service is creating too many unique span names.

Solves https://github.com/SigNoz/signoz-otel-collector/issues/602