### PR TITLE
fix(7303): removed unused double mv's

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -61,7 +61,6 @@ type SchemaMigrationRecord struct {
 	MigrationID uint64
 	UpItems     []Operation
 	DownItems   []Operation
-	IsNecessary bool
 }
 
 // MigrationManager is the manager for the schema migrations.
@@ -638,7 +637,7 @@ func (m *MigrationManager) MigrateUpSync(ctx context.Context, upVersions []uint6
 			continue
 		}
 		for _, item := range migration.UpItems {
-			if (!item.IsMutation() && item.IsIdempotent() && item.IsLightweight()) || migration.IsNecessary {
+			if !item.IsMutation() && item.IsIdempotent() && item.IsLightweight() {
 				if err := m.RunOperation(ctx, item, migration.MigrationID, signozMetricsDB, false); err != nil {
 					return err
 				}

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -61,6 +61,7 @@ type SchemaMigrationRecord struct {
 	MigrationID uint64
 	UpItems     []Operation
 	DownItems   []Operation
+	IsNecessary bool
 }
 
 // MigrationManager is the manager for the schema migrations.
@@ -637,7 +638,7 @@ func (m *MigrationManager) MigrateUpSync(ctx context.Context, upVersions []uint6
 			continue
 		}
 		for _, item := range migration.UpItems {
-			if !item.IsMutation() && item.IsIdempotent() && item.IsLightweight() {
+			if (!item.IsMutation() && item.IsIdempotent() && item.IsLightweight()) || migration.IsNecessary {
 				if err := m.RunOperation(ctx, item, migration.MigrationID, signozMetricsDB, false); err != nil {
 					return err
 				}

--- a/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
@@ -877,7 +877,6 @@ var MetricsMigrations = []SchemaMigrationRecord{
 						FROM signoz_metrics.time_series_v4_1day`,
 			},
 		},
-		IsNecessary: true,
 	},
 	// no need for down items, and there is a default value for the column
 	// so it's a safe migration without any down migration

--- a/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
@@ -801,6 +801,84 @@ var MetricsMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1004,
+		UpItems: []Operation{
+			DropTableOperation{
+				Database: "signoz_metrics",
+				Table:    "time_series_v4_6hrs_mv_separate_attrs",
+			},
+			DropTableOperation{
+				Database: "signoz_metrics",
+				Table:    "time_series_v4_1day_mv_separate_attrs",
+			},
+			DropTableOperation{
+				Database: "signoz_metrics",
+				Table:    "time_series_v4_1week_mv_separate_attrs",
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_metrics",
+				ViewName: "time_series_v4_6hrs_mv",
+				Query: `SELECT
+							env,
+							temporality,
+							metric_name,
+							description,
+							unit,
+							type,
+							is_monotonic,
+							fingerprint,
+							floor(unix_milli / 21600000) * 21600000 AS unix_milli,
+							labels,
+							attrs,
+							scope_attrs,
+							resource_attrs,
+							__normalized
+						FROM signoz_metrics.time_series_v4`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_metrics",
+				ViewName: "time_series_v4_1day_mv",
+				Query: `SELECT
+							env,
+							temporality,
+							metric_name,
+							description,
+							unit,
+							type,
+							is_monotonic,
+							fingerprint,
+							floor(unix_milli / 86400000) * 86400000 AS unix_milli,
+							labels,
+							attrs,
+							scope_attrs,
+							resource_attrs,
+							__normalized
+						FROM signoz_metrics.time_series_v4_6hrs`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_metrics",
+				ViewName: "time_series_v4_1week_mv",
+				Query: `SELECT
+							env,
+							temporality,
+							metric_name,
+							description,
+							unit,
+							type,
+							is_monotonic,
+							fingerprint,
+							floor(unix_milli / 604800000) * 604800000 AS unix_milli,
+							labels,
+							attrs,
+							scope_attrs,
+							resource_attrs,
+							__normalized
+						FROM signoz_metrics.time_series_v4_1day`,
+			},
+		},
+		IsNecessary: true,
+	},
 	// no need for down items, and there is a default value for the column
 	// so it's a safe migration without any down migration
 }


### PR DESCRIPTION
We have added New Migration to remove unused MV's.
We have added IsNecessary properties to bypass migration checks.

Testing - 
We have run the migration in local , no more double mv's.
<img width="503" alt="Screenshot 2025-06-13 at 3 02 41 AM" src="https://github.com/user-attachments/assets/721a6ff8-5758-4977-96d0-0ae292039e5c" />

For sanity we have pushed one metric and checked it in all aggregated tables.
<img width="1413" alt="Screenshot 2025-06-13 at 3 04 14 AM" src="https://github.com/user-attachments/assets/5869ac25-2ce4-4a8c-9d04-e9f2b8aab880" />
