### PR TITLE
fix(lint): resolve remaining golangci-lint errors across codebase (part 2)

### DIFF
--- a/exporter/signozkafkaexporter/internal/awsmsk/iam_scram_client.go
+++ b/exporter/signozkafkaexporter/internal/awsmsk/iam_scram_client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/Shopify/sarama"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	sign "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/aws/credentials" //nolint:staticcheck
+	sign "github.com/aws/aws-sdk-go/aws/signer/v4" //nolint:staticcheck
 	"go.uber.org/multierr"
 )
 

--- a/internal/kafka/awsmsk/iam_scram_client.go
+++ b/internal/kafka/awsmsk/iam_scram_client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/IBM/sarama"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	sign "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/aws/credentials" //nolint:staticcheck
+	sign "github.com/aws/aws-sdk-go/aws/signer/v4" //nolint:staticcheck
 	"go.uber.org/multierr"
 )
 

--- a/pkg/keycheck/keycheck.go
+++ b/pkg/keycheck/keycheck.go
@@ -138,7 +138,7 @@ func isULID(s string) bool {
 
 	// Check if it's base32 (A-Z, 0-9, excluding I, L, O, U)
 	for _, char := range s {
-		if !((char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9')) {
+		if !(char >= 'A' && char <= 'Z') && !(char >= '0' && char <= '9') {
 			return false
 		}
 		// Exclude I, L, O, U

--- a/pkg/keycheck/keycheck.go
+++ b/pkg/keycheck/keycheck.go
@@ -138,7 +138,7 @@ func isULID(s string) bool {
 
 	// Check if it's base32 (A-Z, 0-9, excluding I, L, O, U)
 	for _, char := range s {
-		if !(char >= 'A' && char <= 'Z') && !(char >= '0' && char <= '9') {
+		if (char < 'A' || char > 'Z') && (char < '0' || char > '9') {
 			return false
 		}
 		// Exclude I, L, O, U

--- a/pkg/schema/traces/event.go
+++ b/pkg/schema/traces/event.go
@@ -81,7 +81,7 @@ func NewEventsAndErrorEvents(input ptrace.SpanEventSlice, serviceName string, lo
 			event.IsError = true
 			errorEvent.Event = event
 			uuidWithHyphen := uuid.New()
-			uuid := strings.Replace(uuidWithHyphen.String(), "-", "", -1)
+			uuid := strings.ReplaceAll(uuidWithHyphen.String(), "-", "")
 			errorEvent.ErrorID = uuid
 			var hash [16]byte
 			if lowCardinalExceptionGrouping {

--- a/processor/signozlogspipelineprocessor/stanza/entry/field.go
+++ b/processor/signozlogspipelineprocessor/stanza/entry/field.go
@@ -145,7 +145,7 @@ func fromJSONDot(s string) ([]string, error) {
 			tokenStart = i
 			state = InUnbracketedToken
 		case InBracket:
-			if !(c == '\'' || c == '"') {
+			if c != '\'' && c != '"' {
 				return nil, fmt.Errorf("strings in brackets must be surrounded by quotes")
 			}
 			state = InQuote
@@ -172,10 +172,11 @@ func fromJSONDot(s string) ([]string, error) {
 				return nil, fmt.Errorf("bracketed access must be followed by a dot or another bracketed access")
 			}
 		case InUnbracketedToken:
-			if c == '.' {
+			switch c {
+			case '.':
 				fields = append(fields, s[tokenStart:i])
 				tokenStart = i + 1
-			} else if c == '[' {
+			case '[':
 				fields = append(fields, s[tokenStart:i])
 				state = InBracket
 			}

--- a/processor/signozlogspipelineprocessor/stanza/operator/helper/like.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/helper/like.go
@@ -39,7 +39,7 @@ func parseLikePattern(pattern string) (kind patternKind, lit1, lit2 string) {
 	n := len(runes)
 
 	leadingPct := n > 0 && runes[0] == '%'
-	trailingPct := n > 0 && runes[n-1] == '%' && !(n > 1 && runes[n-2] == '\\')
+	trailingPct := n > 0 && runes[n-1] == '%' && (n <= 1 || runes[n-2] != '\\')
 
 	// Walk the pattern collecting literal characters. When we encounter an
 	// unescaped '%' in the interior (not the leading/trailing sentinel), we

--- a/processor/signozlogspipelineprocessor/stanza/operator/helper/parser.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/helper/parser.go
@@ -144,7 +144,7 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 	}
 
 	if err := entry.Set(p.ParseTo, newValue); err != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set parse_to"))
+		return p.HandleEntryError(ctx, entry, fmt.Errorf("set parse_to: %w", err))
 	}
 
 	if p.BodyField != nil {
@@ -175,16 +175,16 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 
 	// Handle parsing errors after attempting to parse all
 	if timeParseErr != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(timeParseErr, "time parser"))
+		return p.HandleEntryError(ctx, entry, fmt.Errorf("time parser: %w", timeParseErr))
 	}
 	if severityParseErr != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(severityParseErr, "severity parser"))
+		return p.HandleEntryError(ctx, entry, fmt.Errorf("severity parser: %w", severityParseErr))
 	}
 	if traceParseErr != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(traceParseErr, "trace parser"))
+		return p.HandleEntryError(ctx, entry, fmt.Errorf("trace parser: %w", traceParseErr))
 	}
 	if scopeNameParserErr != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(scopeNameParserErr, "scope_name parser"))
+		return p.HandleEntryError(ctx, entry, fmt.Errorf("scope_name parser: %w", scopeNameParserErr))
 	}
 	return nil
 }

--- a/processor/signozlogspipelineprocessor/stanza/operator/helper/scope_name.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/helper/scope_name.go
@@ -4,6 +4,8 @@
 package signozstanzahelper
 
 import (
+	"fmt"
+
 	signozstanzaentry "github.com/SigNoz/signoz-otel-collector/processor/signozlogspipelineprocessor/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -34,7 +36,7 @@ func (p *ScopeNameParser) Parse(ent *entry.Entry) error {
 	if !ok {
 		err := ent.Set(p.ParseFrom, value)
 		if err != nil {
-			return errors.Wrap(err, "parse_from field does not contain a string")
+			return fmt.Errorf("parse_from field does not contain a string: %w", err)
 		}
 		return errors.NewError(
 			"parse_from field does not contain a string",

--- a/processor/signozlogspipelineprocessor/stanza/operator/helper/severity.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/helper/severity.go
@@ -33,7 +33,7 @@ func (p *SeverityParser) Parse(ent *entry.Entry) error {
 
 	severity, sevText, err := p.Mapping.find(value)
 	if err != nil {
-		return errors.Wrap(err, "parse")
+		return fmt.Errorf("parse: %w", err)
 	}
 	if p.overwriteText && severity != entry.Default {
 		sevText = severity.String()

--- a/processor/signozlogspipelineprocessor/stanza/operator/helper/time.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/helper/time.go
@@ -78,7 +78,7 @@ func (t *TimeParser) Validate() error {
 		var err error
 		t.Layout, err = StrptimeToGotime(t.Layout)
 		if err != nil {
-			return errors.Wrap(err, "parse strptime layout")
+			return fmt.Errorf("parse strptime layout: %w", err)
 		}
 		t.LayoutType = GotimeKey
 	case EpochKey:
@@ -99,7 +99,7 @@ func (t *TimeParser) Validate() error {
 
 	if t.LayoutType == GotimeKey { // also covers StrptimeKey because it was remapped above
 		if err := t.setLocation(); err != nil {
-			return errors.Wrap(err, "invalid 'location'")
+			return fmt.Errorf("invalid 'location': %w", err)
 		}
 	}
 

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/transformer.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/normalize/transformer.go
@@ -29,7 +29,7 @@ type Processor struct {
 
 // Process will parse an entry for JSON.
 func (p *Processor) Process(ctx context.Context, entry *entry.Entry) error {
-	err := p.TransformerOperator.ProcessWith(ctx, entry, p.transform)
+	err := p.ProcessWith(ctx, entry, p.transform)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (p *Processor) ProcessBatch(ctx context.Context, entries []*entry.Entry) er
 
 // normalize log body
 func (p *Processor) transform(entry *entry.Entry) error {
-	parsedValue := make(map[string]any)
+	var parsedValue map[string]any
 	switch v := entry.Body.(type) {
 	case string:
 		parsedValue = p.processTextLogs(v)
@@ -132,7 +132,9 @@ func (p *Processor) normalize(entry *entry.Entry) {
 				// delete "message" first, then shift all inner keys to top level
 				entry.Delete(message)
 				for key, value := range mapValue {
-					entry.Set(signozstanzaentry.NewBodyField(key), value)
+					if err := entry.Set(signozstanzaentry.NewBodyField(key), value); err != nil {
+						p.Logger().Error("Failed to set body field", zap.Error(err))
+					}
 				}
 			}
 		}

--- a/receiver/httplogreceiver/bodyparser/heroku.go
+++ b/receiver/httplogreceiver/bodyparser/heroku.go
@@ -112,10 +112,7 @@ func octetCountingSplitter(data string) []string {
 		lengthStr := ""
 
 		// ignore tabs and spaces
-		for {
-			if index >= length || (data[index] != ' ' && data[index] != '\t' && data[index] != '\n') {
-				break
-			}
+		for index < length && (data[index] == ' ' || data[index] == '\t' || data[index] == '\n') {
 			index++
 		}
 

--- a/receiver/httplogreceiver/httplogreceiver.go
+++ b/receiver/httplogreceiver/httplogreceiver.go
@@ -135,7 +135,7 @@ func (r *httplogreceiver) Start(ctx context.Context, host component.Host) error 
 	mx := mux.NewRouter()
 	mx.HandleFunc("/", r.handleLogs)
 
-	r.server, err = r.config.ServerConfig.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings, mx)
+	r.server, err = r.config.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings, mx)
 	if err != nil {
 		return err
 	}

--- a/receiver/signozawsfirehosereceiver/logs_test.go
+++ b/receiver/signozawsfirehosereceiver/logs_test.go
@@ -82,8 +82,8 @@ func TestLogsReceiverWithSuccess(t *testing.T) {
 	sink := &consumertest.LogsSink{}
 	cfg := createDefaultConfig().(*Config)
 	cfg.RecordType = "test"
-	cfg.ServerConfig.NetAddr.Endpoint = "localhost:0"
-	cfg.ServerConfig.NetAddr.Transport = "tcp"
+	cfg.NetAddr.Endpoint = "localhost:0"
+	cfg.NetAddr.Transport = "tcp"
 
 	receiver, err := newLogsReceiver(
 		cfg,
@@ -129,8 +129,8 @@ func TestLogsReceiverWithError(t *testing.T) {
 
 	cfg := createDefaultConfig().(*Config)
 	cfg.RecordType = "test"
-	cfg.ServerConfig.NetAddr.Endpoint = "localhost:0"
-	cfg.ServerConfig.NetAddr.Transport = "tcp"
+	cfg.NetAddr.Endpoint = "localhost:0"
+	cfg.NetAddr.Transport = "tcp"
 
 	receiver, err := newLogsReceiver(
 		cfg,

--- a/receiver/signozawsfirehosereceiver/metrics_test.go
+++ b/receiver/signozawsfirehosereceiver/metrics_test.go
@@ -82,8 +82,8 @@ func TestMetricsReceiverWithSuccess(t *testing.T) {
 	sink := &consumertest.MetricsSink{}
 	cfg := createDefaultConfig().(*Config)
 	cfg.RecordType = "test"
-	cfg.ServerConfig.NetAddr.Endpoint = "localhost:0"
-	cfg.ServerConfig.NetAddr.Transport = "tcp"
+	cfg.NetAddr.Endpoint = "localhost:0"
+	cfg.NetAddr.Transport = "tcp"
 
 	receiver, err := newMetricsReceiver(
 		cfg,
@@ -129,8 +129,8 @@ func TestMetricsReceiverWithError(t *testing.T) {
 
 	cfg := createDefaultConfig().(*Config)
 	cfg.RecordType = "test"
-	cfg.ServerConfig.NetAddr.Endpoint = "localhost:0"
-	cfg.ServerConfig.NetAddr.Transport = "tcp"
+	cfg.NetAddr.Endpoint = "localhost:0"
+	cfg.NetAddr.Transport = "tcp"
 
 	receiver, err := newMetricsReceiver(
 		cfg,

--- a/receiver/signozawsfirehosereceiver/receiver.go
+++ b/receiver/signozawsfirehosereceiver/receiver.go
@@ -121,13 +121,13 @@ func (fmr *firehoseReceiver) Start(ctx context.Context, host component.Host) err
 	router := configrouter.NewDefaultMuxConfig().ToMuxRouter(fmr.settings.Logger)
 	router.HandleFunc("/awsfirehose/"+fmr.config.RecordType, fmr.ServeHTTP)
 
-	fmr.server, err = fmr.config.ServerConfig.ToServer(ctx, host.GetExtensions(), fmr.settings.TelemetrySettings, router)
+	fmr.server, err = fmr.config.ToServer(ctx, host.GetExtensions(), fmr.settings.TelemetrySettings, router)
 	if err != nil {
 		return err
 	}
 
 	var listener net.Listener
-	listener, err = fmr.config.ServerConfig.ToListener(ctx)
+	listener, err = fmr.config.ToListener(ctx)
 	if err != nil {
 		return err
 	}

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -461,7 +461,7 @@ type baseConsumerGroupHandler struct {
 func (b *baseConsumerGroupHandler) WithMemoryLimiter(ctx context.Context, claim sarama.ConsumerGroupClaim, consume func() error) error {
 	// Execute f() immediately
 	err := consume()
-	if err == nil || !(err.Error() == errHighMemoryUsage.Error()) {
+	if err == nil || err.Error() != errHighMemoryUsage.Error() {
 		return err
 	}
 
@@ -481,7 +481,7 @@ func (b *baseConsumerGroupHandler) WithMemoryLimiter(ctx context.Context, claim 
 				b.group.ResumeAll()
 				return nil
 			}
-			if !(err.Error() == errHighMemoryUsage.Error()) {
+			if err.Error() != errHighMemoryUsage.Error() {
 				b.group.ResumeAll()
 				return err
 			}

--- a/usage/common.go
+++ b/usage/common.go
@@ -48,7 +48,7 @@ func Encrypt(key, text []byte) ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 		return nil, err
 	}
-	cfb := cipher.NewCFBEncrypter(block, iv)
+	cfb := cipher.NewCFBEncrypter(block, iv) //nolint:staticcheck
 	cfb.XORKeyStream(ciphertext[aes.BlockSize:], []byte(b))
 	return ciphertext, nil
 }


### PR DESCRIPTION
## Summary

Fixes remaining lint issues after PR #836. Excludes `exporter/jsontypeexporter` (planned for separate cleanup).

Check this [lint check log](https://github.com/SigNoz/signoz-otel-collector/actions/runs/27000878959/job/79680808636) for understanding the errors.

One commit per category:

- **errcheck + ineffassign + QF1008** (`normalize/transformer.go`): check error from `entry.Set`, use `var parsedValue` instead of `make`, remove redundant embedded field selector
- **SA1019 — deprecated `errors.Wrap`** (`stanza/operator/helper/parser.go`): replace 5 instances of `errors.Wrap(err, "msg")` with `fmt.Errorf("msg: %w", err)`
- **SA1019 — nolint** (`awsmsk/iam_scram_client.go` ×2, `usage/common.go`): suppress deprecation warnings for aws-sdk-go v1 and `cipher.NewCFBEncrypter` that cannot be upgraded in this PR
- **QF1001/QF1003/QF1004/QF1006 simplifications**: De Morgan's law negations, tagged switch, `strings.ReplaceAll`, lift for-loop break condition

## Test plan

- [x] `go build ./...` passes locally
- [x] CI lint check passes for the fixed cases
- [x] No behavioural changes — all fixes are mechanical simplifications or error handling additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)