### PR TITLE
fix: field key ingestion sql stmt

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/index_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations.go
@@ -27,7 +27,7 @@ var (
 
 	// non-string type: no lower(...), any non-String type
 	jsonNumberSubColumnIndexExprRe = regexp.MustCompile(
-		`assumeNotNull\(dynamicElement\((?P<expr>.+?),\s*'(?P<type>[^']+)'\)\)\)$`,
+		`assumeNotNull\(dynamicElement\((?P<expr>.+?),\s*'(?P<type>[^']+)'\)\)$`,
 	)
 )
 

--- a/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
@@ -145,7 +145,7 @@ func TestUnfoldJSONSubColumnIndexExpr(t *testing.T) {
 			errorSubstr: "invalid expression: dynamicElement(body.nested.path,'Float64')",
 		}, {
 			name:        "test-4",
-			expr:        "lower(assumeNotNull(dynamicElement(body.nested.`order-id`,'Int64')))",
+			expr:        "assumeNotNull(dynamicElement(body.nested.`order-id`,'Int64'))",
 			wantExpr:    "body.nested.`order-id`",
 			wantType:    "Int64",
 			wantError:   false,

--- a/exporter/metadataexporter/json_writer.go
+++ b/exporter/metadataexporter/json_writer.go
@@ -294,7 +294,7 @@ func (w *jsonMetadataWriter) Process(ctx context.Context, ld plog.Logs) error {
 
 // flushTypeSet writes all path-type records for the body source to distributed_json_path_types.
 func (w *jsonMetadataWriter) flushTypeSet(ctx context.Context, ta *typesAccumulator) error {
-	sql := fmt.Sprintf("INSERT INTO %s (signal, field_context, name, field_data_type, last_seen) VALUES (?, ?, ?, ?, ?)", distributedFieldKeysTable)
+	sql := fmt.Sprintf("INSERT INTO %s (signal, field_context, %s, %s, last_seen) VALUES (?, ?, ?, ?, ?)", distributedFieldKeysTable, constants.FieldKeysTableNameColumn, constants.FieldKeysTableDataTypeColumn)
 	stmt, err := w.conn.PrepareBatch(ctx, sql, driver.WithReleaseConnection())
 	if err != nil {
 		return fmt.Errorf("failed to prepare path types batch: %w", err)


### PR DESCRIPTION
## Pull Request

### Summary
This PR tackles 2 issues
- Wrong stmt generation for path ingestion in field_keys table
- UnfoldJSONSubColumnIndexExpr failing with Int64


### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

