### PR TITLE
fix(metering): added missing metric metering

### DIFF
--- a/pkg/metering/v1/metrics.go
+++ b/pkg/metering/v1/metrics.go
@@ -79,12 +79,23 @@ func (meter *metrics) CountPerResource(rmd pmetric.ResourceMetrics) int {
 				// each bucket is treated as separate sample
 				for i := 0; i < metric.Histogram().DataPoints().Len(); i++ {
 					subCount += metric.Histogram().DataPoints().At(i).BucketCounts().Len()
+					subCount += 1 // count metric
+					if metric.Histogram().DataPoints().At(i).HasSum() {
+						subCount += 1
+					}
+					if metric.Histogram().DataPoints().At(i).HasMin() {
+						subCount += 1
+					}
+					if metric.Histogram().DataPoints().At(i).HasMax() {
+						subCount += 1
+					}
 				}
 				count += subCount
 			case pmetric.MetricTypeSummary:
 				subCount := 0
 				for i := 0; i < metric.Summary().DataPoints().Len(); i++ {
 					subCount += metric.Summary().DataPoints().At(i).QuantileValues().Len()
+					subCount += 2 // count,sum metrics
 				}
 				count += subCount
 			case pmetric.MetricTypeExponentialHistogram:
@@ -97,6 +108,16 @@ func (meter *metrics) CountPerResource(rmd pmetric.ResourceMetrics) int {
 					// each bucket of positive and negative is treated as separate sample
 					subCount += metric.ExponentialHistogram().DataPoints().At(i).Negative().BucketCounts().Len() +
 						metric.ExponentialHistogram().DataPoints().At(i).Positive().BucketCounts().Len()
+					subCount += 1 // count metric
+					if metric.ExponentialHistogram().DataPoints().At(i).HasSum() {
+						subCount += 1
+					}
+					if metric.ExponentialHistogram().DataPoints().At(i).HasMin() {
+						subCount += 1
+					}
+					if metric.ExponentialHistogram().DataPoints().At(i).HasMax() {
+						subCount += 1
+					}
 				}
 				count += subCount
 			}

--- a/pkg/metering/v1/metrics_test.go
+++ b/pkg/metering/v1/metrics_test.go
@@ -53,6 +53,8 @@ func TestMetrics_CountHistogramMetrics(t *testing.T) {
 	meter := NewMetrics(zap.NewNop())
 
 	// 6 data points * 20 buckets = 120
+	// 6 data points * 4 (sum,count,min,max) metrics = 24
+	// total -> 120 + 24 = 144
 	assert.Equal(t, 144, meter.Count(md))
 }
 
@@ -67,6 +69,8 @@ func TestMetrics_CountExponentialHistogramMetrics(t *testing.T) {
 
 	// 6 data points * 20 buckets = 120
 	// 120 negative + 120 positive = 240
+	// 6 data points * 4 (sum,count,min,max) metrics = 24
+	// total -> 240 + 24 = 264
 	assert.Equal(t, 264, meter.Count(md))
 }
 

--- a/pkg/metering/v1/metrics_test.go
+++ b/pkg/metering/v1/metrics_test.go
@@ -53,7 +53,7 @@ func TestMetrics_CountHistogramMetrics(t *testing.T) {
 	meter := NewMetrics(zap.NewNop())
 
 	// 6 data points * 20 buckets = 120
-	assert.Equal(t, 120, meter.Count(md))
+	assert.Equal(t, 144, meter.Count(md))
 }
 
 func TestMetrics_CountExponentialHistogramMetrics(t *testing.T) {
@@ -67,7 +67,7 @@ func TestMetrics_CountExponentialHistogramMetrics(t *testing.T) {
 
 	// 6 data points * 20 buckets = 120
 	// 120 negative + 120 positive = 240
-	assert.Equal(t, 240, meter.Count(md))
+	assert.Equal(t, 264, meter.Count(md))
 }
 
 func TestMetrics_CountSummaryMetrics(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMetrics_CountSummaryMetrics(t *testing.T) {
 
 	meter := NewMetrics(zap.NewNop())
 
-	assert.Equal(t, 18, meter.Count(md))
+	assert.Equal(t, 30, meter.Count(md))
 }
 
 func TestMetrics_CountSummaryMetrics_WithExcludePattern(t *testing.T) {


### PR DESCRIPTION
- the metrics count package wasn't taking into account the sum / count / min / max metric datapoints that we generate for histogram, summary and exponential histogram metric types 

contributes to - https://github.com/SigNoz/platform-pod/issues/858 