### PR TITLE
fix(exporter/signozclickhousemetrics): do not count reduced metrics towards usage and other fixes

### DIFF
--- a/exporter/signozclickhousemetrics/exporter.go
+++ b/exporter/signozclickhousemetrics/exporter.go
@@ -516,10 +516,14 @@ func (c *clickhouseMetricsExporter) processHistogram(b *batch, metric pmetric.Me
 
 	resourceFingerprintMap := resourceFingerprint.AttributesAsMap()
 	scopeFingerprintMap := scopeFingerprint.AttributesAsMap()
-	// rules match the base metric name and cover every derived series
-	reducer := c.newReducerFor(name, resourceFingerprint, scopeFingerprint)
+	// rules are keyed by the flattened metric name
+	countReducer := c.newReducerFor(name+countSuffix, resourceFingerprint, scopeFingerprint)
+	sumReducer := c.newReducerFor(name+sumSuffix, resourceFingerprint, scopeFingerprint)
+	minReducer := c.newReducerFor(name+minSuffix, resourceFingerprint, scopeFingerprint)
+	maxReducer := c.newReducerFor(name+maxSuffix, resourceFingerprint, scopeFingerprint)
+	bucketReducer := c.newReducerFor(name+bucketSuffix, resourceFingerprint, scopeFingerprint)
 
-	addSample := func(batch *batch, dp pmetric.HistogramDataPoint, suffix string) {
+	addSample := func(batch *batch, dp pmetric.HistogramDataPoint, suffix string, reducer *reducer) {
 		unixMilli := dp.Timestamp().AsTime().UnixMilli()
 		sampleTyp := typ
 		sampleUnit := unit
@@ -587,7 +591,7 @@ func (c *clickhouseMetricsExporter) processHistogram(b *batch, metric pmetric.Me
 		}
 	}
 
-	addBucketSample := func(batch *batch, dp pmetric.HistogramDataPoint, suffix string) {
+	addBucketSample := func(batch *batch, dp pmetric.HistogramDataPoint, suffix string, reducer *reducer) {
 		var cumulativeCount uint64
 		unixMilli := dp.Timestamp().AsTime().UnixMilli()
 		pointAttrs := dp.Attributes()
@@ -704,17 +708,17 @@ func (c *clickhouseMetricsExporter) processHistogram(b *batch, metric pmetric.Me
 			c.logger.Debug(NanDetectedErrMsg, zap.String("metric_name", name))
 			continue
 		}
-		addSample(b, dp, countSuffix)
+		addSample(b, dp, countSuffix, countReducer)
 		if dp.HasSum() {
-			addSample(b, dp, sumSuffix)
+			addSample(b, dp, sumSuffix, sumReducer)
 		}
 		if dp.HasMin() {
-			addSample(b, dp, minSuffix)
+			addSample(b, dp, minSuffix, minReducer)
 		}
 		if dp.HasMax() {
-			addSample(b, dp, maxSuffix)
+			addSample(b, dp, maxSuffix, maxReducer)
 		}
-		addBucketSample(b, dp, bucketSuffix)
+		addBucketSample(b, dp, bucketSuffix, bucketReducer)
 	}
 
 	// Add resource/scope metadata for all suffixes after processing all datapoints
@@ -746,10 +750,12 @@ func (c *clickhouseMetricsExporter) processSummary(b *batch, metric pmetric.Metr
 
 	resourceFingerprintMap := resourceFingerprint.AttributesAsMap()
 	scopeFingerprintMap := scopeFingerprint.AttributesAsMap()
-	// rules match the base metric name and cover every derived series
-	reducer := c.newReducerFor(name, resourceFingerprint, scopeFingerprint)
+	// rules are keyed by the flattened metric name
+	countReducer := c.newReducerFor(name+countSuffix, resourceFingerprint, scopeFingerprint)
+	sumReducer := c.newReducerFor(name+sumSuffix, resourceFingerprint, scopeFingerprint)
+	quantileReducer := c.newReducerFor(name+quantilesSuffix, resourceFingerprint, scopeFingerprint)
 
-	addSample := func(batch *batch, dp pmetric.SummaryDataPoint, suffix string) {
+	addSample := func(batch *batch, dp pmetric.SummaryDataPoint, suffix string, reducer *reducer) {
 		unixMilli := dp.Timestamp().AsTime().UnixMilli()
 		sampleTyp := typ
 		sampleUnit := unit
@@ -804,7 +810,7 @@ func (c *clickhouseMetricsExporter) processSummary(b *batch, metric pmetric.Metr
 		}
 	}
 
-	addQuantileSample := func(batch *batch, dp pmetric.SummaryDataPoint, suffix string) {
+	addQuantileSample := func(batch *batch, dp pmetric.SummaryDataPoint, suffix string, reducer *reducer) {
 		// quantile values are instantaneous estimates with gauge semantics, not counters
 		quantileTemporality := pmetric.AggregationTemporalityUnspecified
 		quantileIsMonotonic := false
@@ -888,9 +894,9 @@ func (c *clickhouseMetricsExporter) processSummary(b *batch, metric pmetric.Metr
 		if skip {
 			continue
 		}
-		addSample(b, dp, countSuffix)
-		addSample(b, dp, sumSuffix)
-		addQuantileSample(b, dp, quantilesSuffix)
+		addSample(b, dp, countSuffix, countReducer)
+		addSample(b, dp, sumSuffix, sumReducer)
+		addQuantileSample(b, dp, quantilesSuffix, quantileReducer)
 	}
 
 	// Add resource/scope metadata for all suffixes after processing all datapoints
@@ -1097,9 +1103,9 @@ func (c *clickhouseMetricsExporter) processExponentialHistogram(b *batch, metric
 
 func (c *clickhouseMetricsExporter) prepareBatch(ctx context.Context, md pmetric.Metrics) *batch {
 	batch := newBatch(c.logger,
-		int(c.lastSamplesLen.Load()),
-		int(c.lastTsLen.Load()),
-		int(c.lastMetadataLen.Load()))
+		int(float64(c.lastSamplesLen.Load())*1.5),
+		int(float64(c.lastTsLen.Load())*1.5),
+		int(float64(c.lastMetadataLen.Load())*1.5))
 	start := time.Now()
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
@@ -1302,12 +1308,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 			if err != nil {
 				return err
 			}
-			collectUsage := true
-			if strings.HasPrefix(sample.metricName, "signoz") || strings.HasPrefix(sample.metricName, "chi") || strings.HasPrefix(sample.metricName, "otelcol") {
-				collectUsage = false
-			}
-
-			if collectUsage {
+			if collectUsageForSample(sample) {
 				usage.AddMetric(metrics, "default", 1, 0)
 			}
 		}
@@ -1452,6 +1453,18 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 	}
 
 	return errors.Join(errs...)
+}
+
+func collectUsageForSample(s *sample) bool {
+	if s.reducedFingerprint != 0 {
+		return false
+	}
+	if strings.HasPrefix(s.metricName, "signoz") ||
+		strings.HasPrefix(s.metricName, "chi") ||
+		strings.HasPrefix(s.metricName, "otelcol") {
+		return false
+	}
+	return true
 }
 
 func makeCacheKey(a, b uint64) string {

--- a/exporter/signozclickhousemetrics/exporter.go
+++ b/exporter/signozclickhousemetrics/exporter.go
@@ -1308,7 +1308,7 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 			if err != nil {
 				return err
 			}
-			if collectUsageForSample(sample) {
+			if c.collectUsageForSample(sample) {
 				usage.AddMetric(metrics, "default", 1, 0)
 			}
 		}
@@ -1455,13 +1455,13 @@ func (c *clickhouseMetricsExporter) writeBatch(ctx context.Context, batch *batch
 	return errors.Join(errs...)
 }
 
-func collectUsageForSample(s *sample) bool {
-	if s.reducedFingerprint != 0 {
-		return false
-	}
+func (c *clickhouseMetricsExporter) collectUsageForSample(s *sample) bool {
 	if strings.HasPrefix(s.metricName, "signoz") ||
 		strings.HasPrefix(s.metricName, "chi") ||
 		strings.HasPrefix(s.metricName, "otelcol") {
+		return false
+	}
+	if s.reducedFingerprint != 0 || c.ruleFor(s.metricName) != nil {
 		return false
 	}
 	return true

--- a/exporter/signozclickhousemetrics/factory.go
+++ b/exporter/signozclickhousemetrics/factory.go
@@ -43,12 +43,19 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings,
 	}
 
 	id := uuid.New()
+	usageOpts := usage.Options{
+		ReportingInterval: usage.DefaultCollectionInterval,
+	}
+	if chCfg.Reduction.Enabled {
+		usageOpts.ReducedUsageTables = []string{
+			"distributed_samples_v4_reduced_last_60s",
+			"distributed_samples_v4_reduced_sum_60s",
+		}
+	}
 	collector := usage.NewUsageCollector(
 		id,
 		conn,
-		usage.Options{
-			ReportingInterval: usage.DefaultCollectionInterval,
-		},
+		usageOpts,
 		"signoz_metrics",
 		UsageExporter,
 		set.Logger,

--- a/exporter/signozclickhousemetrics/rules.go
+++ b/exporter/signozclickhousemetrics/rules.go
@@ -23,8 +23,8 @@ var protectedLabels = map[string]struct{}{
 
 const rulesPollTimeout = 30 * time.Second
 
-// reductionRule is one compiled label drop/keep rule, keyed by base metric
-// name; it covers every series derived from that metric.
+// reductionRule is one compiled label drop/keep rule, keyed by the flattened
+// metric name, e.g. http.server.duration.bucket.
 type reductionRule struct {
 	// keys is the configured label set; keep picks the mode. keep=false drops
 	// keys (rest kept); keep=true keeps only keys (rest dropped). protected
@@ -53,7 +53,7 @@ func (r *reductionRule) appliesAt(unixMilli int64) bool {
 
 type ruleSet map[string]*reductionRule
 
-// ruleFor returns the active rule for the base metric name, or nil.
+// ruleFor returns the active rule for the metric name, or nil.
 func (c *clickhouseMetricsExporter) ruleFor(metricName string) *reductionRule {
 	rules := c.reductionRules.Load()
 	if rules == nil {
@@ -216,7 +216,7 @@ type reducedSeries struct {
 	resource    *pkgfingerprint.Fingerprint
 }
 
-// newReducerFor returns a reducer for the metric, or nil when reduction is
+// newReducerFor returns a reducer for the metric name, or nil when reduction is
 // disabled or no rule matches.
 func (c *clickhouseMetricsExporter) newReducerFor(metricName string, resourceFingerprint, scopeFingerprint *pkgfingerprint.Fingerprint) *reducer {
 	if !c.cfg.Reduction.Enabled {
@@ -235,7 +235,7 @@ func (c *clickhouseMetricsExporter) newReducerFor(metricName string, resourceFin
 
 // reduce returns the reduced series for a datapoint fingerprint, or nil when the
 // rule does not apply at the datapoint's timestamp (pre-epoch data stays unreduced
-// and flows to the long-retention tables). nameWithSuffix is the stored series
+// and flows to the long-retention tables). nameWithSuffix is the stored metric
 // name, e.g. metric.bucket.
 func (r *reducer) reduce(pointFingerprint *pkgfingerprint.Fingerprint, nameWithSuffix string, unixMilli int64) *reducedSeries {
 	if r == nil || !r.rule.appliesAt(unixMilli) {

--- a/exporter/signozclickhousemetrics/rules_test.go
+++ b/exporter/signozclickhousemetrics/rules_test.go
@@ -304,12 +304,30 @@ func Test_reductionRuleAppliesAt(t *testing.T) {
 }
 
 func Test_collectUsageForSample(t *testing.T) {
-	assert.True(t, collectUsageForSample(&sample{metricName: "http.server.duration.count"}))
-	assert.False(t, collectUsageForSample(&sample{metricName: "signoz.collector.foo"}))
-	assert.False(t, collectUsageForSample(&sample{metricName: "chi.foo"}))
-	assert.False(t, collectUsageForSample(&sample{metricName: "otelcol.foo"}))
-	// reduced (ruled) samples are billed via the reduced dimension, not as ingested usage
-	assert.False(t, collectUsageForSample(&sample{metricName: "http.server.duration.bucket", reducedFingerprint: 42}))
+	exp := newReductionExporter(t, ruleSet{
+		"http.server.duration0.bucket": {keys: labelSet("resource.attr_0")},
+	})
+
+	assert.True(t, exp.collectUsageForSample(&sample{metricName: "http.server.duration0.count"}))
+
+	// internal metrics
+	assert.False(t, exp.collectUsageForSample(&sample{metricName: "signoz.collector.foo"}))
+	assert.False(t, exp.collectUsageForSample(&sample{metricName: "chi.foo"}))
+	assert.False(t, exp.collectUsageForSample(&sample{metricName: "otelcol.foo"}))
+
+	// reduced
+	assert.False(t, exp.collectUsageForSample(&sample{metricName: "anything", reducedFingerprint: 42}))
+
+	// ruled metric is skipped
+	assert.False(t, exp.collectUsageForSample(&sample{metricName: "http.server.duration0.bucket"}))
+
+	disabled, err := NewClickHouseExporter(
+		WithLogger(zap.NewNop()),
+		WithConfig(&Config{}),
+		WithMeter(noop.NewMeterProvider().Meter(internalmetadata.ScopeName)),
+	)
+	require.NoError(t, err)
+	assert.True(t, disabled.collectUsageForSample(&sample{metricName: "http.server.duration0.bucket"}))
 }
 
 func Test_reductionConfigValidate(t *testing.T) {

--- a/exporter/signozclickhousemetrics/rules_test.go
+++ b/exporter/signozclickhousemetrics/rules_test.go
@@ -229,27 +229,45 @@ func Test_reductionCollapsesAcrossResources(t *testing.T) {
 	assert.Equal(t, batch.samples[0].reducedFingerprint, batch.samples[1].reducedFingerprint)
 }
 
-func Test_reductionHistogramDerivedSeries(t *testing.T) {
+func Test_reductionHistogramFlattenedRules(t *testing.T) {
+	// rules are keyed by the flattened metric name: only the listed derived
+	// metrics (.bucket and .count here) are reduced; .sum/.min/.max pass through.
 	exp := newReductionExporter(t, ruleSet{
-		"http.server.duration0": {keys: labelSet("resource.attr_0")},
+		"http.server.duration0.bucket": {keys: labelSet("resource.attr_0")},
+		"http.server.duration0.count":  {keys: labelSet("resource.attr_0")},
 	})
 	metrics := pmetricsgen.GenerateHistogramMetrics(1, 1, 1, 1, 1, 0, 0)
 	batch := exp.prepareBatch(context.Background(), metrics)
 
 	require.NotEmpty(t, batch.samples)
 	for _, s := range batch.samples {
-		assert.NotZero(t, s.reducedFingerprint, "derived series %s should inherit the base metric rule", s.metricName)
+		if strings.HasSuffix(s.metricName, bucketSuffix) || strings.HasSuffix(s.metricName, countSuffix) {
+			assert.NotZero(t, s.reducedFingerprint, "ruled metric %s should be reduced", s.metricName)
+		} else {
+			assert.Zero(t, s.reducedFingerprint, "unruled metric %s should pass through", s.metricName)
+		}
 	}
-	var reducedBuckets int
+
+	var reducedBuckets, reducedCount, reducedOther int
 	for _, ts := range batch.ts {
-		if ts.isReduced && strings.HasSuffix(ts.metricName, bucketSuffix) {
+		if !ts.isReduced {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(ts.metricName, bucketSuffix):
 			reducedBuckets++
 			assert.Contains(t, ts.attrs, "le", "le is a protected label and must survive reduction")
 			assert.NotContains(t, ts.resourceAttrs, "resource.attr_0")
+		case strings.HasSuffix(ts.metricName, countSuffix):
+			reducedCount++
+		default:
+			reducedOther++
 		}
 	}
 	// 20 explicit bounds + the +Inf bucket
 	assert.Equal(t, 21, reducedBuckets)
+	assert.Equal(t, 1, reducedCount)
+	assert.Zero(t, reducedOther, "only ruled metrics emit reduced rows")
 }
 
 func Test_reductionSkipsExponentialHistogram(t *testing.T) {
@@ -283,6 +301,15 @@ func Test_reductionRuleAppliesAt(t *testing.T) {
 	assert.True(t, rule.appliesAt(101))
 	assert.True(t, rule.drop("a"))
 	assert.False(t, rule.drop("b"))
+}
+
+func Test_collectUsageForSample(t *testing.T) {
+	assert.True(t, collectUsageForSample(&sample{metricName: "http.server.duration.count"}))
+	assert.False(t, collectUsageForSample(&sample{metricName: "signoz.collector.foo"}))
+	assert.False(t, collectUsageForSample(&sample{metricName: "chi.foo"}))
+	assert.False(t, collectUsageForSample(&sample{metricName: "otelcol.foo"}))
+	// reduced (ruled) samples are billed via the reduced dimension, not as ingested usage
+	assert.False(t, collectUsageForSample(&sample{metricName: "http.server.duration.bucket", reducedFingerprint: 42}))
 }
 
 func Test_reductionConfigValidate(t *testing.T) {

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -15,6 +15,20 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// 10m refreshable mvs + 5 minutes grace
+	reducedUsageSettleWindow = 15 * time.Minute
+	reducedUsageTimeout      = 120 * time.Second
+	// report every hour window
+	reducedUsageWindow = time.Hour
+	// grace look back
+	reducedUsageLookbackWindows = 3
+)
+
+var reducedUsageNamespace = uuid.MustParse("6f9619ff-8b86-d011-b42d-00cf4fc964ff")
+
+var reducedUsageCollectorID = uuid.MustParse("00000000-0000-0000-0000-7265647563ed")
+
 // Options provides options for LogExporter
 type Options struct {
 	// ReportingInterval is a time interval between two successive metrics export.
@@ -48,8 +62,9 @@ type UsageCollector struct {
 	ttl                  int
 	logger               *zap.Logger
 
-	closeChan chan struct{}
-	wg        sync.WaitGroup
+	closeChan     chan struct{}
+	wg            sync.WaitGroup
+	reducedCancel context.CancelFunc
 }
 
 var CollectorID uuid.UUID
@@ -96,7 +111,6 @@ func (e *UsageCollector) Start() error {
 	if err := e.ir.Start(); err != nil {
 		return err
 	}
-	// metrics-only: report retained (reduced) sample usage read from ClickHouse
 	if len(e.o.ReducedUsageTables) > 0 {
 		e.startReducedUsageReporter()
 	}
@@ -106,6 +120,12 @@ func (e *UsageCollector) Start() error {
 func (c *UsageCollector) Stop() error {
 	c.ir.Stop()
 	c.ir.Flush()
+	// cancel any in-flight reduced-usage query so shutdown isn't blocked
+	// then stop the reporter loop and wait for it to exit
+	// before the caller closes the shared connection.
+	if c.reducedCancel != nil {
+		c.reducedCancel()
+	}
 	close(c.closeChan)
 	c.wg.Wait()
 	return nil
@@ -143,34 +163,27 @@ func (e *UsageCollector) ExportMetrics(ctx context.Context, metrics []*metricdat
 	return nil
 }
 
-const (
-	reducedUsageSettleWindow = 15 * time.Minute
-	reducedUsageTimeout      = 120 * time.Second
-)
-
-var reducedUsageNamespace = uuid.MustParse("6f9619ff-8b86-d011-b42d-00cf4fc964ff")
-
-var reducedUsageCollectorID = uuid.MustParse("00000000-0000-0000-0000-7265647563ed")
-
-func dayExporterID(day time.Time) uuid.UUID {
-	return uuid.NewSHA1(reducedUsageNamespace, []byte("reduced-usage:"+day.UTC().Format("2006-01-02")))
+func windowStartOf(t time.Time) time.Time {
+	return t.UTC().Truncate(reducedUsageWindow)
 }
 
-func startOfUTCDay(t time.Time) time.Time {
-	t = t.UTC()
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+func windowExporterID(windowStart time.Time) uuid.UUID {
+	return uuid.NewSHA1(reducedUsageNamespace, []byte(fmt.Sprintf("reduced-usage:%d", windowStart.UTC().Unix())))
 }
 
 // startReducedUsageReporter periodically reports retained/reduced metric sample
 // usage read from ClickHouse. Started only when Options.ReducedUsageTables is set.
 func (e *UsageCollector) startReducedUsageReporter() {
+	ctx, cancel := context.WithCancel(context.Background())
+	e.reducedCancel = cancel
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
+		defer cancel()
 		report := func() {
-			ctx, cancel := context.WithTimeout(context.Background(), reducedUsageTimeout)
-			defer cancel()
-			e.reportReducedUsage(ctx)
+			rctx, rcancel := context.WithTimeout(ctx, reducedUsageTimeout)
+			defer rcancel()
+			e.reportReducedUsage(rctx)
 		}
 		report() // first immediate report
 		ticker := time.NewTicker(e.o.ReportingInterval)
@@ -187,31 +200,48 @@ func (e *UsageCollector) startReducedUsageReporter() {
 }
 
 func (e *UsageCollector) reportReducedUsage(ctx context.Context) {
-	now := time.Now().UTC()
-	for _, day := range []time.Time{now.AddDate(0, 0, -1), now} {
-		if err := e.writeReducedUsage(ctx, day, now); err != nil {
-			e.logger.Error("failed to report reduced usage", zap.Time("day", day), zap.Error(err))
+	e.reportReducedUsageAt(ctx, time.Now().UTC())
+}
+
+// reportReducedUsageAt writes the last few finished hour windows. A window is
+// written only after its data is final, and its count never changes after that,
+// so writing the same window again on later ticks does not affect anything
+func (e *UsageCollector) reportReducedUsageAt(ctx context.Context, now time.Time) {
+	for _, windowStart := range reducedWindowStarts(now) {
+		if err := e.writeReducedWindow(ctx, windowStart); err != nil {
+			e.logger.Error("failed to report reduced usage", zap.Time("window_start", windowStart), zap.Error(err))
 		}
 	}
 }
 
-func (e *UsageCollector) writeReducedUsage(ctx context.Context, day, now time.Time) error {
-	start := startOfUTCDay(day)
-	end := start.Add(24 * time.Hour)
-	if upper := now.Add(-reducedUsageSettleWindow); end.After(upper) {
-		end = upper
+// reducedWindowStarts returns the start times of the last few finished hour
+// windows, newest first. An hour's data is final once the hour ended at least
+// reducedUsageSettleWindow ago, so we go back from (now - settle).
+func reducedWindowStarts(now time.Time) []time.Time {
+	readyUntil := now.Add(-reducedUsageSettleWindow)
+	lastStart := windowStartOf(readyUntil).Add(-reducedUsageWindow)
+	starts := make([]time.Time, reducedUsageLookbackWindows)
+	for i := range starts {
+		starts[i] = lastStart.Add(-time.Duration(i) * reducedUsageWindow)
 	}
-	if !end.After(start) {
-		return nil // nothing settled for this day yet
-	}
+	return starts
+}
 
-	count, err := e.reducedSampleCount(ctx, start, end)
+// writeReducedWindow counts the retained data points in one finished hour
+// window and writes a single row for it. The row is stamped at the window's start
+// so latest wins during the insert and uses a per-window id, so every pod writes
+// the exact same row (duplicates collapse on read).
+// the count is associated to the window's own day
+func (e *UsageCollector) writeReducedWindow(ctx context.Context, windowStart time.Time) error {
+	windowEnd := windowStart.Add(reducedUsageWindow)
+
+	count, err := e.reducedSampleCount(ctx, windowStart, windowEnd)
 	if err != nil {
 		return err
 	}
 
-	exporterID := dayExporterID(day)
-	payload, err := json.Marshal(Usage{TimeStamp: now, Count: int64(count)})
+	exporterID := windowExporterID(windowStart)
+	payload, err := json.Marshal(Usage{TimeStamp: windowStart, Count: int64(count)})
 	if err != nil {
 		return err
 	}
@@ -221,23 +251,27 @@ func (e *UsageCollector) writeReducedUsage(ctx context.Context, day, now time.Ti
 	}
 	return e.db.Exec(ctx,
 		fmt.Sprintf("insert into %s.%s values ($1, $2, $3, $4, $5)", e.dbName, e.distributedTableName),
-		GetTenantNameFromResource(), reducedUsageCollectorID.String(), exporterID.String(), now, string(encrypted),
+		GetTenantNameFromResource(), reducedUsageCollectorID.String(), exporterID.String(), windowStart, string(encrypted),
 	)
 }
 
-// reducedSampleCount returns the number of distinct retained reduced samples in
-// [start, end): one row per (env, temporality, metric_name, reduced_fingerprint,
-// unix_milli), summed across the configured reduced tables.
 func (e *UsageCollector) reducedSampleCount(ctx context.Context, start, end time.Time) (uint64, error) {
 	var total uint64
 	for _, table := range e.o.ReducedUsageTables {
 		var count uint64
+		// The fingerprint is built from env + temporality + metric_name, so
+		// (reduced_fingerprint, unix_milli) identifies a row uniquely.
+		// Grouping by just these two columns reads less data and uses far less
+		// memory than grouping by all five (measured ~3.7x faster, ~2.7x less memory
+		// on the cluster). It still counts correctly because every row for a
+		// fingerprint sits on one node. max_threads keeps this background query
+		// from taking too much of the database at once.
 		query := fmt.Sprintf(`SELECT count() FROM (
-			SELECT env, temporality, metric_name, reduced_fingerprint, unix_milli
+			SELECT reduced_fingerprint, unix_milli
 			FROM %s.%s
 			WHERE unix_milli >= ? AND unix_milli < ?
-			GROUP BY env, temporality, metric_name, reduced_fingerprint, unix_milli
-		)`, e.dbName, table)
+			GROUP BY reduced_fingerprint, unix_milli
+		) SETTINGS max_threads = 8`, e.dbName, table)
 		if err := e.db.QueryRow(ctx, query, start.UnixMilli(), end.UnixMilli()).Scan(&count); err != nil {
 			return 0, err
 		}

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -19,6 +19,11 @@ import (
 type Options struct {
 	// ReportingInterval is a time interval between two successive metrics export.
 	ReportingInterval time.Duration
+	// ReducedUsageTables, when non-empty, enables reporting of retained (reduced)
+	// metric sample usage read from these ClickHouse tables. Only the metrics
+	// exporter sets this (with reduction enabled); leaving it empty disables the
+	// behavior, so logs/traces collectors never run it.
+	ReducedUsageTables []string
 }
 
 type Usage struct {
@@ -42,6 +47,9 @@ type UsageCollector struct {
 	prevSize             int64
 	ttl                  int
 	logger               *zap.Logger
+
+	closeChan chan struct{}
+	wg        sync.WaitGroup
 }
 
 var CollectorID uuid.UUID
@@ -71,6 +79,7 @@ func NewUsageCollector(
 		prevSize:             0,
 		ttl:                  3,
 		logger:               logger,
+		closeChan:            make(chan struct{}),
 	}
 }
 
@@ -84,12 +93,21 @@ func (e *UsageCollector) Start() error {
 		}
 	})
 	e.ir.ReportingInterval = e.o.ReportingInterval
-	return e.ir.Start()
+	if err := e.ir.Start(); err != nil {
+		return err
+	}
+	// metrics-only: report retained (reduced) sample usage read from ClickHouse
+	if len(e.o.ReducedUsageTables) > 0 {
+		e.startReducedUsageReporter()
+	}
+	return nil
 }
 
 func (c *UsageCollector) Stop() error {
 	c.ir.Stop()
 	c.ir.Flush()
+	close(c.closeChan)
+	c.wg.Wait()
 	return nil
 }
 
@@ -123,4 +141,107 @@ func (e *UsageCollector) ExportMetrics(ctx context.Context, metrics []*metricdat
 		}
 	}
 	return nil
+}
+
+const (
+	reducedUsageSettleWindow = 15 * time.Minute
+	reducedUsageTimeout      = 120 * time.Second
+)
+
+var reducedUsageNamespace = uuid.MustParse("6f9619ff-8b86-d011-b42d-00cf4fc964ff")
+
+var reducedUsageCollectorID = uuid.MustParse("00000000-0000-0000-0000-7265647563ed")
+
+func dayExporterID(day time.Time) uuid.UUID {
+	return uuid.NewSHA1(reducedUsageNamespace, []byte("reduced-usage:"+day.UTC().Format("2006-01-02")))
+}
+
+func startOfUTCDay(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// startReducedUsageReporter periodically reports retained/reduced metric sample
+// usage read from ClickHouse. Started only when Options.ReducedUsageTables is set.
+func (e *UsageCollector) startReducedUsageReporter() {
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		report := func() {
+			ctx, cancel := context.WithTimeout(context.Background(), reducedUsageTimeout)
+			defer cancel()
+			e.reportReducedUsage(ctx)
+		}
+		report() // first immediate report
+		ticker := time.NewTicker(e.o.ReportingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-e.closeChan:
+				return
+			case <-ticker.C:
+				report()
+			}
+		}
+	}()
+}
+
+func (e *UsageCollector) reportReducedUsage(ctx context.Context) {
+	now := time.Now().UTC()
+	for _, day := range []time.Time{now.AddDate(0, 0, -1), now} {
+		if err := e.writeReducedUsage(ctx, day, now); err != nil {
+			e.logger.Error("failed to report reduced usage", zap.Time("day", day), zap.Error(err))
+		}
+	}
+}
+
+func (e *UsageCollector) writeReducedUsage(ctx context.Context, day, now time.Time) error {
+	start := startOfUTCDay(day)
+	end := start.Add(24 * time.Hour)
+	if upper := now.Add(-reducedUsageSettleWindow); end.After(upper) {
+		end = upper
+	}
+	if !end.After(start) {
+		return nil // nothing settled for this day yet
+	}
+
+	count, err := e.reducedSampleCount(ctx, start, end)
+	if err != nil {
+		return err
+	}
+
+	exporterID := dayExporterID(day)
+	payload, err := json.Marshal(Usage{TimeStamp: now, Count: int64(count)})
+	if err != nil {
+		return err
+	}
+	encrypted, err := Encrypt([]byte(exporterID.String())[:32], payload)
+	if err != nil {
+		return err
+	}
+	return e.db.Exec(ctx,
+		fmt.Sprintf("insert into %s.%s values ($1, $2, $3, $4, $5)", e.dbName, e.distributedTableName),
+		GetTenantNameFromResource(), reducedUsageCollectorID.String(), exporterID.String(), now, string(encrypted),
+	)
+}
+
+// reducedSampleCount returns the number of distinct retained reduced samples in
+// [start, end): one row per (env, temporality, metric_name, reduced_fingerprint,
+// unix_milli), summed across the configured reduced tables.
+func (e *UsageCollector) reducedSampleCount(ctx context.Context, start, end time.Time) (uint64, error) {
+	var total uint64
+	for _, table := range e.o.ReducedUsageTables {
+		var count uint64
+		query := fmt.Sprintf(`SELECT count() FROM (
+			SELECT env, temporality, metric_name, reduced_fingerprint, unix_milli
+			FROM %s.%s
+			WHERE unix_milli >= ? AND unix_milli < ?
+			GROUP BY env, temporality, metric_name, reduced_fingerprint, unix_milli
+		)`, e.dbName, table)
+		if err := e.db.QueryRow(ctx, query, start.UnixMilli(), end.UnixMilli()).Scan(&count); err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
 }

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -13,27 +13,47 @@ import (
 	"go.uber.org/zap"
 )
 
-func Test_startOfUTCDay(t *testing.T) {
-	got := startOfUTCDay(time.Date(2026, 6, 29, 13, 30, 45, 123, time.UTC))
-	assert.Equal(t, time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC), got)
+func Test_windowStartOf(t *testing.T) {
+	got := windowStartOf(time.Date(2026, 6, 30, 13, 42, 7, 0, time.UTC))
+	assert.Equal(t, time.Date(2026, 6, 30, 13, 0, 0, 0, time.UTC), got)
+
+	// normalized to UTC: 15:30 +02:00 == 13:30 UTC -> window starts at 13:00 UTC
+	plus2 := time.FixedZone("plus2", 2*60*60)
+	assert.Equal(t, time.Date(2026, 6, 30, 13, 0, 0, 0, time.UTC),
+		windowStartOf(time.Date(2026, 6, 30, 15, 30, 0, 0, plus2)))
 }
 
-func Test_dayExporterID(t *testing.T) {
-	day := time.Date(2026, 6, 29, 13, 0, 0, 0, time.UTC)
+func Test_windowExporterID(t *testing.T) {
+	w := time.Date(2026, 6, 30, 13, 0, 0, 0, time.UTC)
 
-	// deterministic and identical across calls (i.e. across pods)
-	require.Equal(t, dayExporterID(day), dayExporterID(day))
+	require.Equal(t, windowExporterID(w), windowExporterID(w))
 
-	// same id for any clock time within the same UTC day
-	assert.Equal(t, dayExporterID(day), dayExporterID(time.Date(2026, 6, 29, 23, 59, 59, 0, time.UTC)))
-
-	// normalized to UTC: a wall clock on the 30th in +02:00 that is still the
-	// 29th in UTC maps to the 29th's id
+	// same instant in another zone
 	plus2 := time.FixedZone("plus2", 2*60*60)
-	assert.Equal(t, dayExporterID(day), dayExporterID(time.Date(2026, 6, 30, 1, 30, 0, 0, plus2)))
+	assert.Equal(t, windowExporterID(w), windowExporterID(w.In(plus2)))
 
-	// a different UTC day gets a different id (its own epoch)
-	assert.NotEqual(t, dayExporterID(day), dayExporterID(day.AddDate(0, 0, 1)))
+	assert.NotEqual(t, windowExporterID(w), windowExporterID(w.Add(reducedUsageWindow)))
+}
+
+func Test_reducedWindowStarts(t *testing.T) {
+	// settle = 15m, window = 1h, lookback = 3.
+	// now = 13:20, readyUntil = 13:05, window containing readyUntil is [13:00,14:00),
+	// so the newest fully-settled window is [12:00,13:00), then the two before it.
+	now := time.Date(2026, 6, 30, 13, 20, 0, 0, time.UTC)
+	got := reducedWindowStarts(now)
+
+	require.Len(t, got, reducedUsageLookbackWindows)
+	assert.Equal(t, time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC), got[0])
+	assert.Equal(t, time.Date(2026, 6, 30, 11, 0, 0, 0, time.UTC), got[1])
+	assert.Equal(t, time.Date(2026, 6, 30, 10, 0, 0, 0, time.UTC), got[2])
+
+	horizon := now.Add(-reducedUsageSettleWindow)
+	for _, ws := range got {
+		assert.False(t, ws.Add(reducedUsageWindow).After(horizon), "window %s not settled", ws)
+	}
+
+	afterMidnight := time.Date(2026, 6, 30, 0, 20, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2026, 6, 29, 23, 0, 0, 0, time.UTC), reducedWindowStarts(afterMidnight)[0])
 }
 
 func Test_reducedSampleCount(t *testing.T) {
@@ -42,8 +62,6 @@ func Test_reducedSampleCount(t *testing.T) {
 	conn.MatchExpectationsInOrder(false)
 
 	cols := []cmock.ColumnType{{Name: "count()", Type: "UInt64"}}
-	// one distinct-count query per configured reduced table; the results are summed.
-	// the regex also asserts the distinct-by-reduced_fingerprint grouping shape.
 	conn.ExpectQueryRow(`reduced_last_60s[\s\S]*GROUP BY[\s\S]*reduced_fingerprint`).
 		WillReturnRow(cmock.NewRow(cols, []any{uint64(7)}))
 	conn.ExpectQueryRow(`reduced_sum_60s[\s\S]*GROUP BY[\s\S]*reduced_fingerprint`).

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,0 +1,68 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func Test_startOfUTCDay(t *testing.T) {
+	got := startOfUTCDay(time.Date(2026, 6, 29, 13, 30, 45, 123, time.UTC))
+	assert.Equal(t, time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC), got)
+}
+
+func Test_dayExporterID(t *testing.T) {
+	day := time.Date(2026, 6, 29, 13, 0, 0, 0, time.UTC)
+
+	// deterministic and identical across calls (i.e. across pods)
+	require.Equal(t, dayExporterID(day), dayExporterID(day))
+
+	// same id for any clock time within the same UTC day
+	assert.Equal(t, dayExporterID(day), dayExporterID(time.Date(2026, 6, 29, 23, 59, 59, 0, time.UTC)))
+
+	// normalized to UTC: a wall clock on the 30th in +02:00 that is still the
+	// 29th in UTC maps to the 29th's id
+	plus2 := time.FixedZone("plus2", 2*60*60)
+	assert.Equal(t, dayExporterID(day), dayExporterID(time.Date(2026, 6, 30, 1, 30, 0, 0, plus2)))
+
+	// a different UTC day gets a different id (its own epoch)
+	assert.NotEqual(t, dayExporterID(day), dayExporterID(day.AddDate(0, 0, 1)))
+}
+
+func Test_reducedSampleCount(t *testing.T) {
+	conn, err := cmock.NewClickHouseWithQueryMatcher(nil, sqlmock.QueryMatcherRegexp)
+	require.NoError(t, err)
+	conn.MatchExpectationsInOrder(false)
+
+	cols := []cmock.ColumnType{{Name: "count()", Type: "UInt64"}}
+	// one distinct-count query per configured reduced table; the results are summed.
+	// the regex also asserts the distinct-by-reduced_fingerprint grouping shape.
+	conn.ExpectQueryRow(`reduced_last_60s[\s\S]*GROUP BY[\s\S]*reduced_fingerprint`).
+		WillReturnRow(cmock.NewRow(cols, []any{uint64(7)}))
+	conn.ExpectQueryRow(`reduced_sum_60s[\s\S]*GROUP BY[\s\S]*reduced_fingerprint`).
+		WillReturnRow(cmock.NewRow(cols, []any{uint64(5)}))
+
+	uc := NewUsageCollector(
+		uuid.New(),
+		conn,
+		Options{ReducedUsageTables: []string{
+			"distributed_samples_v4_reduced_last_60s",
+			"distributed_samples_v4_reduced_sum_60s",
+		}},
+		"signoz_metrics",
+		nil,
+		zap.NewNop(),
+	)
+
+	total, err := uc.reducedSampleCount(context.Background(), time.UnixMilli(0), time.UnixMilli(60000))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(12), total)
+	require.NoError(t, conn.ExpectationsWereMet())
+}


### PR DESCRIPTION
Follow up to #839 

- exclude reduced metrics from usage count, and report the retained samples separately
- fix the issue with histogram `.bucket` reduced rule not working, the metric name is further normalised
- add the missing 1.5x we discussed, good it works without it but as an added benefit, update
- update the usage to report from the reduced tables in hourly fashion, with 2 windows look back to tolerate 2-3 hours of delay in ingesting data (under regular circumstances). it can always be rectified if needed.