### PR TITLE
feat(manager): add a retry loop for no node coordination error

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -540,14 +540,14 @@ func (m *MigrationManager) getDistributedDDLQueue(ctx context.Context) ([]Distri
 				m.logger.Error("ClickHouse exception was received", zap.Any("exception", exception), zap.Int("attempt", i+1))
 				if exception.Code == 999 {
 					// An expection with No node was thrown while querying the distributed_ddl_queue. Retry the ddl queue again
-					if strings.Contains(exception.Error(), "No Node") {
+					if strings.Contains(exception.Error(), "No node") {
 						m.logger.Error("A retryable exception was received", zap.Error(err), zap.Int("attempt", i+1))
 						continue
 					}
 				}
 			}
 
-			if strings.Contains(err.Error(), "No Node") {
+			if strings.Contains(err.Error(), "No node") {
 				m.logger.Error("A retryable exception was received", zap.Error(err), zap.Int("attempt", i+1))
 				continue
 			}

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -532,6 +532,7 @@ func (m *MigrationManager) getDistributedDDLQueue(ctx context.Context) ([]Distri
 	var ddlQueue []DistributedDDLQueue
 	query := "SELECT entry, cluster, query, host, port, status, exception_code FROM system.distributed_ddl_queue WHERE status != 'Finished'"
 
+	// 10 attempts is an arbitrary number. If we don't get the DDL queue after 10 attempts, we give up.
 	for i := 0; i < 10; i++ {
 		if err := m.conn.Select(ctx, &ddlQueue, query); err != nil {
 			if exception, ok := err.(*clickhouse.Exception); ok {

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -532,7 +532,7 @@ func (m *MigrationManager) getDistributedDDLQueue(ctx context.Context) ([]Distri
 	var ddlQueue []DistributedDDLQueue
 	query := "SELECT entry, cluster, query, host, port, status, exception_code FROM system.distributed_ddl_queue WHERE status != 'Finished'"
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		if err := m.conn.Select(ctx, &ddlQueue, query); err != nil {
 			if exception, ok := err.(*clickhouse.Exception); ok {
 				if exception.Code == 999 {


### PR DESCRIPTION
#### Features

When clickhouse DDLWorker deletes the task before we query the distributed_ddl_queue, a error is thrown saying "No Node: Code: 999. Coordination::Exception: Coordination error: No node, path \/clickhouse\/signoz-clickhouse\/task_queue\/ddl\/query-0000001757."

We are adding a retry loop to prevent crashes of schema migrator when this happens