### PR TITLE
fix: distinguish IPv4 from IPv6 addresses (#601)

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"net"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/cenkalti/backoff/v4"
@@ -337,7 +338,12 @@ func (m *MigrationManager) HostAddrs() ([]string, error) {
 		if err := rows.Scan(&hostAddr, &port); err != nil {
 			return nil, errors.Join(ErrFailedToGetHostAddrs, err)
 		}
-		hostAddrs[fmt.Sprintf("%s:%d", hostAddr, port)] = struct{}{}
+		if net.ParseIP(hostAddr).To4() != nil {
+			hostAddrs[fmt.Sprintf("%s:%d", hostAddr, port)] = struct{}{}
+		}
+		else {
+			hostAddrs[fmt.Sprintf("[%s]:%d", hostAddr, port)] = struct{}{}
+		}
 	}
 
 	if len(hostAddrs) != 0 {


### PR DESCRIPTION
This is an attempt to provide a fix for issue #601.

The problem seems to lie in function HostAddrs at line 341 where host address is concatenated to port
https://github.com/SigNoz/signoz-otel-collector/blob/1d7bf04531ca0e64d490c630e2a6090ba5ee9e37/cmd/signozschemamigrator/schema_migrator/manager.go#L334-L341

Then later in the for loop at line 345 it tries to open connections (line 349):
https://github.com/SigNoz/signoz-otel-collector/blob/1d7bf04531ca0e64d490c630e2a6090ba5ee9e37/cmd/signozschemamigrator/schema_migrator/manager.go#L345-L350

I never wrote any Go code but I think the fix might be quite simple. According to [this StackOverflow answer](https://stackoverflow.com/questions/22751035/golang-distinguish-ipv4-ipv6), testing the result of  `To4()` would help distinguish IPv4 and IPv6 addresses. 

Please note this is my first time writing Go. I'd appreciate if someone more knowledgeable would pick this up =)
This fix would allow me to deploy Signoz in an IPv6-only environment.

Thanks again for any help

