### PR TITLE
feat(trace-json): store trace attributes as json

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/index_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations.go
@@ -383,3 +383,7 @@ func JSONPathsIndexExpr(column string) string {
 func JSONFullTextIndexExpr(column string) string {
 	return fmt.Sprintf("lower(toString(%s))", column)
 }
+
+func JSONValuesIndexExpr(column string) string {
+	return fmt.Sprintf("JSONAllValues(%s)", column)
+}

--- a/cmd/signozschemamigrator/schema_migrator/index_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations.go
@@ -383,7 +383,3 @@ func JSONPathsIndexExpr(column string) string {
 func JSONFullTextIndexExpr(column string) string {
 	return fmt.Sprintf("lower(toString(%s))", column)
 }
-
-func JSONValuesIndexExpr(column string) string {
-	return fmt.Sprintf("JSONAllValues(%s)", column)
-}

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1184,8 +1184,23 @@ var TracesMigrations = []SchemaMigrationRecord{
 				},
 				After: &Column{Name: "attributes_bool"},
 			},
+			AlterTableAddIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index: Index{
+					Name:        "attributes_paths_tokenbf",
+					Expression:  JSONPathsIndexExpr("attributes"),
+					Type:        "tokenbf_v1(1024, 2, 0)",
+					Granularity: 1,
+				},
+			},
 		},
 		DownItems: []Operation{
+			AlterTableDropIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index:    Index{Name: "attributes_paths_tokenbf"},
+			},
 			AlterTableDropColumn{
 				Database: "signoz_traces",
 				Table:    "distributed_signoz_index_v3",

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1161,4 +1161,71 @@ var TracesMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1011,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column: Column{
+					Name:  "attributes",
+					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer(uint(0))},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes_bool"},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column: Column{
+					Name:  "attributes",
+					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer(uint(0))},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes_bool"},
+			},
+			AlterTableAddIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index: Index{
+					Name:        "attributes_paths_tokenbf",
+					Expression:  JSONPathsIndexExpr("attributes"),
+					Type:        "tokenbf_v1(1024, 2, 0)",
+					Granularity: 1,
+				},
+			},
+			AlterTableAddIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index: Index{
+					Name:        "attributes_vals_ngrambf",
+					Expression:  JSONValuesIndexExpr("attributes"),
+					Type:        "ngrambf_v1(4, 5000, 2, 0)",
+					Granularity: 1,
+				},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index:    Index{Name: "attributes_vals_ngrambf"},
+			},
+			AlterTableDropIndex{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Index:    Index{Name: "attributes_paths_tokenbf"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column:   Column{Name: "attributes"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column:   Column{Name: "attributes"},
+			},
+		},
+	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1184,38 +1184,8 @@ var TracesMigrations = []SchemaMigrationRecord{
 				},
 				After: &Column{Name: "attributes_bool"},
 			},
-			AlterTableAddIndex{
-				Database: "signoz_traces",
-				Table:    "signoz_index_v3",
-				Index: Index{
-					Name:        "attributes_paths_tokenbf",
-					Expression:  JSONPathsIndexExpr("attributes"),
-					Type:        "tokenbf_v1(1024, 2, 0)",
-					Granularity: 1,
-				},
-			},
-			AlterTableAddIndex{
-				Database: "signoz_traces",
-				Table:    "signoz_index_v3",
-				Index: Index{
-					Name:        "attributes_vals_ngrambf",
-					Expression:  JSONFullTextIndexExpr("attributes"),
-					Type:        "ngrambf_v1(4, 5000, 2, 0)",
-					Granularity: 1,
-				},
-			},
 		},
 		DownItems: []Operation{
-			AlterTableDropIndex{
-				Database: "signoz_traces",
-				Table:    "signoz_index_v3",
-				Index:    Index{Name: "attributes_vals_ngrambf"},
-			},
-			AlterTableDropIndex{
-				Database: "signoz_traces",
-				Table:    "signoz_index_v3",
-				Index:    Index{Name: "attributes_paths_tokenbf"},
-			},
 			AlterTableDropColumn{
 				Database: "signoz_traces",
 				Table:    "distributed_signoz_index_v3",

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1172,6 +1172,12 @@ var TracesMigrations = []SchemaMigrationRecord{
 					{Name: "object_shared_data_serialization_version", Value: "'advanced'"},
 				},
 			},
+		},
+		DownItems: []Operation{},
+	},
+	{
+		MigrationID: 1012,
+		UpItems: []Operation{
 			AlterTableAddColumn{
 				Database: "signoz_traces",
 				Table:    "signoz_index_v3",
@@ -1192,6 +1198,23 @@ var TracesMigrations = []SchemaMigrationRecord{
 				},
 				After: &Column{Name: "attributes_bool"},
 			},
+		},
+		DownItems: []Operation{
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column:   Column{Name: "attributes"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column:   Column{Name: "attributes"},
+			},
+		},
+	},
+	{
+		MigrationID: 1013,
+		UpItems: []Operation{
 			AlterTableAddIndex{
 				Database: "signoz_traces",
 				Table:    "signoz_index_v3",
@@ -1208,16 +1231,6 @@ var TracesMigrations = []SchemaMigrationRecord{
 				Database: "signoz_traces",
 				Table:    "signoz_index_v3",
 				Index:    Index{Name: "attributes_paths_tokenbf"},
-			},
-			AlterTableDropColumn{
-				Database: "signoz_traces",
-				Table:    "distributed_signoz_index_v3",
-				Column:   Column{Name: "attributes"},
-			},
-			AlterTableDropColumn{
-				Database: "signoz_traces",
-				Table:    "signoz_index_v3",
-				Column:   Column{Name: "attributes"},
 			},
 		},
 	},

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1199,7 +1199,7 @@ var TracesMigrations = []SchemaMigrationRecord{
 				Table:    "signoz_index_v3",
 				Index: Index{
 					Name:        "attributes_vals_ngrambf",
-					Expression:  JSONValuesIndexExpr("attributes"),
+					Expression:  JSONFullTextIndexExpr("attributes"),
 					Type:        "ngrambf_v1(4, 5000, 2, 0)",
 					Granularity: 1,
 				},

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1164,6 +1164,14 @@ var TracesMigrations = []SchemaMigrationRecord{
 	{
 		MigrationID: 1011,
 		UpItems: []Operation{
+			AlterTableModifySettings{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Settings: TableSettings{
+					{Name: "object_serialization_version", Value: "'v3'"},
+					{Name: "object_shared_data_serialization_version", Value: "'advanced'"},
+				},
+			},
 			AlterTableAddColumn{
 				Database: "signoz_traces",
 				Table:    "signoz_index_v3",

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations_test.go
@@ -22,6 +22,9 @@ func TestTracesMigrationsExactNature(t *testing.T) {
 			TracesMigrations[6],
 			TracesMigrations[7],
 			TracesMigrations[8],
+			TracesMigrations[11],
+			TracesMigrations[12],
+			TracesMigrations[13],
 		},
 		[]SchemaMigrationRecord{
 			TracesMigrations[1], // 1001 (async)

--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -56,6 +56,7 @@ const (
 		attributes_string,
 		attributes_number,
 		attributes_bool,
+		attributes,
 		resources_string,
 		resource,
 		scope,
@@ -72,6 +73,7 @@ const (
 		has_error,
 		is_remote
 		) VALUES (
+			?,
 			?,
 			?,
 			?,

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/pkg/metering"
+	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/usage"
 	"github.com/SigNoz/signoz-otel-collector/utils"
 	"github.com/SigNoz/signoz-otel-collector/utils/fingerprint"
@@ -239,20 +239,6 @@ func (attrMap *attributesData) add(key string, value pcommon.Value) {
 	attrMap.SpanAttributes = append(attrMap.SpanAttributes, spanAttribute)
 }
 
-func (attrMap *attributesData) toAttributes() map[string]any {
-	result := make(map[string]any, len(attrMap.StringMap)+len(attrMap.NumberMap)+len(attrMap.BoolMap))
-	for k, v := range attrMap.StringMap {
-		result[k] = v
-	}
-	for k, v := range attrMap.NumberMap {
-		result[k] = v
-	}
-	for k, v := range attrMap.BoolMap {
-		result[k] = v
-	}
-	return result
-}
-
 func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace.Span, ServiceName string, resource pcommon.Resource, scope pcommon.InstrumentationScope, config storageConfig) (*SpanV3, error) {
 	durationNano := uint64(otelSpan.EndTimestamp() - otelSpan.StartTimestamp())
 
@@ -350,7 +336,7 @@ func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace
 		AttributeString:  attrMap.StringMap,
 		AttributesNumber: attrMap.NumberMap,
 		AttributesBool:   attrMap.BoolMap,
-		Attributes:       attrMap.toAttributes(),
+		Attributes:       otelSpan.Attributes().AsRaw(),
 
 		ResourcesString:         resourceAttrs,
 		BillableResourcesString: billableResourceAttrs,

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -239,6 +239,20 @@ func (attrMap *attributesData) add(key string, value pcommon.Value) {
 	attrMap.SpanAttributes = append(attrMap.SpanAttributes, spanAttribute)
 }
 
+func (attrMap *attributesData) toAttributes() map[string]any {
+	result := make(map[string]any, len(attrMap.StringMap)+len(attrMap.NumberMap)+len(attrMap.BoolMap))
+	for k, v := range attrMap.StringMap {
+		result[k] = v
+	}
+	for k, v := range attrMap.NumberMap {
+		result[k] = v
+	}
+	for k, v := range attrMap.BoolMap {
+		result[k] = v
+	}
+	return result
+}
+
 func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace.Span, ServiceName string, resource pcommon.Resource, scope pcommon.InstrumentationScope, config storageConfig) (*SpanV3, error) {
 	durationNano := uint64(otelSpan.EndTimestamp() - otelSpan.StartTimestamp())
 
@@ -336,6 +350,7 @@ func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace
 		AttributeString:  attrMap.StringMap,
 		AttributesNumber: attrMap.NumberMap,
 		AttributesBool:   attrMap.BoolMap,
+		Attributes:       attrMap.toAttributes(),
 
 		ResourcesString:         resourceAttrs,
 		BillableResourcesString: billableResourceAttrs,

--- a/exporter/clickhousetracesexporter/schema-signoz.go
+++ b/exporter/clickhousetracesexporter/schema-signoz.go
@@ -168,6 +168,7 @@ type SpanV3 struct {
 	AttributeString  map[string]string  `json:"attributes_string,omitempty"`
 	AttributesNumber map[string]float64 `json:"attributes_number,omitempty"`
 	AttributesBool   map[string]bool    `json:"attributes_bool,omitempty"`
+	Attributes       map[string]any     `json:"-"`
 
 	ResourcesString map[string]string `json:"-"`
 	// billable resource contains filtered keys from resources string which needs to be billed

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -185,6 +185,7 @@ func (w *SpanWriter) writeIndexBatchV3(ctx context.Context, batchSpans []*SpanV3
 			span.AttributeString,
 			span.AttributesNumber,
 			span.AttributesBool,
+			span.Attributes,
 			span.ResourcesString,
 			span.ResourcesString,
 			marshalledScope,


### PR DESCRIPTION
## Pull Request

### Summary
Store attributes column of json type to store the attributes as raw json. Not adding any index in values for now since `toString(attributes)` is expensive and `JSONAllValues` is only supported in Clickhouse v26.4

Breaking Change: This change requires clickhouse to be atleast v25.12.5

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Part of https://github.com/SigNoz/engineering-pod/issues/5068

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No