### PR TITLE
feat(signozclickhousemeter): support writing gauge metrics to the meter samples table

### DIFF
--- a/exporter/signozclickhousemeter/exporter.go
+++ b/exporter/signozclickhousemeter/exporter.go
@@ -127,6 +127,53 @@ func (c *clickhouseMeterExporter) processSum(batch *batch, metric pmetric.Metric
 	}
 }
 
+// processGauge processes gauge metrics
+func (c *clickhouseMeterExporter) processGauge(batch *batch, metric pmetric.Metric, resourceFingerprint, scopeFingerprint *pkgfingerprint.Fingerprint) {
+	name := metric.Name()
+	desc := metric.Description()
+	unit := metric.Unit()
+	typ := metric.Type()
+	// gauge metrics do not have a temporality
+	temporality := pmetric.AggregationTemporalityUnspecified
+	// there is no monotonicity for gauge metrics
+	isMonotonic := false
+
+	resourceFingerprintMap := resourceFingerprint.AttributesAsMap()
+	scopeFingerprintMap := scopeFingerprint.AttributesAsMap()
+
+	for i := 0; i < metric.Gauge().DataPoints().Len(); i++ {
+		dp := metric.Gauge().DataPoints().At(i)
+		var value float64
+		switch dp.ValueType() {
+		case pmetric.NumberDataPointValueTypeInt:
+			value = float64(dp.IntValue())
+		case pmetric.NumberDataPointValueTypeDouble:
+			value = dp.DoubleValue()
+		}
+		if math.IsNaN(value) {
+			c.logger.Warn(NanDetectedErrMsg, zap.String("metric_name", name))
+			continue
+		}
+		unixMilli := dp.Timestamp().AsTime().UnixMilli()
+		fingerprint := pkgfingerprint.NewFingerprint(pkgfingerprint.PointFingerprintType, scopeFingerprint.Hash(), dp.Attributes(), map[string]string{
+			"__temporality__": temporality.String(),
+		})
+		fingerprintMap := fingerprint.AttributesAsMap()
+		batch.addSample(&sample{
+			temporality: temporality,
+			metricName:  name,
+			fingerprint: fingerprint.HashWithName(name),
+			unixMilli:   unixMilli,
+			value:       value,
+			description: desc,
+			unit:        unit,
+			typ:         typ,
+			isMonotonic: isMonotonic,
+			labels:      pkgfingerprint.NewLabelsAsJSONString(name, fingerprintMap, scopeFingerprintMap, resourceFingerprintMap),
+		})
+	}
+}
+
 func (c *clickhouseMeterExporter) prepareBatch(_ context.Context, md pmetric.Metrics) *batch {
 	batch := newBatch()
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
@@ -143,6 +190,8 @@ func (c *clickhouseMeterExporter) prepareBatch(_ context.Context, md pmetric.Met
 			for k := 0; k < sm.Metrics().Len(); k++ {
 				metric := sm.Metrics().At(k)
 				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					c.processGauge(batch, metric, resourceFingerprint, scopeFingerprint)
 				case pmetric.MetricTypeSum:
 					c.processSum(batch, metric, resourceFingerprint, scopeFingerprint)
 				default:

--- a/exporter/signozclickhousemeter/exporter_test.go
+++ b/exporter/signozclickhousemeter/exporter_test.go
@@ -72,6 +72,51 @@ func Test_prepareBatchSumWithNan(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func Test_prepareBatchGaugeWithNoRecordedValue(t *testing.T) {
+	metrics := pmetricsgen.GenerateGaugeMetrics(1, 1, 1, 1, 1, 0, 1)
+	exp, err := NewClickHouseExporter(zap.NewNop(), &Config{DSN: "tcp://localhost:9000?database=default"})
+	require.NoError(t, err)
+	batch := exp.prepareBatch(context.Background(), metrics)
+	assert.NotNil(t, batch)
+	expectedSamples := []sample{
+		{
+			temporality: pmetric.AggregationTemporalityUnspecified,
+			metricName:  "system.memory.usage0",
+			unixMilli:   1727286182000,
+			value:       0,
+			description: "memory usage of the host",
+			unit:        "bytes",
+			typ:         pmetric.MetricTypeGauge,
+			isMonotonic: false,
+			labels:      "{\"__name__\":\"system.memory.usage0\",\"__scope.name__\":\"go.signoz.io/app/reader\",\"__scope.schema_url__\":\"scope.schema_url\",\"__scope.version__\":\"1.0.0\",\"__temporality__\":\"Unspecified\",\"gauge.attr_0\":\"1\",\"resource.attr_0\":\"value0\",\"scope.attr_0\":\"value0\"}",
+		},
+	}
+	assert.Equal(t, len(expectedSamples), len(batch.samples))
+
+	for idx, sample := range expectedSamples {
+		curSample := batch.samples[idx]
+		assert.Equal(t, sample.temporality, curSample.temporality)
+		assert.Equal(t, sample.metricName, curSample.metricName)
+		assert.Equal(t, sample.unixMilli, curSample.unixMilli)
+		assert.Equal(t, sample.value, curSample.value)
+		assert.Equal(t, sample.typ, curSample.typ)
+		assert.Equal(t, sample.isMonotonic, curSample.isMonotonic)
+		assert.Equal(t, sample.labels, curSample.labels)
+	}
+	err = exp.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
+func Test_prepareBatchGaugeWithNan(t *testing.T) {
+	metrics := pmetricsgen.GenerateGaugeMetrics(1, 1, 1, 1, 1, 1, 0)
+	exp, err := NewClickHouseExporter(zap.NewNop(), &Config{DSN: "tcp://localhost:9000?database=default"})
+	require.NoError(t, err)
+	batch := exp.prepareBatch(context.Background(), metrics)
+	assert.Equal(t, 0, len(batch.samples))
+	err = exp.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
 func Test_shutdown(t *testing.T) {
 	conn, err := cmock.NewClickHouseNative(nil)
 	if err != nil {


### PR DESCRIPTION
## Pull Request

### Summary
Add gauge metric support to the `signozclickhousemeter` exporter. It only handled `Sum` metrics before — gauges were dropped with an "unknown metric type" warning. This adds a `processGauge` path (mirrors `processSum`, writes with `temporality=Unspecified` and `is_monotonic=false`, skips NaN) and routes `MetricTypeGauge` to it. Includes unit tests.

### Related Issues
Closes https://github.com/SigNoz/platform-pod/issues/2297

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No