### PR TITLE
Fixed go-lint errors

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -267,6 +267,7 @@ func (m *MigrationManager) runCustomRetentionMigrationsForLogs(ctx context.Conte
 	return nil
 }
 
+//nolint:unused
 func (m *MigrationManager) runSquashedMigrationsForLogs(ctx context.Context) error {
 	m.logger.Info("Checking if should run squashed migrations for logs")
 	should, err := m.shouldRunSquashed(ctx, "signoz_logs")

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
 	"go.uber.org/zap"
 )
 

--- a/exporter/signozclickhousemeter/exporter_test.go
+++ b/exporter/signozclickhousemeter/exporter_test.go
@@ -26,7 +26,7 @@ func Benchmark_prepareBatchSum(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		exp.prepareBatch(context.Background(), metrics)
 	}
-	exp.Shutdown(context.Background())
+	_ = exp.Shutdown(context.Background())
 }
 
 func Test_prepareBatchSumWithNoRecordedValue(t *testing.T) {
@@ -57,7 +57,7 @@ func Test_prepareBatchSumWithNoRecordedValue(t *testing.T) {
 		assert.Equal(t, sample.unixMilli, curSample.unixMilli)
 		assert.Equal(t, sample.value, curSample.value)
 	}
-	exp.Shutdown(context.Background())
+	_ = exp.Shutdown(context.Background())
 }
 
 func Test_prepareBatchSumWithNan(t *testing.T) {
@@ -66,7 +66,7 @@ func Test_prepareBatchSumWithNan(t *testing.T) {
 	require.NoError(t, err)
 	batch := exp.prepareBatch(context.Background(), metrics)
 	assert.Equal(t, 0, len(batch.samples))
-	exp.Shutdown(context.Background())
+	_ = exp.Shutdown(context.Background())
 }
 
 func Test_shutdown(t *testing.T) {

--- a/exporter/signozclickhousemetrics/exporter.go
+++ b/exporter/signozclickhousemetrics/exporter.go
@@ -1071,7 +1071,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 			}
 		}
 		for k, v := range metrics {
-			stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(usage.TagTenantKey, k), tag.Upsert(usage.TagExporterIdKey, c.exporterID.String())}, ExporterSigNozSentMetricPoints.M(int64(v.Count)), ExporterSigNozSentMetricPointsBytes.M(int64(v.Size)))
+			_ = stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(usage.TagTenantKey, k), tag.Upsert(usage.TagExporterIdKey, c.exporterID.String())}, ExporterSigNozSentMetricPoints.M(int64(v.Count)), ExporterSigNozSentMetricPointsBytes.M(int64(v.Size)))
 		}
 		return statement.Send()
 	}

--- a/exporter/signozkafkaexporter/factory_test.go
+++ b/exporter/signozkafkaexporter/factory_test.go
@@ -139,7 +139,7 @@ func TestCreateMetricExporter(t *testing.T) {
 
 			// Clean up the producer if created
 			if tc.cleanup && exporter != nil {
-				exporter.Shutdown(context.Background())
+				_ = exporter.Shutdown(context.Background())
 			}
 		})
 	}
@@ -221,7 +221,7 @@ func TestCreateLogExporter(t *testing.T) {
 
 			// Clean up the producer if created
 			if tc.cleanup && exporter != nil {
-				exporter.Shutdown(context.Background())
+				_ = exporter.Shutdown(context.Background())
 			}
 		})
 	}
@@ -303,7 +303,7 @@ func TestCreateTraceExporter(t *testing.T) {
 
 			// Clean up the producer if created
 			if tc.cleanup && exporter != nil {
-				exporter.Shutdown(context.Background())
+				_ = exporter.Shutdown(context.Background())
 			}
 		})
 	}

--- a/opamp/config_test.go
+++ b/opamp/config_test.go
@@ -37,12 +37,12 @@ func TestParseConfig(t *testing.T) {
 func TestParseConfigAddsID(t *testing.T) {
 	// make a copy of the file
 	func() {
-		copy("./testdata/agent-id.yaml", "./testdata/agent-id-copy.yaml")
+		_ = copy("./testdata/agent-id.yaml", "./testdata/agent-id-copy.yaml")
 	}()
 
 	// restore the original file
 	defer func() {
-		copy("./testdata/agent-id-copy.yaml", "./testdata/agent-id.yaml")
+		_ = copy("./testdata/agent-id-copy.yaml", "./testdata/agent-id.yaml")
 		os.Remove("./testdata/agent-id-copy.yaml")
 	}()
 

--- a/opamp/helpers.go
+++ b/opamp/helpers.go
@@ -71,7 +71,7 @@ func WaitForEndpoint(endpoint string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	waitForPortToListen(port)
+	_ = waitForPortToListen(port)
 }
 
 // fileHash returns the SHA256 hash of the file at the given path.

--- a/opamp/server_client.go
+++ b/opamp/server_client.go
@@ -206,18 +206,18 @@ func (s *serverClient) initialNopConfig() ([]byte, error) {
 	}
 
 	if !k.Exists("receivers.nop") {
-		k.Set("receivers.nop", map[string]any{})
+		_ = k.Set("receivers.nop", map[string]any{})
 	}
 
 	if !k.Exists("exporters.nop") {
-		k.Set("exporters.nop", map[string]any{})
+		_ = k.Set("exporters.nop", map[string]any{})
 	}
 
 	for _, key := range k.Keys() {
 		// Delete all service.pipelines.*.receivers keys
 		if strings.HasPrefix(key, "service.pipelines.") && strings.HasSuffix(key, ".receivers") {
 			k.Delete(key)
-			k.Set(key, []any{"nop"})
+			_ = k.Set(key, []any{"nop"})
 		}
 
 		// delete the processors
@@ -228,7 +228,7 @@ func (s *serverClient) initialNopConfig() ([]byte, error) {
 		// delete the exporters
 		if strings.HasPrefix(key, "service.pipelines.") && strings.HasSuffix(key, ".exporters") {
 			k.Delete(key)
-			k.Set(key, []any{"nop"})
+			_ = k.Set(key, []any{"nop"})
 		}
 	}
 

--- a/pkg/parser/grok/config_test.go
+++ b/pkg/parser/grok/config_test.go
@@ -44,7 +44,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_from_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseFrom = signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					cfg.ParseFrom = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					return cfg
 				}(),
 			},
@@ -52,7 +52,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField("log")}}
+					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("log")}}
 					return cfg
 				}(),
 			},
@@ -68,7 +68,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "timestamp",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("timestamp_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("timestamp_field")}
 					newTime := signozstanzahelper.TimeParser{
 						LayoutType: "strptime",
 						Layout:     "%Y-%m-%d",
@@ -82,7 +82,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "severity",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("severity_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("severity_field")}
 					severityParser := signozstanzahelper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
 					mapping := map[string]interface{}{
@@ -109,7 +109,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.Pattern = "a=%{NOTSPACE:data}"
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("logger_name_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("logger_name_field")}
 					loggerNameParser := signozstanzahelper.NewScopeNameParser()
 					loggerNameParser.ParseFrom = parseField
 					cfg.ScopeNameParser = &loggerNameParser
@@ -120,7 +120,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_attributes",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewAttributeField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewAttributeField()}}
 					return p
 				}(),
 			},
@@ -128,7 +128,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_body",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}}
 					return p
 				}(),
 			},
@@ -136,7 +136,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_resource",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewResourceField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewResourceField()}}
 					return p
 				}(),
 			},

--- a/processor/signozlogspipelineprocessor/config_test.go
+++ b/processor/signozlogspipelineprocessor/config_test.go
@@ -31,11 +31,11 @@ func TestLoadConfig(t *testing.T) {
 					Builder: func() *regex.Config {
 						cfg := regex.NewConfig()
 						cfg.Regex = "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"
-						sevField := signozstanzaentry.Field{entry.NewAttributeField("sev")}
+						sevField := signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("sev")}
 						sevCfg := signozstanzahelper.NewSeverityConfig()
 						sevCfg.ParseFrom = &sevField
 						cfg.SeverityConfig = &sevCfg
-						timeField := signozstanzaentry.Field{entry.NewAttributeField("time")}
+						timeField := signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("time")}
 						timeCfg := signozstanzahelper.NewTimeParser()
 						timeCfg.Layout = "%Y-%m-%d %H:%M:%S"
 						timeCfg.ParseFrom = &timeField

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config.go
@@ -46,7 +46,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		return nil, err
 	}
 
-	if c.From == (signozstanzaentry.Field{entry.NewNilField()}) {
+	if c.From == (signozstanzaentry.Field{FieldInterface: entry.NewNilField()}) {
 		return nil, fmt.Errorf("copy: missing from field")
 	}
 

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config_test.go
@@ -20,7 +20,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "body_to_body",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 					cfg.To = entry.NewBodyField("key2")
 					return cfg
 				}(),
@@ -29,7 +29,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "body_to_attribute",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 					cfg.To = entry.NewAttributeField("key2")
 					return cfg
 				}(),
@@ -38,7 +38,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "attribute_to_resource",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{entry.NewAttributeField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("key")}
 					cfg.To = entry.NewResourceField("key2")
 					return cfg
 				}(),
@@ -47,7 +47,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "attribute_to_body",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{entry.NewAttributeField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("key")}
 					cfg.To = entry.NewBodyField("key2")
 					return cfg
 				}(),
@@ -56,7 +56,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "attribute_to_nested_attribute",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{entry.NewAttributeField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("key")}
 					cfg.To = entry.NewAttributeField("one", "two", "three")
 					return cfg
 				}(),
@@ -65,7 +65,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "resource_to_nested_resource",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.From = signozstanzaentry.Field{entry.NewResourceField("key")}
+					cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewResourceField("key")}
 					cfg.To = entry.NewResourceField("one", "two", "three")
 					return cfg
 				}(),

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/transformer_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/transformer_test.go
@@ -45,7 +45,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewBodyField("key2")
 				return cfg
 			}(),
@@ -67,7 +67,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("nested", "nestedkey")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("nested", "nestedkey")}
 				cfg.To = entry.NewBodyField("key2")
 				return cfg
 			}(),
@@ -89,7 +89,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewBodyField("nested", "key2")
 				return cfg
 			}(),
@@ -111,7 +111,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewAttributeField("key2")
 				return cfg
 			}(),
@@ -133,7 +133,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField()}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}
 				cfg.To = entry.NewAttributeField("one", "two")
 				return cfg
 			}(),
@@ -158,7 +158,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField()}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}
 				cfg.To = entry.NewResourceField("one", "two")
 				return cfg
 			}(),
@@ -183,7 +183,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{entry.NewAttributeField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("key")}
 				cfg.To = entry.NewBodyField("key2")
 				return cfg
 			}(),
@@ -210,7 +210,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{entry.NewAttributeField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("key")}
 				cfg.To = entry.NewResourceField("key2")
 				return cfg
 			}(),
@@ -231,7 +231,7 @@ func TestBuildAndProcess(t *testing.T) {
 			false,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewBodyField("nested")
 				return cfg
 			}(),
@@ -250,7 +250,7 @@ func TestBuildAndProcess(t *testing.T) {
 			true,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewAttributeField()
 				return cfg
 			}(),
@@ -262,7 +262,7 @@ func TestBuildAndProcess(t *testing.T) {
 			true,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{signozstanzaentry.NewBodyField("key")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("key")}
 				cfg.To = entry.NewResourceField()
 				return cfg
 			}(),
@@ -274,7 +274,7 @@ func TestBuildAndProcess(t *testing.T) {
 			true,
 			func() *Config {
 				cfg := NewConfig()
-				cfg.From = signozstanzaentry.Field{entry.NewAttributeField("nonexistentkey")}
+				cfg.From = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("nonexistentkey")}
 				cfg.To = entry.NewResourceField("key2")
 				return cfg
 			}(),

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/json/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/json/config_test.go
@@ -32,7 +32,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_from_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseFrom = signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					cfg.ParseFrom = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					return cfg
 				}(),
 			},
@@ -40,7 +40,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField("log")}}
+					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("log")}}
 					return cfg
 				}(),
 			},
@@ -48,7 +48,7 @@ func TestConfig(t *testing.T) {
 				Name: "timestamp",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("timestamp_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("timestamp_field")}
 					newTime := signozstanzahelper.TimeParser{
 						LayoutType: "strptime",
 						Layout:     "%Y-%m-%d",
@@ -62,7 +62,7 @@ func TestConfig(t *testing.T) {
 				Name: "severity",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("severity_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("severity_field")}
 					severityParser := signozstanzahelper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
 					mapping := map[string]any{
@@ -81,7 +81,7 @@ func TestConfig(t *testing.T) {
 				Expect: func() *Config {
 					cfg := NewConfig()
 					loggerNameParser := signozstanzahelper.NewScopeNameParser()
-					loggerNameParser.ParseFrom = signozstanzaentry.Field{signozstanzaentry.NewBodyField("logger_name_field")}
+					loggerNameParser.ParseFrom = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("logger_name_field")}
 					cfg.ScopeNameParser = &loggerNameParser
 					return cfg
 				}(),
@@ -90,7 +90,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_attributes",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewAttributeField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewAttributeField()}}
 					return p
 				}(),
 			},
@@ -98,7 +98,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_body",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}}
 					return p
 				}(),
 			},
@@ -106,7 +106,7 @@ func TestConfig(t *testing.T) {
 				Name: "parse_to_resource",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewResourceField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewResourceField()}}
 					return p
 				}(),
 			},
@@ -114,7 +114,7 @@ func TestConfig(t *testing.T) {
 				Name: "json_flattening",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewAttributeField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewAttributeField()}}
 					p.EnableFlattening = true
 					p.MaxFlatteningDepth = 4
 					p.EnablePaths = true

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/json/parser_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/json/parser_test.go
@@ -174,7 +174,7 @@ func TestParser(t *testing.T) {
 		{
 			"with_timestamp",
 			func(p *Config) {
-				parseFrom := signozstanzaentry.Field{entry.NewAttributeField("timestamp")}
+				parseFrom := signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("timestamp")}
 				p.TimeParser = &signozstanzahelper.TimeParser{
 					ParseFrom:  &parseFrom,
 					LayoutType: "epoch",
@@ -197,7 +197,7 @@ func TestParser(t *testing.T) {
 			"with_scope",
 			func(p *Config) {
 				p.ScopeNameParser = &signozstanzahelper.ScopeNameParser{
-					ParseFrom: signozstanzaentry.Field{entry.NewAttributeField("logger_name")},
+					ParseFrom: signozstanzaentry.Field{FieldInterface: entry.NewAttributeField("logger_name")},
 				}
 			},
 			&entry.Entry{

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/regex/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/regex/config_test.go
@@ -32,7 +32,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_from_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseFrom = signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					cfg.ParseFrom = signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					return cfg
 				}(),
 			},
@@ -40,7 +40,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField("log")}}
+					cfg.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("log")}}
 					return cfg
 				}(),
 			},
@@ -56,7 +56,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "timestamp",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("timestamp_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("timestamp_field")}
 					newTime := signozstanzahelper.TimeParser{
 						LayoutType: "strptime",
 						Layout:     "%Y-%m-%d",
@@ -70,7 +70,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "severity",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("severity_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("severity_field")}
 					severityParser := signozstanzahelper.NewSeverityConfig()
 					severityParser.ParseFrom = &parseField
 					mapping := map[string]any{
@@ -97,7 +97,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.Regex = "^Host=(?P<host>[^,]+), Logger=(?P<logger_name_field>.*)$"
-					parseField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("logger_name_field")}
+					parseField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("logger_name_field")}
 					loggerNameParser := signozstanzahelper.NewScopeNameParser()
 					loggerNameParser.ParseFrom = parseField
 					cfg.ScopeNameParser = &loggerNameParser
@@ -108,7 +108,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_attributes",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewAttributeField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewAttributeField()}}
 					return p
 				}(),
 			},
@@ -116,7 +116,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_body",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{signozstanzaentry.NewBodyField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}}
 					return p
 				}(),
 			},
@@ -124,7 +124,7 @@ func TestParserGoldenConfig(t *testing.T) {
 				Name: "parse_to_resource",
 				Expect: func() *Config {
 					p := NewConfig()
-					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{entry.NewResourceField()}}
+					p.ParseTo = signozstanzaentry.RootableField{Field: signozstanzaentry.Field{FieldInterface: entry.NewResourceField()}}
 					return p
 				}(),
 			},

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/severity/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/severity/config_test.go
@@ -30,7 +30,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "parse_from_simple",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					from := signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					from := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					cfg.ParseFrom = &from
 					return cfg
 				}(),
@@ -39,7 +39,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "parse_with_preset",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					from := signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					from := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					cfg.ParseFrom = &from
 					cfg.Preset = "http"
 					return cfg

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/severity/parser_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/severity/parser_test.go
@@ -205,8 +205,8 @@ func TestSeverityParser(t *testing.T) {
 		},
 	}
 
-	rootField := signozstanzaentry.Field{entry.NewBodyField()}
-	someField := signozstanzaentry.Field{entry.NewBodyField("some_field")}
+	rootField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField()}
+	someField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField("some_field")}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/time/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/time/config_test.go
@@ -30,7 +30,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "parse_strptime",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					from := signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					from := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					cfg.ParseFrom = &from
 					cfg.LayoutType = "strptime"
 					cfg.Layout = "%Y-%m-%d"
@@ -41,7 +41,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "parse_gotime",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					from := signozstanzaentry.Field{signozstanzaentry.NewBodyField("from")}
+					from := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("from")}
 					cfg.ParseFrom = &from
 					cfg.LayoutType = "gotime"
 					cfg.Layout = "2006-01-02"

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/time/parser_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/time/parser_test.go
@@ -244,8 +244,8 @@ func TestTimeParser(t *testing.T) {
 		},
 	}
 
-	rootField := signozstanzaentry.Field{signozstanzaentry.NewBodyField()}
-	someField := signozstanzaentry.Field{signozstanzaentry.NewBodyField("some_field")}
+	rootField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField()}
+	someField := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("some_field")}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -411,8 +411,8 @@ func TestTimeEpochs(t *testing.T) {
 		},
 	}
 
-	rootField := signozstanzaentry.Field{entry.NewBodyField()}
-	someField := signozstanzaentry.Field{entry.NewBodyField("some_field")}
+	rootField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField()}
+	someField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField("some_field")}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -473,8 +473,8 @@ func TestTimeErrors(t *testing.T) {
 		},
 	}
 
-	rootField := signozstanzaentry.Field{entry.NewBodyField()}
-	someField := signozstanzaentry.Field{entry.NewBodyField("some_field")}
+	rootField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField()}
+	someField := signozstanzaentry.Field{FieldInterface: entry.NewBodyField("some_field")}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/config_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/config_test.go
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 			{
 				Name: "spanid",
 				Expect: func() *Config {
-					parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_span_id")}
+					parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_span_id")}
 					cfg := signozstanzahelper.SpanIDConfig{}
 					cfg.ParseFrom = &parseFrom
 
@@ -42,7 +42,7 @@ func TestConfig(t *testing.T) {
 			{
 				Name: "traceid",
 				Expect: func() *Config {
-					parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_trace_id")}
+					parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_trace_id")}
 					cfg := signozstanzahelper.TraceIDConfig{}
 					cfg.ParseFrom = &parseFrom
 
@@ -54,7 +54,7 @@ func TestConfig(t *testing.T) {
 			{
 				Name: "trace_flags",
 				Expect: func() *Config {
-					parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_trace_flags_id")}
+					parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_trace_flags_id")}
 					cfg := signozstanzahelper.TraceFlagsConfig{}
 					cfg.ParseFrom = &parseFrom
 

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/parser_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/parser_test.go
@@ -46,7 +46,7 @@ func TestBuild(t *testing.T) {
 		{
 			"spanid",
 			func() (*Config, error) {
-				parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_span_id")}
+				parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_span_id")}
 				cfg := NewConfigWithID("test_id")
 				cfg.SpanID.ParseFrom = &parseFrom
 				return cfg, nil
@@ -56,7 +56,7 @@ func TestBuild(t *testing.T) {
 		{
 			"traceid",
 			func() (*Config, error) {
-				parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_trace_id")}
+				parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_trace_id")}
 				cfg := NewConfigWithID("test_id")
 				cfg.TraceID.ParseFrom = &parseFrom
 				return cfg, nil
@@ -66,7 +66,7 @@ func TestBuild(t *testing.T) {
 		{
 			"trace-flags",
 			func() (*Config, error) {
-				parseFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("trace-flags-field")}
+				parseFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("trace-flags-field")}
 				cfg := NewConfigWithID("test_id")
 				cfg.TraceFlags.ParseFrom = &parseFrom
 				return cfg, nil
@@ -120,9 +120,9 @@ func TestProcess(t *testing.T) {
 			"all",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				spanFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_span_id")}
-				traceFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("app_trace_id")}
-				flagsFrom := signozstanzaentry.Field{signozstanzaentry.NewBodyField("trace_flags_field")}
+				spanFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_span_id")}
+				traceFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("app_trace_id")}
+				flagsFrom := signozstanzaentry.Field{FieldInterface: signozstanzaentry.NewBodyField("trace_flags_field")}
 				cfg.SpanID.ParseFrom = &spanFrom
 				cfg.TraceID.ParseFrom = &traceFrom
 				cfg.TraceFlags.ParseFrom = &flagsFrom

--- a/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder.go
+++ b/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder.go
@@ -10,7 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
 )
 
 const (

--- a/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
+++ b/receiver/signozawsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
 )
 
 const (


### PR DESCRIPTION
This pull request primarily focuses on improving code quality and consistency by handling ignored return values, updating field initialization patterns, and making minor dependency adjustments. The most significant changes include explicitly ignoring function return values where appropriate, updating the construction of `Field` types for clarity and correctness, and aligning a dependency version.

**Code quality improvements:**

* Replaced direct calls to functions whose return values were previously ignored with assignments to `_`, making it explicit that the return value is intentionally not used. This change was applied across multiple test and helper files, such as `exporter/signozclickhousemeter/exporter_test.go`, `exporter/signozclickhousemetrics/exporter.go`, `exporter/signozkafkaexporter/factory_test.go`, `opamp/config_test.go`, `opamp/helpers.go`, and `opamp/server_client.go`. [[1]](diffhunk://#diff-d794d096e0c5dd4c8dd34c55679077855f0ec8235003ffaf60f75c95a96ac367L29-R29) [[2]](diffhunk://#diff-d794d096e0c5dd4c8dd34c55679077855f0ec8235003ffaf60f75c95a96ac367L60-R60) [[3]](diffhunk://#diff-d794d096e0c5dd4c8dd34c55679077855f0ec8235003ffaf60f75c95a96ac367L69-R69) [[4]](diffhunk://#diff-31f7ad7473d98eaafc2917fbdecca8c459334dc7f935d401a391d6058598489cL1074-R1074) [[5]](diffhunk://#diff-01bb47712db2289618a097cbc012f902042c2b1af1ecee7e12bbc6204c8cedd4L142-R142) [[6]](diffhunk://#diff-01bb47712db2289618a097cbc012f902042c2b1af1ecee7e12bbc6204c8cedd4L224-R224) [[7]](diffhunk://#diff-01bb47712db2289618a097cbc012f902042c2b1af1ecee7e12bbc6204c8cedd4L306-R306) [[8]](diffhunk://#diff-9f40dea3425cac752770afb46a2c17af3ba8870249fd2849d152f9052a3e729cL40-R45) [[9]](diffhunk://#diff-f3c9ef9ebe848dfb6c6b569783a4c2d1dcaecb358081cdb67d3a461c29389e8fL74-R74) [[10]](diffhunk://#diff-55b3684175cc520ae6dec4e2546d8541e52cdb54055e469b1940cca3baf1d621L209-R220) [[11]](diffhunk://#diff-55b3684175cc520ae6dec4e2546d8541e52cdb54055e469b1940cca3baf1d621L231-R231)

**Field initialization and configuration:**

* Updated the way `Field` and related types are constructed throughout the codebase to use the `FieldInterface` property explicitly. This affects various test and configuration files, ensuring consistency and correctness in field assignment, such as in `pkg/parser/grok/config_test.go`, `processor/signozlogspipelineprocessor/config_test.go`, `processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config.go`, and related test files. [[1]](diffhunk://#diff-90bf001bb2f10a12474a975076115727e8cdcc23f254155db61a25883b3d1702L47-R55) [[2]](diffhunk://#diff-90bf001bb2f10a12474a975076115727e8cdcc23f254155db61a25883b3d1702L71-R71) [[3]](diffhunk://#diff-90bf001bb2f10a12474a975076115727e8cdcc23f254155db61a25883b3d1702L85-R85) [[4]](diffhunk://#diff-90bf001bb2f10a12474a975076115727e8cdcc23f254155db61a25883b3d1702L112-R112) [[5]](diffhunk://#diff-90bf001bb2f10a12474a975076115727e8cdcc23f254155db61a25883b3d1702L123-R139) [[6]](diffhunk://#diff-47b56e8c3aa54f8f4ad14609649dbf13046a6ee97c05392af0bfb235e22ae9f5L34-R38) [[7]](diffhunk://#diff-1635a03e020fd7d45147cdd20a58d7b9e6938d1b50cbbefcef8e22c41a194933L49-R49) [[8]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L23-R23) [[9]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L32-R32) [[10]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L41-R41) [[11]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L50-R50) [[12]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L59-R59) [[13]](diffhunk://#diff-4c2805723653725eebb551a2a0f7d7385d8644ba8ec2f14dfe84d85d7b9911f7L68-R68) [[14]](diffhunk://#diff-56150bedd5c9ee0763d2d74de0360a792c369df84c722f1095a20bce2d2476fdL48-R48) [[15]](diffhunk://#diff-56150bedd5c9ee0763d2d74de0360a792c369df84c722f1095a20bce2d2476fdL70-R70) [[16]](diffhunk://#diff-56150bedd5c9ee0763d2d74de0360a792c369df84c722f1095a20bce2d2476fdL92-R92) [[17]](diffhunk://#diff-56150bedd5c9ee0763d2d74de0360a792c369df84c722f1095a20bce2d2476fdL114-R114) [[18]](diffhunk://#diff-56150bedd5c9ee0763d2d74de0360a792c369df84c722f1095a20bce2d2476fdL136-R136)

**Dependency update:**

* Downgraded the import of `go.opentelemetry.io/collector/semconv` from version `v1.27.0` to `v1.13.0` in `exporter/clickhousetracesexporter/clickhouse_exporter_v3.go`, possibly for compatibility reasons.

**Minor changes:**

* Added a `//nolint:unused` directive to suppress linter warnings for an unused function in `cmd/signozschemamigrator/schema_migrator/manager.go`.