### PR TITLE
fix(schema-migrator): stop logging plain-text DSN credentials

### DIFF
--- a/cmd/signozschemamigrator/main.go
+++ b/cmd/signozschemamigrator/main.go
@@ -88,7 +88,13 @@ func registerSyncMigrate(cmd *cobra.Command) {
 			clusterName := cmd.Flags().Lookup("cluster-name").Value.String()
 			development := strings.ToLower(cmd.Flags().Lookup("dev").Value.String()) == "true"
 
-			logger.Info("Running migrations in sync mode", zap.String("dsn", dsn), zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
+			logger.Info("Running migrations in sync mode", zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
+
+			opts, err := clickhouse.ParseDSN(dsn)
+			if err != nil {
+				return fmt.Errorf("failed to parse dsn: %w", err)
+			}
+			logger.Info("Parsed DSN", zap.String("addr", strings.Join(opts.Addr, ",")), zap.String("db", opts.Auth.Database))
 
 			upVersions := []uint64{}
 			for _, version := range strings.Split(cmd.Flags().Lookup("up").Value.String(), ",") {
@@ -119,12 +125,6 @@ func registerSyncMigrate(cmd *cobra.Command) {
 			if len(upVersions) != 0 && len(downVersions) != 0 {
 				return fmt.Errorf("cannot provide both up and down migrations")
 			}
-
-			opts, err := clickhouse.ParseDSN(dsn)
-			if err != nil {
-				return fmt.Errorf("failed to parse dsn: %w", err)
-			}
-			logger.Info("Parsed DSN", zap.Any("opts", opts))
 
 			conn, err := clickhouse.Open(opts)
 			if err != nil {
@@ -186,7 +186,13 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 			clusterName := cmd.Flags().Lookup("cluster-name").Value.String()
 			development := strings.ToLower(cmd.Flags().Lookup("dev").Value.String()) == "true"
 
-			logger.Info("Running migrations in async mode", zap.String("dsn", dsn), zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
+			logger.Info("Running migrations in async mode", zap.Bool("replication", replicationEnabled), zap.String("cluster-name", clusterName))
+
+			opts, err := clickhouse.ParseDSN(dsn)
+			if err != nil {
+				return fmt.Errorf("failed to parse dsn: %w", err)
+			}
+			logger.Info("Parsed DSN", zap.String("addr", strings.Join(opts.Addr, ",")), zap.String("db", opts.Auth.Database))
 
 			upVersions := []uint64{}
 			for _, version := range strings.Split(cmd.Flags().Lookup("up").Value.String(), ",") {
@@ -217,12 +223,6 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 			if len(upVersions) != 0 && len(downVersions) != 0 {
 				return fmt.Errorf("cannot provide both up and down migrations")
 			}
-
-			opts, err := clickhouse.ParseDSN(dsn)
-			if err != nil {
-				return fmt.Errorf("failed to parse dsn: %w", err)
-			}
-			logger.Info("Parsed DSN", zap.Any("opts", opts))
 
 			conn, err := clickhouse.Open(opts)
 			if err != nil {


### PR DESCRIPTION
### Summary
This PR closes (https://github.com/SigNoz/signoz/issues/8985)
@Nageshbansal asked the issue creator if they wanted to submit a PR to fix it. They didn’t, so I opened the PR with the fix.

### Issue 
If we check **schema-migrator-sync** and **schema-migrator-async** logs in docker for the following cases:
1. When signoz is deployed by executing install.sh in signoz/deploy **[ok]**
```
{"L":"info","timestamp":"2025-10-29T04:58:02.076Z","C":"signozschemamigrator/main.go:91","M":"Running migrations in sync mode","dsn":"tcp://clickhouse:9000","replication":false,"cluster-name":"cluster"}
``` 

2. When signoz is Deployed with Helm directly as mentioned [here](https://signoz.io/docs/install/kubernetes/others/) or as mentioned in the **[issue]**

```
{"L":"info","timestamp":"2025-10-29T05:26:26.420Z","C":"signozschemamigrator/main.go:91","M":"Running migrations in sync mode","dsn":"tcp://admin:27ff0399-Password@signoz-clickhouse:9000","replication":false,"cluster-name":"cluster"}
``` 

**Note**: Here I have edited the password, but output contains full length password

3. Additionally in all cases 
```go
opts, err := clickhouse.ParseDSN(dsn)
if err != nil {
	return fmt.Errorf("failed to parse dsn: %w", err)
}
logger.Info("Parsed DSN", zap.Any("opts", opts))
```
Logs -> "M":"Parsed DSN","optsError":"json: unsupported type: func(context.Context, string) (net.Conn, error)"
```
{"L":"info","timestamp":"2025-10-29T05:26:26.420Z","C":"signozschemamigrator/main.go:127","M":"Parsed DSN","optsError":"json: unsupported type: func(context.Context, string) (net.Conn, error)"}
``` 

### FIX
For Both `registerSyncMigrate` and   `registerAsyncMigrate`.
1. Moved DSN parsing block up just below log (Running migrations)

2. Removed `zap.String("dsn", dsn)` from log (Running migrations)

3. Added `zap.String("addr", strings.Join(opts.Addr, ",")), zap.String("db", opts.Auth.Database)` to log(Parsed DSN)

This keeps logging limited to safe fields (addr, db) as show below 
```
{"L":"info","timestamp":"2025-10-29T15:24:49.979+0530","C":"signozschemamigrator/main.go:91","M":"Running migrations in sync mode","replication":false,"cluster-name":"cluster"}
{"L":"info","timestamp":"2025-10-29T15:24:49.979+0530","C":"signozschemamigrator/main.go:97","M":"Parsed DSN","addr":"signoz-clickhouse:9000","db":"signoz"}
``` 

### Alternate solution 
Implement a masking function
```go
maskedDsn := schema_migrator.maskDsn(dsn)
logger.Info("Running migrations in async mode", zap.String("dsn", maskedDsn), zap.Bool("replication", replicationEnabled),zap.String("cluster-name", clusterName))
``` 

Only catch here is if dsn provided by the user is not of a valid format then masking function will not mask it and return it as it is . `maskDsn()` will be setup in a new `utils.go`  in schema_migrator dir and will have `utils_test.go` (unit test) along with it.

