### PR TITLE
fix(lint): resolve golangci-lint errors across codebase (part 1)

### DIFF
--- a/cmd/signozotelcollector/migrate/async_up.go
+++ b/cmd/signozotelcollector/migrate/async_up.go
@@ -65,6 +65,9 @@ func newAsyncUp(dsn string, cluster string, replication bool, timeout time.Durat
 		schemamigrator.WithConnOptions(*opts),
 		schemamigrator.WithLogger(logger),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &asyncUp{
 		conn:             conn,

--- a/cmd/signozotelcollector/migrate/sync_up.go
+++ b/cmd/signozotelcollector/migrate/sync_up.go
@@ -65,6 +65,9 @@ func newSyncUp(dsn string, cluster string, replication bool, timeout time.Durati
 		schemamigrator.WithConnOptions(*opts),
 		schemamigrator.WithLogger(logger),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &syncUp{
 		conn:             conn,

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -380,7 +380,7 @@ func (m *MigrationManager) HostAddrs() ([]string, error) {
 	if err != nil {
 		return nil, errors.Join(ErrFailedToGetHostAddrs, err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var hostAddr string
 		var port uint16
@@ -411,7 +411,7 @@ func (m *MigrationManager) HostAddrs() ([]string, error) {
 			if err != nil {
 				return nil, errors.Join(ErrFailedToGetConn, err)
 			}
-			defer rows.Close()
+			defer func() { _ = rows.Close() }()
 			for rows.Next() {
 				var hostAddr string
 				var port uint16

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -535,25 +535,25 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 	if err != nil {
 		return fmt.Errorf("PrepareTagBatchV2:%w", err)
 	}
-	defer tagStatementV2.Close()
+	defer func() { _ = tagStatementV2.Close() }()
 
 	attributeKeysStmt, err = e.db.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.%s", databaseName, distributedLogsAttributeKeys), driver.WithReleaseConnection())
 	if err != nil {
 		return fmt.Errorf("PrepareAttributeKeysBatch:%w", err)
 	}
-	defer attributeKeysStmt.Close()
+	defer func() { _ = attributeKeysStmt.Close() }()
 
 	resourceKeysStmt, err = e.db.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.%s", databaseName, distributedLogsResourceKeys), driver.WithReleaseConnection())
 	if err != nil {
 		return fmt.Errorf("PrepareResourceKeysBatch:%w", err)
 	}
-	defer resourceKeysStmt.Close()
+	defer func() { _ = resourceKeysStmt.Close() }()
 
 	insertLogsStmtV2, err = e.db.PrepareBatch(ctx, e.insertLogsSQLV2, driver.WithReleaseConnection())
 	if err != nil {
 		return fmt.Errorf("PrepareBatchV2:%w", err)
 	}
-	defer insertLogsStmtV2.Close()
+	defer func() { _ = insertLogsStmtV2.Close() }()
 
 	// resource fingerprints aggregated by consumer
 	resourcesSeen := newResourcesSeenMap()
@@ -766,7 +766,7 @@ producerIteration:
 	if err != nil {
 		return fmt.Errorf("couldn't PrepareBatch for inserting resource fingerprints :%w", err)
 	}
-	defer insertResourcesStmtV2.Close()
+	defer func() { _ = insertResourcesStmtV2.Close() }()
 
 	err = resourcesSeen.rangeAll(func(bucketTs int64, resourceLables, fingerprint string) error {
 		key := utils.MakeKeyForRFCache(bucketTs, fingerprint)

--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -167,7 +167,7 @@ func (s *clickhouseTracesExporter) Shutdown(_ context.Context) error {
 			s.logger.Error("Error stopping usage collector", zap.Error(err))
 		}
 	}
-	s.Writer.Close()
+	_ = s.Writer.Close()
 
 	return nil
 }

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -155,7 +155,7 @@ func populateEventsV3(events ptrace.SpanEventSlice, span *SpanV3, lowCardinalExc
 			event.IsError = true
 			errorEvent.Event = event
 			uuidWithHyphen := uuid.New()
-			uuid := strings.Replace(uuidWithHyphen.String(), "-", "", -1)
+			uuid := strings.ReplaceAll(uuidWithHyphen.String(), "-", "")
 			errorEvent.ErrorID = uuid
 			var hash [16]byte
 			if lowCardinalExceptionGrouping {
@@ -310,7 +310,7 @@ func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace
 
 	tenant := usage.GetTenantNameFromResource()
 
-	var span *SpanV3 = &SpanV3{
+	span := &SpanV3{
 		TsBucketStart: bucketStart,
 		FingerPrint:   fingerprint,
 

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -291,13 +291,13 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 	if err != nil {
 		return fmt.Errorf("could not prepare batch for span attributes key table due to error: %w", err)
 	}
-	defer tagKeyStatement.Close()
+	defer func() { _ = tagKeyStatement.Close() }()
 
 	tagStatementV2, err = w.db.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.%s", w.traceDatabase, w.attributeTableV2), driver.WithReleaseConnection())
 	if err != nil {
 		return fmt.Errorf("could not prepare batch for span attributes table v2 due to error: %w", err)
 	}
-	defer tagStatementV2.Close()
+	defer func() { _ = tagStatementV2.Close() }()
 
 	// create map of span attributes of key, tagType, dataType and isColumn to avoid duplicates in batch
 	mapOfSpanAttributeKeys := make(map[string]struct{})
@@ -353,8 +353,8 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 				continue
 			}
 
-			if spanAttribute.DataType == "string" {
-
+			switch spanAttribute.DataType {
+			case "string":
 				if _, ok := shouldSkipKeys[v2Key]; !ok {
 					// TODO: handle error
 					_ = tagStatementV2.Append(
@@ -366,8 +366,7 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 						nil,
 					)
 				}
-
-			} else if spanAttribute.DataType == "float64" {
+			case "float64":
 				if _, ok = shouldSkipKeys[v2Key]; !ok {
 					// TODO: handle error
 					_ = tagStatementV2.Append(
@@ -379,7 +378,7 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 						spanAttribute.NumberValue,
 					)
 				}
-			} else if spanAttribute.DataType == "bool" {
+			case "bool":
 				if _, ok = shouldSkipKeys[v2Key]; !ok {
 					// TODO: handle erroe
 					_ = tagStatementV2.Append(
@@ -521,7 +520,7 @@ func (w *SpanWriter) WriteResourcesV3(ctx context.Context, resourcesSeen map[int
 	if err != nil {
 		return fmt.Errorf("couldn't PrepareBatch for inserting resource fingerprints :%w", err)
 	}
-	defer insertResourcesStmtV3.Close()
+	defer func() { _ = insertResourcesStmtV3.Close() }()
 
 	for bucketTs, resources := range resourcesSeen {
 		for resourceLabels, fingerprint := range resources {

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -153,7 +153,7 @@ func (w *SpanWriter) writeIndexBatchV3(ctx context.Context, batchSpans []*SpanV3
 	if err != nil {
 		return fmt.Errorf("could not prepare batch for index table: %w", err)
 	}
-	defer statement.Close()
+	defer func() { _ = statement.Close() }()
 
 	for _, span := range batchSpans {
 
@@ -236,7 +236,7 @@ func (w *SpanWriter) writeErrorBatchV3(ctx context.Context, batchSpans []*SpanV3
 	if err != nil {
 		return fmt.Errorf("could not prepare batch for error table: %w", err)
 	}
-	defer statement.Close()
+	defer func() { _ = statement.Close() }()
 
 	for _, span := range batchSpans {
 		for _, errorEvent := range span.ErrorEvents {

--- a/exporter/jsontypeexporter/exporter.go
+++ b/exporter/jsontypeexporter/exporter.go
@@ -340,7 +340,7 @@ func (e *jsonTypeExporter) persistTypes(ctx context.Context, typeSet *TypeSet) e
 	if err != nil {
 		return fmt.Errorf("failed to prepare batch statement: %w", err)
 	}
-	defer statement.Close()
+	defer func() { _ = statement.Close() }()
 
 	now := time.Now().UnixNano()
 	insertedCount := 0

--- a/exporter/jsontypeexporter/exporter.go
+++ b/exporter/jsontypeexporter/exporter.go
@@ -340,7 +340,7 @@ func (e *jsonTypeExporter) persistTypes(ctx context.Context, typeSet *TypeSet) e
 	if err != nil {
 		return fmt.Errorf("failed to prepare batch statement: %w", err)
 	}
-	defer func() { _ = statement.Close() }()
+	defer statement.Close()
 
 	now := time.Now().UnixNano()
 	insertedCount := 0

--- a/exporter/jsontypeexporter/exporter_benchmark_test.go
+++ b/exporter/jsontypeexporter/exporter_benchmark_test.go
@@ -27,7 +27,7 @@ func buildLogs(count int) plog.Logs {
 	for i := 0; i < count; i++ {
 		lr := lrs.AppendEmpty()
 		lr.SetTimestamp(pcommon.Timestamp(0))
-		lr.Body().FromRaw(batch.Rows[i].Body)
+		_ = lr.Body().FromRaw(batch.Rows[i].Body)
 	}
 	return ld
 }

--- a/exporter/jsontypeexporter/exporter_benchmark_test.go
+++ b/exporter/jsontypeexporter/exporter_benchmark_test.go
@@ -27,7 +27,7 @@ func buildLogs(count int) plog.Logs {
 	for i := 0; i < count; i++ {
 		lr := lrs.AppendEmpty()
 		lr.SetTimestamp(pcommon.Timestamp(0))
-		_ = lr.Body().FromRaw(batch.Rows[i].Body)
+		lr.Body().FromRaw(batch.Rows[i].Body)
 	}
 	return ld
 }

--- a/exporter/jsontypeexporter/exporter_test.go
+++ b/exporter/jsontypeexporter/exporter_test.go
@@ -309,7 +309,7 @@ func TestAnalyzePValue_EndToEndTypes(t *testing.T) {
 			// Expected final types per path (subset assertion)
 			if len(got) != len(testCase.expected) {
 				buf := bytes.NewBuffer(nil)
-				_ = json.NewEncoder(buf).Encode(got)
+				json.NewEncoder(buf).Encode(got)
 				t.Log(buf.String())
 				t.Fatalf("got %d paths, expected %d", len(got), len(testCase.expected))
 			}

--- a/exporter/jsontypeexporter/exporter_test.go
+++ b/exporter/jsontypeexporter/exporter_test.go
@@ -309,7 +309,7 @@ func TestAnalyzePValue_EndToEndTypes(t *testing.T) {
 			// Expected final types per path (subset assertion)
 			if len(got) != len(testCase.expected) {
 				buf := bytes.NewBuffer(nil)
-				json.NewEncoder(buf).Encode(got)
+				_ = json.NewEncoder(buf).Encode(got)
 				t.Log(buf.String())
 				t.Fatalf("got %d paths, expected %d", len(got), len(testCase.expected))
 			}

--- a/exporter/metadataexporter/attribute_writer.go
+++ b/exporter/metadataexporter/attribute_writer.go
@@ -39,7 +39,7 @@ func (w *attributeMetadataWriter) Process(ctx context.Context, ld plog.Logs) err
 		w.logger.Error("failed to prepare batch", zap.Error(err), zap.String("pipeline", pipeline.SignalLogs.String()))
 		return nil
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	totalLogRecords := 0
 	records := make([]writeToStatementBatchRecord, 0)

--- a/exporter/metadataexporter/exporter.go
+++ b/exporter/metadataexporter/exporter.go
@@ -341,7 +341,7 @@ func (e *metadataExporter) updateTagValueCountFromDB(ctx context.Context, p *upd
 		p.logger.Error("failed to query tag value counts", zap.String("signal", p.signalName), zap.Error(err))
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	newMap := make(map[string]tagValueCountFromDB)
 	for rows.Next() {
@@ -692,7 +692,7 @@ func (e *metadataExporter) PushTraces(ctx context.Context, td ptrace.Traces) err
 		e.set.Logger.Error("failed to prepare batch", zap.Error(err), zap.String("pipeline", pipeline.SignalTraces.String()))
 		return nil
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	totalSpans := 0
 	records := make([]writeToStatementBatchRecord, 0)
@@ -764,7 +764,7 @@ func (e *metadataExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) 
 		e.set.Logger.Error("failed to prepare batch", zap.Error(err), zap.String("pipeline", pipeline.SignalMetrics.String()))
 		return nil
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	totalDps := 0
 	records := make([]writeToStatementBatchRecord, 0)

--- a/exporter/metadataexporter/json_writer.go
+++ b/exporter/metadataexporter/json_writer.go
@@ -265,7 +265,7 @@ func (w *jsonMetadataWriter) Process(ctx context.Context, ld plog.Logs) error {
 	if err != nil {
 		return fmt.Errorf("failed to prepare tag attrs batch: %w", err)
 	}
-	defer vaStmt.Close()
+	defer func() { _ = vaStmt.Close() }()
 
 	va := &valueAccumulator{
 		stmt:             vaStmt,
@@ -313,7 +313,7 @@ func (w *jsonMetadataWriter) flushTypeSet(ctx context.Context, ta *typesAccumula
 	if err != nil {
 		return fmt.Errorf("failed to prepare path types batch: %w", err)
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	if err := appendTypeSet(ta, pipeline.SignalLogs.String(), string(utils.TagTypeBodyField), stmt, time.Now().UnixNano()); err != nil {
 		return fmt.Errorf("failed to append to path types batch: %w", err)

--- a/exporter/metadataexporter/json_writer_test.go
+++ b/exporter/metadataexporter/json_writer_test.go
@@ -271,7 +271,7 @@ func TestWalk_EndToEndTypes(t *testing.T) {
 
 			if len(got) != len(tc.expected) {
 				buf := bytes.NewBuffer(nil)
-				json.NewEncoder(buf).Encode(got)
+				_ = json.NewEncoder(buf).Encode(got)
 				t.Log(buf.String())
 				t.Fatalf("got %d paths, expected %d", len(got), len(tc.expected))
 			}

--- a/exporter/signozclickhousemeter/exporter.go
+++ b/exporter/signozclickhousemeter/exporter.go
@@ -222,7 +222,7 @@ func (c *clickhouseMeterExporter) writeBatch(ctx context.Context, batch *batch) 
 	if err != nil {
 		return err
 	}
-	defer statement.Close()
+	defer func() { _ = statement.Close() }()
 
 	for _, sample := range batch.samples {
 		err = statement.Append(

--- a/exporter/signozclickhousemeter/exporter_test.go
+++ b/exporter/signozclickhousemeter/exporter_test.go
@@ -145,5 +145,5 @@ func Test_shutdown(t *testing.T) {
 	if err != nil {
 		log.Fatalf("an error '%s' was not expected when shutting down exporter", err)
 	}
-	defaultConn.Close()
+	_ = defaultConn.Close()
 }

--- a/exporter/signozclickhousemetrics/exporter.go
+++ b/exporter/signozclickhousemetrics/exporter.go
@@ -1044,7 +1044,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 		if err != nil {
 			return err
 		}
-		defer statement.Close()
+		defer func() { _ = statement.Close() }()
 
 		for _, ts := range timeSeries {
 			roundedUnixMilli := ts.unixMilli / 3600000 * 3600000
@@ -1101,7 +1101,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 		if err != nil {
 			return err
 		}
-		defer statement.Close()
+		defer func() { _ = statement.Close() }()
 
 		for _, sample := range samples {
 			err = statement.Append(
@@ -1156,7 +1156,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 		if err != nil {
 			return err
 		}
-		defer statement.Close()
+		defer func() { _ = statement.Close() }()
 
 		for _, expHist := range expHist {
 			err = statement.Append(
@@ -1201,7 +1201,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 		if err != nil {
 			return err
 		}
-		defer statement.Close()
+		defer func() { _ = statement.Close() }()
 
 		for _, meta := range metadata {
 			err = statement.Append(

--- a/exporter/signozkafkaexporter/scram_client.go
+++ b/exporter/signozkafkaexporter/scram_client.go
@@ -19,11 +19,11 @@ type XDGSCRAMClient struct {
 
 // Begin starts the XDGSCRAMClient conversation.
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
-	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	x.Client, err = x.NewClient(userName, password, authzID)
 	if err != nil {
 		return err
 	}
-	x.ClientConversation = x.Client.NewConversation()
+	x.ClientConversation = x.NewConversation()
 	return nil
 }
 

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -194,7 +194,7 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 	// to accept an address.
 	ln, err := net.Listen("tcp", endpoint)
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	config := Config{
 		ServerConfig: confighttp.ServerConfig{

--- a/internal/kafka/scram_client.go
+++ b/internal/kafka/scram_client.go
@@ -19,11 +19,11 @@ type XDGSCRAMClient struct {
 
 // Begin starts the XDGSCRAMClient conversation.
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
-	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	x.Client, err = x.NewClient(userName, password, authzID)
 	if err != nil {
 		return err
 	}
-	x.ClientConversation = x.Client.NewConversation()
+	x.ClientConversation = x.NewConversation()
 	return nil
 }
 

--- a/opamp/config_manager_test.go
+++ b/opamp/config_manager_test.go
@@ -81,7 +81,7 @@ func TestNewDynamicConfigAddsInstanceId(t *testing.T) {
 	// restore the original file
 	defer func() {
 		_ = copy("./testdata/service-instance-id-copy.yaml", "./testdata/service-instance-id.yaml")
-		os.Remove("./testdata/service-instance-id-copy.yaml")
+		_ = os.Remove("./testdata/service-instance-id-copy.yaml")
 	}()
 
 	_, err := NewDynamicConfig("./testdata/service-instance-id.yaml", func(contents []byte) error { return nil }, nil)
@@ -103,8 +103,8 @@ func TestNewAgentConfigManagerApply(t *testing.T) {
 	defer func() {
 		_ = copy("./testdata/coll-config-path-copy.yaml", "./testdata/coll-config-path.yaml")
 		_ = copy("./testdata/coll-config-path-changed-copy.yaml", "./testdata/coll-config-path-changed.yaml")
-		os.Remove("./testdata/coll-config-path-copy.yaml")
-		os.Remove("./testdata/coll-config-path-changed-copy.yaml")
+		_ = os.Remove("./testdata/coll-config-path-copy.yaml")
+		_ = os.Remove("./testdata/coll-config-path-changed-copy.yaml")
 	}()
 
 	logger := newLogger(t)

--- a/opamp/config_test.go
+++ b/opamp/config_test.go
@@ -45,7 +45,7 @@ func TestParseConfigAddsID(t *testing.T) {
 	defer func() {
 		err := copy("./testdata/agent-id-copy.yaml", "./testdata/agent-id.yaml")
 		assert.NoError(t, err, "failed to restore original file")
-		os.Remove("./testdata/agent-id-copy.yaml")
+		_ = os.Remove("./testdata/agent-id-copy.yaml")
 	}()
 
 	cfg, err := ParseAgentManagerConfig("./testdata/agent-id.yaml")

--- a/opamp/helpers.go
+++ b/opamp/helpers.go
@@ -26,7 +26,7 @@ func GetAvailableLocalAddress() string {
 	}
 	// There is a possible race if something else takes this same port before
 	// the test uses it, however, that is unlikely in practice.
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	return ln.Addr().String()
 }
 
@@ -45,7 +45,7 @@ func waitForPortToListen(port int) error {
 		case <-ticker.C:
 			conn, err := net.Dial("tcp", address)
 			if err == nil && conn != nil {
-				conn.Close()
+				_ = conn.Close()
 				return nil
 			}
 

--- a/opamp/server_client_test.go
+++ b/opamp/server_client_test.go
@@ -32,7 +32,7 @@ func TestNewClient(t *testing.T) {
 		fileContents, err := os.ReadFile("testdata/coll-config-path-changed.yaml")
 		assert.NoError(t, err)
 		atomic.AddInt64(&connected, 1)
-		var resp *protobufs.ServerToAgent = &protobufs.ServerToAgent{}
+		var resp = &protobufs.ServerToAgent{}
 		if atomic.LoadInt64(&connected) == 1 {
 			resp = &protobufs.ServerToAgent{
 				RemoteConfig: &protobufs.AgentRemoteConfig{

--- a/pkg/collectorsimulator/collectorsimulator.go
+++ b/pkg/collectorsimulator/collectorsimulator.go
@@ -71,7 +71,7 @@ func NewCollectorSimulator(
 	}
 	collectorLogsOutputFilePath := logsOutputFile.Name()
 	cleanupFn = func() {
-		os.Remove(collectorLogsOutputFilePath)
+		_ = os.Remove(collectorLogsOutputFilePath)
 	}
 	err = logsOutputFile.Close()
 	if err != nil {
@@ -96,8 +96,8 @@ func NewCollectorSimulator(
 	}
 	simulationConfigPath := simulationConfigFile.Name()
 	cleanupFn = func() {
-		os.Remove(collectorLogsOutputFilePath)
-		os.Remove(simulationConfigPath)
+		_ = os.Remove(collectorLogsOutputFilePath)
+		_ = os.Remove(simulationConfigPath)
 	}
 
 	_, err = simulationConfigFile.Write(collectorConfYaml)

--- a/pkg/parser/grok/grok.go
+++ b/pkg/parser/grok/grok.go
@@ -114,7 +114,7 @@ type Parser struct {
 
 // Process will parse an entry for grok.
 func (r *Parser) Process(ctx context.Context, entry *entry.Entry) error {
-	return r.ParserOperator.ProcessWith(ctx, entry, r.parse)
+	return r.ProcessWith(ctx, entry, r.parse)
 }
 
 func (r *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {

--- a/processor/signozlogspipelineprocessor/config.go
+++ b/processor/signozlogspipelineprocessor/config.go
@@ -16,7 +16,7 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 func (cfg *Config) Validate() error {
-	if len(cfg.BaseConfig.Operators) == 0 {
+	if len(cfg.Operators) == 0 {
 		return errors.New("no operators were configured for signozlogspipeline processor")
 	}
 	return nil
@@ -25,7 +25,7 @@ func (cfg *Config) Validate() error {
 func (cfg *Config) OperatorConfigs() []operator.Config {
 	ops := []operator.Config{}
 
-	for _, op := range cfg.BaseConfig.Operators {
+	for _, op := range cfg.Operators {
 		ops = append(ops, operator.Config(op))
 	}
 	return ops

--- a/processor/signozlogspipelineprocessor/factory.go
+++ b/processor/signozlogspipelineprocessor/factory.go
@@ -44,7 +44,7 @@ func createLogsProcessor(
 	if !ok {
 		return nil, errors.New("could not initialize signozlogspipeline processor")
 	}
-	if len(pCfg.BaseConfig.Operators) == 0 {
+	if len(pCfg.Operators) == 0 {
 		return nil, errors.New("no operators were configured for signozlogspipeline processor")
 	}
 

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/json/parser.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/json/parser.go
@@ -28,7 +28,7 @@ type Parser struct {
 
 // Process will parse an entry for JSON.
 func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
-	return p.ParserOperator.ProcessWith(ctx, entry, p.parse)
+	return p.ProcessWith(ctx, entry, p.parse)
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/regex/parser.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/regex/parser.go
@@ -28,7 +28,7 @@ func (p *Parser) Stop() error {
 
 // Process will parse an entry for regex.
 func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
-	return p.ParserOperator.ProcessWith(ctx, entry, p.parse)
+	return p.ProcessWith(ctx, entry, p.parse)
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/transformer.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/transformer.go
@@ -38,7 +38,7 @@ func (t *Transformer) Transform(entry *entry.Entry) error {
 
 	_, exist := entry.Delete(t.Field.Field)
 	if !exist {
-		return fmt.Errorf("remove: field does not exist: %s", t.Field.Field.String())
+		return fmt.Errorf("remove: field does not exist: %s", t.Field.String())
 	}
 	return nil
 }

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/router/config.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/router/config.go
@@ -71,7 +71,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 			return nil, fmt.Errorf("failed to compile expression '%s': %w", routeConfig.Expression, err)
 		}
 
-		attributer, err := routeConfig.AttributerConfig.Build()
+		attributer, err := routeConfig.Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build attributer for route '%s': %w", routeConfig.Expression, err)
 		}

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/time/config.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/time/config.go
@@ -47,7 +47,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		return nil, err
 	}
 
-	if err := c.TimeParser.Validate(); err != nil {
+	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/time/parser.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/time/parser.go
@@ -17,7 +17,7 @@ type Parser struct {
 
 // Process will parse time from an entry.
 func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
-	return p.ProcessWith(ctx, entry, p.TimeParser.Parse)
+	return p.ProcessWith(ctx, entry, p.Parse)
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/config.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/trace/config.go
@@ -42,7 +42,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		return nil, err
 	}
 
-	if err := c.TraceParser.Validate(); err != nil {
+	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/processor/signoztailsampler/evaluator.go
+++ b/processor/signoztailsampler/evaluator.go
@@ -33,7 +33,7 @@ type defaultEvaluator struct {
 func NewDefaultEvaluator(logger *zap.Logger, policyCfg BasePolicy, subpolicies []BasePolicy) sampling.PolicyEvaluator {
 
 	// condition operator to apply on filters (AND | OR)
-	filterOperator := policyCfg.PolicyFilterCfg.FilterOp
+	filterOperator := policyCfg.FilterOp
 
 	// list of filter evaluators used to decide if this policy
 	// should be applied

--- a/receiver/httplogreceiver/config.go
+++ b/receiver/httplogreceiver/config.go
@@ -24,12 +24,12 @@ type Config struct {
 
 // Validate verifies that the endpoint is valid and the configured port is not 0
 func (rCfg *Config) Validate() error {
-	if rCfg.ServerConfig.NetAddr.Endpoint == "" {
+	if rCfg.NetAddr.Endpoint == "" {
 		return errors.New("must specify an endpoint for the httplogreceiver")
 	}
 
 	// validate port
-	_, portStr, err := net.SplitHostPort(rCfg.ServerConfig.NetAddr.Endpoint)
+	_, portStr, err := net.SplitHostPort(rCfg.NetAddr.Endpoint)
 	if err != nil {
 		return fmt.Errorf("endpoint is not formatted correctly: %w", err)
 	}

--- a/receiver/httplogreceiver/httplogreceiver.go
+++ b/receiver/httplogreceiver/httplogreceiver.go
@@ -127,7 +127,7 @@ func (r *httplogreceiver) Start(ctx context.Context, host component.Host) error 
 	}
 
 	// set up the listener
-	ln, err := r.config.ServerConfig.ToListener(ctx)
+	ln, err := r.config.ToListener(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to bind to address %s: %w", r.config.NetAddr.Endpoint, err)
 	}

--- a/receiver/signozkafkareceiver/pdata_unmarshaler.go
+++ b/receiver/signozkafkareceiver/pdata_unmarshaler.go
@@ -15,7 +15,7 @@ type pdataLogsUnmarshaler struct {
 }
 
 func (p pdataLogsUnmarshaler) Unmarshal(buf []byte) (plog.Logs, error) {
-	return p.Unmarshaler.UnmarshalLogs(buf)
+	return p.UnmarshalLogs(buf)
 }
 
 func (p pdataLogsUnmarshaler) Encoding() string {
@@ -35,7 +35,7 @@ type pdataTracesUnmarshaler struct {
 }
 
 func (p pdataTracesUnmarshaler) Unmarshal(buf []byte) (ptrace.Traces, error) {
-	return p.Unmarshaler.UnmarshalTraces(buf)
+	return p.UnmarshalTraces(buf)
 }
 
 func (p pdataTracesUnmarshaler) Encoding() string {
@@ -55,7 +55,7 @@ type pdataMetricsUnmarshaler struct {
 }
 
 func (p pdataMetricsUnmarshaler) Unmarshal(buf []byte) (pmetric.Metrics, error) {
-	return p.Unmarshaler.UnmarshalMetrics(buf)
+	return p.UnmarshalMetrics(buf)
 }
 
 func (p pdataMetricsUnmarshaler) Encoding() string {

--- a/receiver/signozkafkareceiver/zipkin_unmarshaler_test.go
+++ b/receiver/signozkafkareceiver/zipkin_unmarshaler_test.go
@@ -48,7 +48,7 @@ func TestUnmarshalZipkin(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, protocolTransport.WriteListEnd(context.Background()))
 
-	tdThrift, err := newZipkinThriftUnmarshaler().Unmarshal(thriftTransport.Buffer.Bytes())
+	tdThrift, err := newZipkinThriftUnmarshaler().Unmarshal(thriftTransport.Bytes())
 	require.NoError(t, err)
 
 	protoBytes, err := new(zipkin_proto3.SpanSerializer).Serialize(spans)
@@ -75,7 +75,7 @@ func TestUnmarshalZipkin(t *testing.T) {
 		{
 			unmarshaler: newZipkinThriftUnmarshaler(),
 			encoding:    "zipkin_thrift",
-			bytes:       thriftTransport.Buffer.Bytes(),
+			bytes:       thriftTransport.Bytes(),
 			expected:    tdThrift,
 		},
 	}


### PR DESCRIPTION
## Pull Request

### Summary
Fix golangci-lint errors that are causing CI failures on PRs targeting main. Scoped to two below categories, rest of the lint errors can be fixed separately since they might need thorough review.  

**1. Unchecked error returns (errcheck)**
- All `defer stmt.Close()` / `defer statement.Close()` calls wrapped as `defer func() { _ = x.Close() }()` across exporters, schema migrator, opamp, and pkg packages
- `os.Remove()` calls in test files prefixed with `_ =`
- `json.Encoder.Encode()` and `pcommon.Value.FromRaw()` in test files prefixed with `_ =`
- `async_up.go` / `sync_up.go`: `NewMigrationManager` error was silently ignored — this is also a genuine bug fix

**2. Redundant embedded field selectors (staticcheck QF1008)**
- Applied to files that had *only* this class of error: `scram_client.go` (kafka/signozkafkaexporter), `pdata_unmarshaler.go`, `grok.go`, stanza operator parsers/transformers/configs, `httplogreceiver`, `signoztailsampler/evaluator.go`

**3. All lint fixes in `exporter/clickhousetracesexporter`**
- `strings.ReplaceAll`, tagged switch, omit inferable type (staticcheck QF1004, QF1003, ST1023)

### Related Issues
Unblocks #833

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No