### PR TITLE
chore(metadataexporter): change log level from info to debug for limits

### DIFF
--- a/exporter/metadataexporter/exporter.go
+++ b/exporter/metadataexporter/exporter.go
@@ -507,14 +507,14 @@ func (e *metadataExporter) writeToStatementBatch(ctx context.Context, stmt drive
 	resourcesLimitCheckStart := time.Now()
 	// check max resources limit
 	if e.keyCache.ResourcesLimitExceeded(ctx, ds) {
-		e.set.Logger.Info("resource limit exceeded", zap.String("datasource", ds.String()), zap.Int("records", len(records)))
+		e.set.Logger.Debug("resource limit exceeded", zap.String("datasource", ds.String()), zap.Int("records", len(records)))
 		return 0, nil
 	}
 	resourcesLimitCheckDuration = time.Since(resourcesLimitCheckStart)
 
 	totalCardinalityLimitCheckStart := time.Now()
 	if e.keyCache.TotalCardinalityLimitExceeded(ctx, ds) {
-		e.set.Logger.Info("total cardinality limit exceeded", zap.String("datasource", ds.String()), zap.Int("records", len(records)))
+		e.set.Logger.Debug("total cardinality limit exceeded", zap.String("datasource", ds.String()), zap.Int("records", len(records)))
 		return 0, nil
 	}
 	totalCardinalityLimitCheckDuration = time.Since(totalCardinalityLimitCheckStart)


### PR DESCRIPTION
### Summary
change log level from info to debug for limits
