### PR TITLE
refactor: added missing SetIsMonotonic calls

### DIFF
--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -77,6 +77,11 @@ func (mb *MetricsBuilder) ConvertSumToMetrics(ts *monitoringpb.TimeSeries, m pme
 	m.SetUnit(ts.GetUnit())
 	sum := m.SetEmptySum()
 	sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	// GCP CUMULATIVE metrics are values that constantly increase until they reset to
+	// zero, which matches the OpenTelemetry definition of a monotonic counter (resets
+	// are handled downstream as counter resets). Marking the sum monotonic is what lets
+	// consumers offer rate/increase on these metrics.
+	sum.SetIsMonotonic(true)
 
 	metricAttributes := convertLabelsToMetricAttributes(ts.GetMetric().GetLabels())
 	for _, point := range ts.GetPoints() {
@@ -114,6 +119,12 @@ func (mb *MetricsBuilder) ConvertDeltaToMetrics(ts *monitoringpb.TimeSeries, m p
 	m.SetUnit(ts.GetUnit())
 	sum := m.SetEmptySum()
 	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	// GCP DELTA metrics are counts of discrete items over an interval, so each value is
+	// a non-negative count, i.e. a monotonic counter. Non-monotonic sums written to
+	// Cloud Monitoring via OTLP are stored as gauges, so anything GCP keeps as a delta
+	// was a genuine counter. Distributions with delta temporality never reach this path
+	// (they become histograms), so every sum produced here is safe to mark monotonic.
+	sum.SetIsMonotonic(true)
 
 	metricAttributes := convertLabelsToMetricAttributes(ts.GetMetric().GetLabels())
 	for _, point := range ts.GetPoints() {

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -84,6 +84,72 @@ func TestConvertGaugeToMetrics(t *testing.T) {
 	}
 }
 
+func TestConvertSumToMetrics(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	ts := &monitoringpb.TimeSeries{
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 10},
+					EndTime:   &timestamppb.Timestamp{Seconds: 20},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 100},
+				},
+			},
+		},
+		Metric: &metric.Metric{
+			Labels: map[string]string{"labelKey": "labelValue"},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertSumToMetrics(ts, m)
+
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	sum := m.Sum()
+	assert.Equal(t, pmetric.AggregationTemporalityCumulative, sum.AggregationTemporality())
+	// GCP CUMULATIVE metrics are monotonic counters; the flag is what enables rate downstream.
+	assert.True(t, sum.IsMonotonic(), "cumulative sums must be marked monotonic")
+	require.Equal(t, 1, sum.DataPoints().Len())
+	assert.Equal(t, int64(100), sum.DataPoints().At(0).IntValue())
+}
+
+func TestConvertDeltaToMetrics(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	ts := &monitoringpb.TimeSeries{
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 10},
+					EndTime:   &timestamppb.Timestamp{Seconds: 20},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 42.0},
+				},
+			},
+		},
+		Metric: &metric.Metric{
+			Labels: map[string]string{"labelKey": "labelValue"},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDeltaToMetrics(ts, m)
+
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	sum := m.Sum()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, sum.AggregationTemporality())
+	// GCP DELTA counters are non-negative counts; only genuine counters reach this path.
+	assert.True(t, sum.IsMonotonic(), "delta sums must be marked monotonic")
+	require.Equal(t, 1, sum.DataPoints().Len())
+	assert.Equal(t, 42.0, sum.DataPoints().At(0).DoubleValue())
+}
+
 func TestConvertDistributionToMetrics_NoDataPoints(t *testing.T) {
 	logger := zap.NewNop()
 	mb := NewMetricsBuilder(logger)


### PR DESCRIPTION
## Pull Request

### Summary
Added missing SetIsMonotonic calls for delta and cumulative metrics. To read about the approach please check https://github.com/SigNoz/platform-pod/issues/2901

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes SigNoz/engineering-pod#456) -->
Closes https://github.com/SigNoz/platform-pod/issues/2901

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No
