### PR TITLE
Add TTL to `span_attributes_keys` table

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/table_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations.go
@@ -376,7 +376,7 @@ func (a AlterTableModifyTTL) ToSQL() string {
 }
 
 type AlterTableDropTTL struct {
-	cluster string
+	cluster  string
 	Database string
 	Table    string
 }
@@ -419,6 +419,6 @@ func (a AlterTableDropTTL) ToSQL() string {
 		sql.WriteString(" ON CLUSTER ")
 		sql.WriteString(a.cluster)
 	}
-	sql.WriteString(" REMOVE TTL ")
+	sql.WriteString(" REMOVE TTL")
 	return sql.String()
 }

--- a/cmd/signozschemamigrator/schema_migrator/table_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations.go
@@ -374,3 +374,51 @@ func (a AlterTableModifyTTL) ToSQL() string {
 	}
 	return sql.String()
 }
+
+type AlterTableDropTTL struct {
+	cluster string
+	Database string
+	Table    string
+}
+
+// OnCluster is used to specify the cluster on which the operation should be performed.
+// This is useful when the operation is to be performed on a cluster setup.
+func (a AlterTableDropTTL) OnCluster(cluster string) Operation {
+	a.cluster = cluster
+	return &a
+}
+
+func (a AlterTableDropTTL) WithReplication() Operation {
+	// no-op
+	return &a
+}
+
+func (a AlterTableDropTTL) ShouldWaitForDistributionQueue() (bool, string, string) {
+	return false, a.Database, a.Table
+}
+
+func (a AlterTableDropTTL) IsMutation() bool {
+	return false
+}
+
+func (a AlterTableDropTTL) IsIdempotent() bool {
+	return true
+}
+
+func (a AlterTableDropTTL) IsLightweight() bool {
+	return true
+}
+
+func (a AlterTableDropTTL) ToSQL() string {
+	var sql strings.Builder
+	sql.WriteString("ALTER TABLE ")
+	sql.WriteString(a.Database)
+	sql.WriteString(".")
+	sql.WriteString(a.Table)
+	if a.cluster != "" {
+		sql.WriteString(" ON CLUSTER ")
+		sql.WriteString(a.cluster)
+	}
+	sql.WriteString(" REMOVE TTL ")
+	return sql.String()
+}

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -379,3 +379,35 @@ func TestAlterTableModifyTTL(t *testing.T) {
 		})
 	}
 }
+
+func TestAlterTableDropTTL(t *testing.T) {
+	testCases := []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{
+			name: "alter-table-drop-ttl",
+			op: AlterTableDropTTL{
+				Database: "db",
+				Table:    "table",
+			},
+			want: "ALTER TABLE db.table REMOVE TTL",
+		},
+		{
+			name: "alter-table-drop-ttl-with-cluster",
+			op: AlterTableDropTTL{
+				Database: "db",
+				Table:    "table",
+				cluster:  "cluster",
+			},
+			want: "ALTER TABLE db.table ON CLUSTER cluster REMOVE TTL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.op.ToSQL())
+		})
+	}
+}

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1039,25 +1039,6 @@ var TracesMigrations = []SchemaMigrationRecord{
 					MaterializeTTLAfterModify: false,
 				},
 			},
-			// Add timestamp column to distributed_span_attributes_keys table
-			AlterTableAddColumn{
-				Database: "signoz_traces",
-				Table:    "distributed_span_attributes_keys",
-				Column: Column{
-					Name:    "timestamp",
-					Type:    DateTimeColumnType{},
-					Default: "toDateTime(now())",
-				},
-			},
-			// Set TTL on distributed_span_attributes_keys to match distributed_signoz_span table (15 days)
-			AlterTableModifyTTL{
-				Database: "signoz_traces",
-				Table:    "distributed_span_attributes_keys",
-				TTL:      "timestamp + INTERVAL 15 DAY",
-				Settings: ModifyTTLSettings{
-					MaterializeTTLAfterModify: false,
-				},
-			},
 		},
 		DownItems: []Operation{
 			AlterTableDropColumn{
@@ -1067,12 +1048,9 @@ var TracesMigrations = []SchemaMigrationRecord{
 					Name: "timestamp",
 				},
 			},
-			AlterTableDropColumn{
+			AlterTableDropTTL{
 				Database: "signoz_traces",
-				Table:    "distributed_span_attributes_keys",
-				Column: Column{
-					Name: "timestamp",
-				},
+				Table:    "span_attributes_keys",
 			},
 		},
 	},

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1017,4 +1017,63 @@ var TracesMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1008,
+		UpItems: []Operation{
+			// Add timestamp column to span_attributes_keys table
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "span_attributes_keys",
+				Column: Column{
+					Name:    "timestamp",
+					Type:    DateTimeColumnType{},
+					Default: "toDateTime(now())",
+				},
+			},
+			// Set TTL on span_attributes_keys to match signoz_spans table (15 days)
+			AlterTableModifyTTL{
+				Database: "signoz_traces",
+				Table:    "span_attributes_keys",
+				TTL:      "timestamp + INTERVAL 15 DAY",
+				Settings: ModifyTTLSettings{
+					MaterializeTTLAfterModify: false,
+				},
+			},
+			// Add timestamp column to distributed_span_attributes_keys table
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_span_attributes_keys",
+				Column: Column{
+					Name:    "timestamp",
+					Type:    DateTimeColumnType{},
+					Default: "toDateTime(now())",
+				},
+			},
+			// Set TTL on distributed_span_attributes_keys to match distributed_signoz_span table (15 days)
+			AlterTableModifyTTL{
+				Database: "signoz_traces",
+				Table:    "distributed_span_attributes_keys",
+				TTL:      "timestamp + INTERVAL 15 DAY",
+				Settings: ModifyTTLSettings{
+					MaterializeTTLAfterModify: false,
+				},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "span_attributes_keys",
+				Column: Column{
+					Name: "timestamp",
+				},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_span_attributes_keys",
+				Column: Column{
+					Name: "timestamp",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
This pull request adds a new migration to enhance the `span_attributes_keys` and `distributed_span_attributes_keys` tables in the traces database. The main goal is to introduce a `timestamp` column to both tables and set a time-to-live (TTL) policy, ensuring data retention aligns with related span tables.

Partially fixes: https://github.com/SigNoz/signoz-otel-collector/issues/663

Schema migration changes:

* Added a `timestamp` column with a default value to the `span_attributes_keys` table in the `signoz_traces` database.
* Set a TTL policy on the `span_attributes_keys` table to automatically expire records after 15 days using the new `timestamp` column.
* Added a `timestamp` column with a default value to the `distributed_span_attributes_keys` table in the `signoz_traces` database.
* Set a TTL policy on the `distributed_span_attributes_keys` table to automatically expire records after 15 days using the new `timestamp` column.
* Provided down migration steps to remove the `timestamp` columns from both tables if needed.