### PR TITLE
fix(signozlogspipelineprocessor): remove per-entry goroutine fan-out in ProcessLogs

### DIFF
--- a/processor/signozlogspipelineprocessor/processor.go
+++ b/processor/signozlogspipelineprocessor/processor.go
@@ -5,8 +5,6 @@ package signozlogspipelineprocessor
 import (
 	"context"
 	"encoding/binary"
-	"math"
-	"runtime"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -16,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	_ "github.com/SigNoz/signoz-otel-collector/pkg/parser/grok" // ensure grok parser gets registered.
 )
@@ -33,16 +30,10 @@ func newLogsPipelineProcessor(
 		return nil, err
 	}
 
-	concurrency := int(math.Max(1, float64(runtime.GOMAXPROCS(0))))
-
-	telemetrySettings.Logger.Info("logspipeline concurrency set to ", zap.Int("num", concurrency))
-
 	return &logsPipelineProcessor{
 		telemetrySettings: telemetrySettings,
-
-		limiter:         make(chan struct{}, concurrency),
-		processorConfig: processorConfig,
-		stanzaPipeline:  stanzaPipeline,
+		processorConfig:   processorConfig,
+		stanzaPipeline:    stanzaPipeline,
 	}, nil
 }
 
@@ -52,7 +43,6 @@ type logsPipelineProcessor struct {
 	processorConfig *Config
 	stanzaPipeline  *pipeline.DirectedPipeline
 	firstOp         operator.Operator
-	limiter         chan struct{}
 	shutdownFns     []component.ShutdownFunc
 }
 
@@ -93,33 +83,15 @@ func (p *logsPipelineProcessor) Shutdown(ctx context.Context) error {
 }
 
 func (p *logsPipelineProcessor) ProcessLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
-	p.telemetrySettings.Logger.Debug(
-		"logsPipelineProcessor received logs",
-		zap.Any("logs", ld),
-	)
+	p.telemetrySettings.Logger.Debug("logsPipelineProcessor received logs", zap.Any("logs", ld))
 
 	entries := plogToEntries(ld)
 
-	process := func(ctx context.Context, entry *entry.Entry) {
-		if err := p.firstOp.Process(ctx, entry); err != nil {
+	for _, e := range entries {
+		if err := p.firstOp.Process(ctx, e); err != nil {
 			p.telemetrySettings.Logger.Error("processor encountered an issue with the pipeline", zap.Error(err))
 		}
 	}
-
-	group, groupCtx := errgroup.WithContext(ctx)
-	for _, entry := range entries {
-		p.limiter <- struct{}{}
-		group.Go(func() error {
-			defer func() {
-				<-p.limiter
-			}()
-			process(groupCtx, entry)
-			return nil // not returning error to avoid cancelling groupCtx
-		})
-	}
-
-	// wait for the group execution
-	_ = group.Wait()
 
 	// All stanza ops supported by logs pipelines work synchronously and
 	// they modify the *entry.Entry passed to them in-place.
@@ -131,21 +103,22 @@ func (p *logsPipelineProcessor) ProcessLogs(ctx context.Context, ld plog.Logs) (
 
 // Helpers below have been brought in as is from stanza adapter for logstransform
 func plogToEntries(src plog.Logs) []*entry.Entry {
-	result := []*entry.Entry{}
+	result := make([]*entry.Entry, 0, src.LogRecordCount())
 	for rlIdx := 0; rlIdx < src.ResourceLogs().Len(); rlIdx++ {
 		resourceLogs := src.ResourceLogs().At(rlIdx)
 
 		for slIdx := 0; slIdx < resourceLogs.ScopeLogs().Len(); slIdx++ {
 			scopeLogs := resourceLogs.ScopeLogs().At(slIdx)
+			scopeName := scopeLogs.Scope().Name()
 
 			for lrIdx := 0; lrIdx < scopeLogs.LogRecords().Len(); lrIdx++ {
 				record := scopeLogs.LogRecords().At(lrIdx)
-				entry := entry.Entry{}
-				entry.ScopeName = scopeLogs.Scope().Name()
-				// each entry has separate reference for Resource Tags since these're used in processor, Resource tags can be transformed based on user's pipelines
-				entry.Resource = resourceLogs.Resource().Attributes().AsRaw()
-				convertFrom(record, &entry)
-				result = append(result, &entry)
+				e := entry.Entry{ScopeName: scopeName}
+				// each entry has a separate Resource map: operators like `remove`
+				// can delete keys on Resource per record, so the map must not be shared.
+				e.Resource = resourceLogs.Resource().Attributes().AsRaw()
+				convertFrom(record, &e)
+				result = append(result, &e)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Removes the per-log-entry goroutine fan-out in `ProcessLogs` (introduced in #641) and reverts to a serial processing loop. Profiling on a production-like workload (v0.129.6 / b841a0b, captured 2026-05-15) showed the fan-out costs **~10% of total collector CPU** in `errgroup`/goroutine-spawn overhead, with no measurable throughput gain because each spawned goroutine runs the same stanza pipeline serially through a shared `firstOp.Process` call. Also tidies up two allocation hotspots in `plogToEntries` flagged by the same profile.

Net change: **+13 / -40 lines**, single file.

## Profile evidence

Production-like workload, signoz-otel-collector @ v0.129.6, logs pipeline enabled, ~3.46 cores busy:

| Symbol (cumulative) | Time | % of total CPU |
|---|---|---|
| `golang.org/x/sync/errgroup.(*Group).add.func1` | 13.10 s | **10.2%** |
| `signozlogspipelineprocessor.(*logsPipelineProcessor).ProcessLogs.func2` | 13.06 s | 10.2% |
| `pcommon.Map.Range` (cum, in `plogToEntries`) | 4.31 s | 3.4% |

The first two entries are the goroutine spawn/limiter/`errgroup` overhead. After this PR they disappear from the profile entirely. Expected savings on the captured workload: ~10–12% of total CPU, plus the GC pressure that goes with allocating `errgroup` internals per record.

## Changes

1. `ProcessLogs`: replace the `errgroup`-driven per-entry fan-out with a serial `for _, e := range entries` loop. Drops `limiter`, `process` closure, `errgroup.WithContext`, and the per-iteration `group.Go(...)` spawn.
2. Remove `limiter chan struct{}` field from `logsPipelineProcessor`, the `concurrency`/`GOMAXPROCS` calculation in `newLogsPipelineProcessor`, and the now-unused `math`, `runtime`, `errgroup` imports.
3. `plogToEntries`:
   - Preallocate `result` slice using `src.LogRecordCount()`.
   - Hoist `scopeLogs.Scope().Name()` out of the per-record loop into a per-`ScopeLogs` local.
   - Keep `Resource.AsRaw()` per-record. The `remove` operator (`stanza/operator/operators/remove/transformer.go:39`) can delete keys on `entry.Resource` when configured with a `resource.x` field, so sharing the Resource map across entries would corrupt them. This is documented in an updated comment.
4. Collapse the `Logger.Debug` call to a single line for consistency.

## Trade-off

Intra-`ProcessLogs` parallelism is removed. This matches the pre-#641 design that was in place for years and is the right trade for the workload evidence here. For users who need more logs-pipeline throughput, the OTel-idiomatic path is multiple batchprocessor shards or multiple collector replicas rather than a per-entry fan-out inside a single `ProcessLogs` call. A future PR could move to `operator.ProcessBatch` semantics — every operator already implements `ProcessBatch` — to get coarser-grained parallelism without the per-entry spawn cost.

#641 closed `SigNoz/engineering-pod#2384` and `#2574`; those should be revisited if their root cause was throughput-related, since the implementation that closed them did not actually deliver throughput on this workload.

## Test plan

- [x] `go test ./processor/signozlogspipelineprocessor/... -race -count=1` — all packages pass
- [x] `go build ./processor/signozlogspipelineprocessor/` — clean
- [ ] Staging deploy: capture a 30 s CPU profile with the logs pipeline active; confirm `errgroup.Group.add.func1` is no longer in the top CPU consumers
- [ ] Staging deploy: confirm trace ingestion throughput recovers when both pipelines are active on the same host