### PR TITLE
fix: add normalised fields to the metadata for instrumentation scope

### DIFF
--- a/exporter/clickhousetracesexporter/schema-signoz.go
+++ b/exporter/clickhousetracesexporter/schema-signoz.go
@@ -233,7 +233,7 @@ func NewInstrumentationScope(scope pcommon.InstrumentationScope) Instrumentation
 }
 
 func (s InstrumentationScope) GetSpanAttributes() []SpanAttribute {
-	scopeFields := map[string]string{"scope.name": s.Name, "scope.version": s.Version}
+	scopeFields := map[string]string{"name": s.Name, "version": s.Version}
 	maps.Copy(scopeFields, s.Attributes)
 
 	spanAttrs := make([]SpanAttribute, 0, len(s.Attributes)+len(scopeFields))


### PR DESCRIPTION
## Pull Request

### Summary
Earlier we had added the trace instrumentation scope fields in attribute key table for name and version which included the context as well assuming that we'll restrict the querying to not normalize `scope.version` and `scope.name` to `version` and `name` for readability (see https://github.com/SigNoz/signoz-otel-collector/pull/811). But it seems unnecessary to handle the scope fields differently instead of treating them like every other attribute.

TRD: https://www.notion.so/signoz/Support-for-instrumentation-scope-fields-in-traces-364fcc6bcd1980cba15cd322d5dd7fc9?v=2a7fcc6bcd198049b122000c4ff33372&source=copy_link

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes https://github.com/SigNoz/signoz/issues/5319

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No