### PR TITLE
feat(metering): write real sample timestamp instead of rounding to the hour

### DIFF
--- a/exporter/signozclickhousemeter/exporter.go
+++ b/exporter/signozclickhousemeter/exporter.go
@@ -176,7 +176,6 @@ func (c *clickhouseMeterExporter) writeBatch(ctx context.Context, batch *batch) 
 	defer statement.Close()
 
 	for _, sample := range batch.samples {
-		roundedUnixMilli := sample.unixMilli / 3600000 * 3600000
 		err = statement.Append(
 			sample.temporality.String(),
 			sample.metricName,
@@ -186,7 +185,7 @@ func (c *clickhouseMeterExporter) writeBatch(ctx context.Context, batch *batch) 
 			sample.isMonotonic,
 			sample.labels,
 			sample.fingerprint,
-			roundedUnixMilli,
+			sample.unixMilli,
 			sample.value,
 		)
 		if err != nil {


### PR DESCRIPTION
## Pull Request

### Summary
Write the real `sample.unixMilli` in the `signozclickhousemeter` exporter instead of flooring it to the top of the hour, preserving true sample timestamps in `signoz_meter.samples`.

### Related Issues
Closes https://github.com/SigNoz/platform-pod/issues/2297

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

The collector does marginally less work (drops one arithmetic op per row). Row count, ingestion rate, CPU, memory, and network are unchanged.