### PR TITLE
fix: support ClickHouse 26.x by adding missing columns to AggregatingMergeTree sorting keys

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metrics_migrations.go
@@ -335,7 +335,7 @@ var MetricsMigrations = []SchemaMigrationRecord{
 				},
 				Engine: AggregatingMergeTree{
 					MergeTree: MergeTree{
-						OrderBy:     "(temporality, metric_name, attr_name, attr_type, attr_datatype, attr_string_value)",
+						OrderBy:     "(temporality, metric_name, description, unit, type, is_monotonic, attr_name, attr_type, attr_datatype, attr_string_value)",
 						PartitionBy: "toDate(last_reported_unix_milli / 1000)",
 						TTL:         "toDateTime(last_reported_unix_milli / 1000) + toIntervalSecond(2592000)",
 						Settings: []TableSetting{


### PR DESCRIPTION
## Description
Fixes #12257

ClickHouse 26.x introduced a stricter default for `allow_dimensions_outside_sorting_key` (now defaults to `0`), which causes migrations to fail with `BAD_ARGUMENTS` if an `AggregatingMergeTree` table contains non-aggregate columns that are not part of the `ORDER BY` clause. 

In `signoz-otel-collector`, the `metadata` table defined in `metrics_migrations.go` utilized the `AggregatingMergeTree` engine but included the columns `description`, `unit`, `type`, and `is_monotonic` strictly as standard data dimensions (neither as aggregate functions nor as part of the `ORDER BY` sorting key). 

Instead of passing the `allow_dimensions_outside_sorting_key = 1` setting which would risk breaking backwards compatibility with older ClickHouse versions, this PR adds those missing columns directly into the `ORDER BY` sorting key for the `metadata` table.

Other tables using `AggregatingMergeTree` across the migrator schemas have been audited and already correctly place their non-aggregate dimensions inside their respective `ORDER BY` keys.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)