### PR TITLE
fix(metering): stop counting exponential histogram metrics in meter

### DIFF
--- a/pkg/metering/v1/metrics.go
+++ b/pkg/metering/v1/metrics.go
@@ -99,27 +99,11 @@ func (meter *metrics) CountPerResource(rmd pmetric.ResourceMetrics) int {
 				}
 				count += subCount
 			case pmetric.MetricTypeExponentialHistogram:
-				// we haven't enabled this metric type on Cloud since we don't know how to bill this
-				// If we use the following logic, it will explode the samples count
-				// However, for the sake of completeness, following the same logic as ExplicitBucketHistogram
-				// TODO(srikanthccv): Update this when we support this metric type on Cloud
-				subCount := 0
-				for i := 0; i < metric.ExponentialHistogram().DataPoints().Len(); i++ {
-					// each bucket of positive and negative is treated as separate sample
-					subCount += metric.ExponentialHistogram().DataPoints().At(i).Negative().BucketCounts().Len() +
-						metric.ExponentialHistogram().DataPoints().At(i).Positive().BucketCounts().Len()
-					subCount += 1 // count metric
-					if metric.ExponentialHistogram().DataPoints().At(i).HasSum() {
-						subCount += 1
-					}
-					if metric.ExponentialHistogram().DataPoints().At(i).HasMin() {
-						subCount += 1
-					}
-					if metric.ExponentialHistogram().DataPoints().At(i).HasMax() {
-						subCount += 1
-					}
-				}
-				count += subCount
+				// Intentionally not counted. Exp histograms aren't billable on Cloud yet,
+				// and counting each bucket as a sample would explode the count.
+				// Kept consistent with the signozclickhousemetrics exporter's writeExpHist,
+				// which also does not count these toward usage.
+				// TODO(srikanthccv): revisit when exp histograms are supported on Cloud.
 			}
 		}
 	}

--- a/pkg/metering/v1/metrics_test.go
+++ b/pkg/metering/v1/metrics_test.go
@@ -67,11 +67,8 @@ func TestMetrics_CountExponentialHistogramMetrics(t *testing.T) {
 
 	meter := NewMetrics(zap.NewNop())
 
-	// 6 data points * 20 buckets = 120
-	// 120 negative + 120 positive = 240
-	// 6 data points * 4 (sum,count,min,max) metrics = 24
-	// total -> 240 + 24 = 264
-	assert.Equal(t, 264, meter.Count(md))
+	// exponential histograms are intentionally not counted
+	assert.Equal(t, 0, meter.Count(md))
 }
 
 func TestMetrics_CountSummaryMetrics(t *testing.T) {


### PR DESCRIPTION
## Pull Request

### Summary
Stop counting **ExponentialHistogram** metrics in the meter connector. Previously `CountPerResource` in `pkg/metering/v1/metrics.go` counted each exp histogram bucket as a sample; now it counts 0, matching the exporter's `writeExpHist` path which never counted them. Test updated to assert 0.

### Related Issues
Closes https://github.com/SigNoz/platform-pod/issues/2345

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No