### PR TITLE
fix(processor): int64 detection in json unmarshalling

### DIFF
--- a/exporter/jsontypeexporter/exporter_test.go
+++ b/exporter/jsontypeexporter/exporter_test.go
@@ -136,16 +136,34 @@ func TestAnalyzePValue_EndToEndTypes(t *testing.T) {
 		"uninstall": false,
 	}
 
-	body := pcommon.NewValueEmpty()
-	require.NoError(t, body.FromRaw(input))
-
 	testCases := []struct {
 		name     string
+		input    map[string]any
 		config   *Config
 		expected map[string][]string
 	}{
 		{
+			name: "simple_datatype_test",
+			input: map[string]any{
+				"string": "hello",
+				"int": 123,
+				"float": 123.456,
+				"bool": true,
+			},
+			config: &Config{
+				MaxDepthTraverse:        utils.ToPointer(2),
+				MaxArrayElementsAllowed: utils.ToPointer(4),
+			},
+			expected: map[string][]string{
+				"string": {String},
+				"int": {Int64},
+				"float": {Float64},
+				"bool": {Bool},
+			},
+		},
+		{
 			name: "full_test",
+			input: input,
 			config: &Config{
 				MaxDepthTraverse:        utils.ToPointer(100),
 				MaxArrayElementsAllowed: utils.ToPointer(5),
@@ -200,6 +218,7 @@ func TestAnalyzePValue_EndToEndTypes(t *testing.T) {
 		},
 		{
 			name: "max_depth_traverse_test",
+			input: input,
 			config: &Config{
 				MaxDepthTraverse:        utils.ToPointer(2),
 				MaxArrayElementsAllowed: utils.ToPointer(4),
@@ -237,6 +256,9 @@ func TestAnalyzePValue_EndToEndTypes(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			exp.config = testCase.config
+			body := pcommon.NewValueEmpty()
+			require.NoError(t, body.FromRaw(testCase.input))
+
 			// Collect bitmasks via analyzePValue
 			typeSet := TypeSet{}
 			err := exp.analyzePValue(ctx, body, &typeSet)

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/config.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/config.go
@@ -7,6 +7,7 @@ import (
 
 	signozlogspipelinestanzaoperator "github.com/SigNoz/signoz-otel-collector/processor/signozlogspipelineprocessor/stanza/operator"
 	signozstanzahelper "github.com/SigNoz/signoz-otel-collector/processor/signozlogspipelineprocessor/stanza/operator/helper"
+	"github.com/bytedance/sonic"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
@@ -42,5 +43,6 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 
 	return &Processor{
 		TransformerOperator: transformerOperator,
+		Config:              sonic.Config{UseInt64: true},
 	}, nil
 }

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/transformer.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/transformer.go
@@ -14,6 +14,7 @@ import (
 
 type Processor struct {
 	signozstanzahelper.TransformerOperator
+	sonic.Config
 }
 
 // Process will parse an entry for JSON.
@@ -35,10 +36,12 @@ func (p *Processor) transform(entry *entry.Entry) error {
 		if !(strings.HasPrefix(unquoted, "{") && strings.HasSuffix(unquoted, "}")) {
 			return nil
 		}
-		err := sonic.Unmarshal([]byte(unquoted), &parsedValue)
+		dec := p.Config.Froze().NewDecoder(strings.NewReader(unquoted))
+		err := dec.Decode(&parsedValue)
 		if err != nil { // failed to marshal as JSON; return as is
 			return nil
 		}
+
 	// no need to cover other map types; check comment https://github.com/SigNoz/signoz-otel-collector/pull/584#discussion_r2042020882
 	case map[string]any:
 		parsedValue = v


### PR DESCRIPTION
## Pull Request

### Summary
This issue arise from default behavior of JSON Unmarshalling libs, these doesn't pinpoint Int64 values instead retain them as Float64, which in turns become a problem during jsontypeexporter records Float64 type and ClickHouse records Int64 creating a discrepancy resulting into failure of QB

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes SigNoz/engineering-pod#3732

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

I