### PR TITLE
fix(schema-migrator): escape cluster names with backticks in SQL

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/column_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations.go
@@ -60,7 +60,7 @@ func (a AlterTableAddColumn) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" ADD COLUMN IF NOT EXISTS ")
 	sql.WriteString(a.Column.ToSQL())
@@ -124,7 +124,7 @@ func (a AlterTableDropColumn) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" DROP COLUMN IF EXISTS ")
 	sql.WriteString(a.Column.Name)
@@ -186,7 +186,7 @@ func (a AlterTableModifyColumn) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
 	sql.WriteString(a.Column.Name)
@@ -269,7 +269,7 @@ func (a AlterTableModifyColumnRemove) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
 	sql.WriteString(a.Column.Name)
@@ -332,7 +332,7 @@ func (a AlterTableModifyColumnModifySettings) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
 	sql.WriteString(a.Column.Name)
@@ -395,7 +395,7 @@ func (a AlterTableModifyColumnResetSettings) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY COLUMN IF EXISTS ")
 	sql.WriteString(a.Column.Name)
@@ -459,7 +459,7 @@ func (a AlterTableMaterializeColumn) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MATERIALIZE COLUMN ")
 	sql.WriteString(a.Column.Name)

--- a/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/column_operations_test.go
@@ -24,7 +24,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: ColumnTypeString,
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col String",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-codec",
@@ -37,7 +37,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Codec: "ZSTD(5)",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String CODEC(ZSTD(5))",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col String CODEC(ZSTD(5))",
 		},
 		{
 			name: "col-with-name-and-type-without-cluster",
@@ -62,7 +62,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "'default'",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String DEFAULT 'default'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col String DEFAULT 'default'",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-int-value",
@@ -75,7 +75,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "1",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Int64 DEFAULT 1",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Int64 DEFAULT 1",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-float-value",
@@ -88,7 +88,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "1.1",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Float64 DEFAULT 1.1",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Float64 DEFAULT 1.1",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-bool-value",
@@ -101,7 +101,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "true",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Bool DEFAULT true",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Bool DEFAULT true",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-date-value",
@@ -114,7 +114,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "'2021-01-01'",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Date DEFAULT '2021-01-01'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Date DEFAULT '2021-01-01'",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-uuid-value",
@@ -127,7 +127,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "uuid_nil()", // no such function in clickhouse but shows any expression can be passed as default value
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col UUID DEFAULT uuid_nil()",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col UUID DEFAULT uuid_nil()",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-default-ip-value",
@@ -140,7 +140,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "'127.0.0.1'",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col IPv4 DEFAULT '127.0.0.1'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col IPv4 DEFAULT '127.0.0.1'",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-array-type",
@@ -152,7 +152,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: ArrayColumnType{ColumnTypeInt32},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Int32)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Array(Int32)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-array-type-with-default",
@@ -165,7 +165,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "[1, 2, 3]",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Int32) DEFAULT [1, 2, 3]",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Array(Int32) DEFAULT [1, 2, 3]",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-array-type-with-default-and-array-type",
@@ -178,7 +178,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "[[1, 2, 3], [4, 5, 6]]",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Array(Array(Int32)) DEFAULT [[1, 2, 3], [4, 5, 6]]",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Array(Array(Int32)) DEFAULT [[1, 2, 3], [4, 5, 6]]",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-map-type",
@@ -190,7 +190,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: MapColumnType{ColumnTypeInt32, ColumnTypeString},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Map(Int32, String)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Map(Int32, String)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-map-type-with-default",
@@ -203,7 +203,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "{1: 'a', 2: 'b'}",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Map(Int32, String) DEFAULT {1: 'a', 2: 'b'}",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Map(Int32, String) DEFAULT {1: 'a', 2: 'b'}",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-tuple-type",
@@ -215,7 +215,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: TupleColumnType{[]ColumnType{ColumnTypeBool, ColumnTypeString}},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Tuple(Bool, String)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Tuple(Bool, String)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-low-cardinality-type",
@@ -227,7 +227,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: LowCardinalityColumnType{ColumnTypeString},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col LowCardinality(String)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col LowCardinality(String)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-low-cardinality-type-with-default",
@@ -240,7 +240,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "'default'",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col LowCardinality(String) DEFAULT 'default'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col LowCardinality(String) DEFAULT 'default'",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-json-type",
@@ -252,7 +252,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: JSONColumnType{},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col JSON()",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col JSON()",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-json-type-with-params",
@@ -264,7 +264,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: JSONColumnType{MaxDynamicPaths: utils.ToPointer(uint(10)), MaxDynamicTypes: utils.ToPointer(uint(2))},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col JSON(max_dynamic_paths=10, max_dynamic_types=2)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col JSON(max_dynamic_paths=10, max_dynamic_types=2)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-nullable-type",
@@ -276,7 +276,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: NullableColumnType{ColumnTypeString},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Nullable(String)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Nullable(String)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-nullable-type-with-default",
@@ -289,7 +289,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "'default'",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col Nullable(String) DEFAULT 'default'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col Nullable(String) DEFAULT 'default'",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-simple-aggregate-function-type",
@@ -301,7 +301,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: SimpleAggregateFunction{"Sum", []ColumnType{ColumnTypeInt32}},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32)",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-simple-aggregate-function-type-with-default",
@@ -314,7 +314,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Default: "1",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32) DEFAULT 1",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col SimpleAggregateFunction(Sum, Int32) DEFAULT 1",
 		},
 		{
 			name: "col-with-name-and-type-and-cluster-and-aggregate-function-type",
@@ -326,7 +326,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Type: AggregateFunction{"Sum", []ColumnType{ColumnTypeInt32}},
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col AggregateFunction(Sum, Int32)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col AggregateFunction(Sum, Int32)",
 		},
 		{
 			name: "col-with-alias",
@@ -339,7 +339,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 					Alias: "maincol",
 				},
 			}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD COLUMN IF NOT EXISTS col String ALIAS maincol",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD COLUMN IF NOT EXISTS col String ALIAS maincol",
 		},
 	}
 
@@ -364,7 +364,7 @@ func TestAlterTableDropColumn(t *testing.T) {
 		{
 			name: "drop-column-with-cluster",
 			op:   AlterTableDropColumn{Database: "db", Table: "table", Column: Column{Name: "col"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster DROP COLUMN IF EXISTS col",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` DROP COLUMN IF EXISTS col",
 		},
 	}
 
@@ -389,32 +389,32 @@ func TestAlterTableModifyColumn(t *testing.T) {
 		{
 			name: "modify-column-type-with-cluster",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Type: ColumnTypeIPv4}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col IPv4",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col IPv4",
 		},
 		{
 			name: "modify-column-type-with-default",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Type: ColumnTypeIPv4, Default: "'127.0.0.1'"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col IPv4 DEFAULT '127.0.0.1'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col IPv4 DEFAULT '127.0.0.1'",
 		},
 		{
 			name: "modify-column-default",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Default: "'127.0.0.1'"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col DEFAULT '127.0.0.1'",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col DEFAULT '127.0.0.1'",
 		},
 		{
 			name: "modify-column-compression-codec",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Codec: "ZSTD"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col CODEC(ZSTD)",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col CODEC(ZSTD)",
 		},
 		{
 			name: "modify-column-ttl",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", TTL: "d + INTERVAL 1 DAY"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col TTL d + INTERVAL 1 DAY",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col TTL d + INTERVAL 1 DAY",
 		},
 		{
 			name: "modify-column-settings",
 			op:   AlterTableModifyColumn{Database: "db", Table: "table", Column: Column{Name: "col", Settings: ColumnSettings{ColumnSetting{Name: "min_compress_block_size", Value: "16777216"}}}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col SETTINGS min_compress_block_size = 16777216",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col SETTINGS min_compress_block_size = 16777216",
 		},
 	}
 
@@ -434,27 +434,27 @@ func TestAlterTableModifyColumnRemove(t *testing.T) {
 		{
 			name: "remove-column-property-ttl",
 			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyTTL}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE TTL",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col REMOVE TTL",
 		},
 		{
 			name: "remove-column-property-codec",
 			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyCodec}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE CODEC",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col REMOVE CODEC",
 		},
 		{
 			name: "remove-column-property-default",
 			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyDefault}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE DEFAULT",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col REMOVE DEFAULT",
 		},
 		{
 			name: "remove-column-property-settings",
 			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertySettings}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE SETTINGS",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col REMOVE SETTINGS",
 		},
 		{
 			name: "remove-column-property-materialized",
 			op:   AlterTableModifyColumnRemove{Database: "db", Table: "table", Column: Column{Name: "col"}, Property: ColumnPropertyMaterialized}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY COLUMN IF EXISTS col REMOVE MATERIALIZED",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY COLUMN IF EXISTS col REMOVE MATERIALIZED",
 		},
 	}
 
@@ -479,7 +479,7 @@ func TestAlterTableMaterializeColumn(t *testing.T) {
 		{
 			name: "materialize-column-with-cluster",
 			op:   AlterTableMaterializeColumn{Database: "db", Table: "table", Column: Column{Name: "col"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE COLUMN col",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MATERIALIZE COLUMN col",
 		},
 	}
 

--- a/cmd/signozschemamigrator/schema_migrator/index_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations.go
@@ -105,7 +105,7 @@ func (a AlterTableAddIndex) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" ADD INDEX IF NOT EXISTS ")
 	sql.WriteString(a.Index.Name)
@@ -170,7 +170,7 @@ func (a AlterTableDropIndex) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" DROP INDEX IF EXISTS ")
 	sql.WriteString(a.Index.Name)
@@ -230,7 +230,7 @@ func (a AlterTableMaterializeIndex) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MATERIALIZE INDEX IF EXISTS ")
 	sql.WriteString(a.Index.Name)
@@ -294,7 +294,7 @@ func (a AlterTableClearIndex) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" CLEAR INDEX IF EXISTS ")
 	sql.WriteString(a.Index.Name)

--- a/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/index_operations_test.go
@@ -20,7 +20,7 @@ func TestAlterTableAddIndex(t *testing.T) {
 		{
 			name: "add-index-on-cluster",
 			op:   AlterTableAddIndex{Database: "db", Table: "table", Index: Index{Name: "idx", Expression: "mapKeys(numberTagMap)", Type: "bloom_filter", Granularity: 1}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster ADD INDEX IF NOT EXISTS idx mapKeys(numberTagMap) TYPE bloom_filter GRANULARITY 1",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` ADD INDEX IF NOT EXISTS idx mapKeys(numberTagMap) TYPE bloom_filter GRANULARITY 1",
 		},
 	}
 
@@ -45,7 +45,7 @@ func TestAlterTableDropIndex(t *testing.T) {
 		{
 			name: "drop-index-on-cluster",
 			op:   AlterTableDropIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster DROP INDEX IF EXISTS idx",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` DROP INDEX IF EXISTS idx",
 		},
 	}
 
@@ -70,7 +70,7 @@ func TestAlterTableMaterializeIndex(t *testing.T) {
 		{
 			name: "materialize-index-on-cluster",
 			op:   AlterTableMaterializeIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster MATERIALIZE INDEX IF EXISTS idx",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MATERIALIZE INDEX IF EXISTS idx",
 		},
 		{
 			name: "materialize-index-in-partition",
@@ -100,7 +100,7 @@ func TestAlterTableClearIndex(t *testing.T) {
 		{
 			name: "clear-index-on-cluster",
 			op:   AlterTableClearIndex{Database: "db", Table: "table", Index: Index{Name: "idx"}}.OnCluster("cluster"),
-			want: "ALTER TABLE db.table ON CLUSTER cluster CLEAR INDEX IF EXISTS idx",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` CLEAR INDEX IF EXISTS idx",
 		},
 	}
 

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -150,7 +150,7 @@ func WithBackoff(backoff *backoff.ExponentialBackOff) Option {
 
 func (m *MigrationManager) createDBs() error {
 	for _, db := range Databases {
-		cmd := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s ON CLUSTER %s", db, m.clusterName)
+		cmd := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s ON CLUSTER %s", db, EscapeClusterName(m.clusterName))
 		if err := m.conn.Exec(context.Background(), cmd); err != nil {
 			return errors.Join(ErrFailedToCreateDBs, err)
 		}
@@ -1038,7 +1038,7 @@ func (m *MigrationManager) insertMigrationEntry(ctx context.Context, db string, 
 }
 
 func (m *MigrationManager) updateMigrationEntry(ctx context.Context, db string, migrationID uint64, status string, err string) error {
-	query := fmt.Sprintf("ALTER TABLE %s.schema_migrations_v2 ON CLUSTER %s UPDATE status = $1, error = $2, updated_at = $3 WHERE migration_id = $4", db, m.clusterName)
+	query := fmt.Sprintf("ALTER TABLE %s.schema_migrations_v2 ON CLUSTER %s UPDATE status = $1, error = $2, updated_at = $3 WHERE migration_id = $4", db, EscapeClusterName(m.clusterName))
 	m.logger.Info("Updating migration entry", zap.String("query", query), zap.String("status", status), zap.String("error", err), zap.Uint64("migration_id", migrationID))
 	return m.conn.Exec(ctx, query, status, err, time.Now().UTC().Format("2006-01-02 15:04:05"), migrationID)
 }

--- a/cmd/signozschemamigrator/schema_migrator/op.go
+++ b/cmd/signozschemamigrator/schema_migrator/op.go
@@ -1,5 +1,14 @@
 package schemamigrator
 
+import "fmt"
+
+// EscapeClusterName returns the cluster name escaped with backticks for use in SQL.
+// ClickHouse requires backtick escaping for cluster names that contain special
+// characters like hyphens (e.g., `dev-signoz`).
+func EscapeClusterName(cluster string) string {
+	return fmt.Sprintf("`%s`", cluster)
+}
+
 // Operation is the interface that all operations must implement.
 // An Operation that is not mutation, idempotent and lightweight is expected
 // to complete almost immediately given there are no blocking items in the

--- a/cmd/signozschemamigrator/schema_migrator/projection_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/projection_operations.go
@@ -108,7 +108,7 @@ func (d DropProjectionOperation) ToSQL() string {
 	sql.WriteString(d.Table)
 	if d.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(d.cluster)
+		sql.WriteString(EscapeClusterName(d.cluster))
 	}
 	sql.WriteString(" DROP PROJECTION IF EXISTS ")
 	sql.WriteString(d.Projection.Name)

--- a/cmd/signozschemamigrator/schema_migrator/table_operations.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations.go
@@ -74,7 +74,7 @@ func (c CreateTableOperation) ToSQL() string {
 	sql.WriteString(c.Table)
 	if c.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(c.cluster)
+		sql.WriteString(EscapeClusterName(c.cluster))
 	}
 	columnParts := []string{}
 	for _, column := range c.Columns {
@@ -141,7 +141,7 @@ func (d DropTableOperation) ToSQL() string {
 	sql.WriteString(d.Table)
 	if d.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(d.cluster)
+		sql.WriteString(EscapeClusterName(d.cluster))
 	}
 	if len(d.Settings) > 0 {
 		sql.WriteString(" SETTINGS ")
@@ -203,7 +203,7 @@ func (c CreateMaterializedViewOperation) ToSQL() string {
 	sql.WriteString(c.ViewName)
 	if c.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(c.cluster)
+		sql.WriteString(EscapeClusterName(c.cluster))
 	}
 	sql.WriteString(" TO ")
 	sql.WriteString(c.Database)
@@ -274,7 +274,7 @@ func (c ModifyQueryMaterializedViewOperation) ToSQL() string {
 	sql.WriteString(c.ViewName)
 	if c.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(c.cluster)
+		sql.WriteString(EscapeClusterName(c.cluster))
 	}
 	sql.WriteString(" MODIFY QUERY ")
 	sql.WriteString(c.Query)
@@ -325,7 +325,7 @@ func (d TruncateTableOperation) ToSQL() string {
 	sql.WriteString(d.Table)
 	if d.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(d.cluster)
+		sql.WriteString(EscapeClusterName(d.cluster))
 	}
 	return sql.String()
 }
@@ -388,7 +388,7 @@ func (a AlterTableModifyTTL) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY TTL ")
 	sql.WriteString(a.TTL)
@@ -445,7 +445,7 @@ func (a AlterTableDropTTL) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" REMOVE TTL")
 	return sql.String()
@@ -504,7 +504,7 @@ func (a AlterTableModifySettings) ToSQL() string {
 	sql.WriteString(a.Table)
 	if a.cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(a.cluster)
+		sql.WriteString(EscapeClusterName(a.cluster))
 	}
 	sql.WriteString(" MODIFY SETTING ")
 	sql.WriteString(a.Settings.ToSQL())

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -302,7 +302,7 @@ func TestCreateWithCluster(t *testing.T) {
 					},
 				},
 			},
-			want: "CREATE TABLE IF NOT EXISTS db.table ON CLUSTER cluster (id Int16) ENGINE = ReplacingMergeTree ORDER BY id",
+			want: "CREATE TABLE IF NOT EXISTS db.table ON CLUSTER `cluster` (id Int16) ENGINE = ReplacingMergeTree ORDER BY id",
 		},
 	}
 
@@ -335,7 +335,7 @@ func TestTruncateTable(t *testing.T) {
 				Table:    "table",
 				cluster:  "cluster",
 			},
-			want: "TRUNCATE TABLE IF EXISTS db.table ON CLUSTER cluster",
+			want: "TRUNCATE TABLE IF EXISTS db.table ON CLUSTER `cluster`",
 		},
 	}
 
@@ -369,7 +369,7 @@ func TestAlterTableModifyTTL(t *testing.T) {
 				TTL:      "ts + INTERVAL 1 DAY",
 				cluster:  "cluster",
 			},
-			want: "ALTER TABLE db.table ON CLUSTER cluster MODIFY TTL ts + INTERVAL 1 DAY SETTINGS materialize_ttl_after_modify = 0",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` MODIFY TTL ts + INTERVAL 1 DAY SETTINGS materialize_ttl_after_modify = 0",
 		},
 	}
 
@@ -401,7 +401,7 @@ func TestAlterTableDropTTL(t *testing.T) {
 				Table:    "table",
 				cluster:  "cluster",
 			},
-			want: "ALTER TABLE db.table ON CLUSTER cluster REMOVE TTL",
+			want: "ALTER TABLE db.table ON CLUSTER `cluster` REMOVE TTL",
 		},
 	}
 


### PR DESCRIPTION
The schema migrator fails when using ClickHouse cluster names with special characters like hyphens (e.g. `dev-signoz`). Cluster names were written directly into SQL statements without escaping, causing syntax errors.

The fix wraps cluster names in backticks in all SQL statements generated by the schema migrator.

Fixes #838