### PR TITLE
chore(signozclickhousemetrics): move warn to debug

### DIFF
--- a/exporter/signozclickhousemetrics/exporter.go
+++ b/exporter/signozclickhousemetrics/exporter.go
@@ -311,7 +311,7 @@ func (c *clickhouseMetricsExporter) processGauge(batch *batch, metric pmetric.Me
 			value = dp.DoubleValue()
 		}
 		if math.IsNaN(value) {
-			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			continue
 		}
 		unixMilli := dp.Timestamp().AsTime().UnixMilli()
@@ -375,7 +375,7 @@ func (c *clickhouseMetricsExporter) processSum(batch *batch, metric pmetric.Metr
 			value = dp.DoubleValue()
 		}
 		if math.IsNaN(value) {
-			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			continue
 		}
 		unixMilli := dp.Timestamp().AsTime().UnixMilli()
@@ -579,7 +579,7 @@ func (c *clickhouseMetricsExporter) processHistogram(b *batch, metric pmetric.Me
 		// 5. bucket counts
 		// Check if any of the key float fields are NaN.
 		if math.IsNaN(dp.Sum()) || math.IsNaN(dp.Min()) || math.IsNaN(dp.Max()) {
-			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			continue
 		}
 		addSample(b, dp, countSuffix)
@@ -708,7 +708,7 @@ func (c *clickhouseMetricsExporter) processSummary(b *batch, metric pmetric.Metr
 		skip := false
 
 		if math.IsNaN(dp.Sum()) {
-			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			skip = true
 		}
 
@@ -717,7 +717,7 @@ func (c *clickhouseMetricsExporter) processSummary(b *batch, metric pmetric.Metr
 		for j := 0; j < quantiles.Len(); j++ {
 			q := quantiles.At(j)
 			if math.IsNaN(q.Value()) {
-				c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+				c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 				skip = true
 				break
 			}
@@ -888,7 +888,7 @@ func (c *clickhouseMetricsExporter) processExponentialHistogram(b *batch, metric
 		// 4. max
 		// 5. ddsketch
 		if math.IsNaN(dp.Sum()) || math.IsNaN(dp.Min()) || math.IsNaN(dp.Max()) {
-			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			continue
 		}
 		addSample(b, dp, countSuffix)


### PR DESCRIPTION
Moving NaN logs to debug. Its very noisy.