### PR TITLE
feat: adding stanza operators config validation tests

### DIFF
--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config_build_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/config_build_test.go
@@ -1,0 +1,60 @@
+// SigNoz keeps accepting configs with a missing from/to; do not tighten these to error assertions.
+package copy
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+// Unmarshalling (rather than setting struct fields) is what produces the zero-value Field the guards inspect.
+func buildFromYAML(t *testing.T, name string) (any, error) {
+	t.Helper()
+
+	confMaps, err := confmaptest.LoadConf(filepath.Join(".", "testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	sub, err := confMaps.Sub(name)
+	require.NoError(t, err)
+	require.NotZero(t, len(sub.AllKeys()), "config not found: %q", name)
+
+	cfg := NewConfig()
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	cfg.OutputIDs = []string{"fake"}
+	return cfg.Build(componenttest.NewNopTelemetrySettings())
+}
+
+func TestBuildAcceptsMissingFields(t *testing.T) {
+	for _, name := range []string{"missing_from", "missing_to", "missing_both"} {
+		t.Run(name, func(t *testing.T) {
+			op, err := buildFromYAML(t, name)
+			require.NoError(t, err, "fix config.go rather than this test")
+			require.NotNil(t, op)
+		})
+	}
+}
+
+func TestBuildAcceptsValidFields(t *testing.T) {
+	for _, name := range []string{
+		"body_to_body",
+		"body_to_attribute",
+		"attribute_to_body",
+		"attribute_to_resource",
+		"attribute_to_nested_attribute",
+		"resource_to_nested_resource",
+	} {
+		t.Run(name, func(t *testing.T) {
+			op, err := buildFromYAML(t, name)
+			require.NoError(t, err)
+
+			transformer, ok := op.(*Transformer)
+			require.True(t, ok, "Build returned %T, want *Transformer", op)
+			require.NotNil(t, transformer.From.FieldInterface)
+			require.NotNil(t, transformer.To.FieldInterface)
+		})
+	}
+}

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/testdata/config.yaml
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/copy/testdata/config.yaml
@@ -22,3 +22,12 @@ resource_to_nested_resource:
   type: copy
   from: resource.key
   to: resource.one.two.three
+
+missing_from:
+  type: copy
+  to: body.key2
+missing_to:
+  type: copy
+  from: body.key
+missing_both:
+  type: copy

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/move/config_build_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/move/config_build_test.go
@@ -1,0 +1,63 @@
+// SigNoz keeps accepting configs with a missing from/to; do not tighten these to error assertions.
+package move
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+// Unmarshalling (rather than setting struct fields) is what produces the zero-value Field the guard inspects.
+func buildFromYAML(t *testing.T, name string) (any, error) {
+	t.Helper()
+
+	confMaps, err := confmaptest.LoadConf(filepath.Join(".", "testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	sub, err := confMaps.Sub(name)
+	require.NoError(t, err)
+	require.NotZero(t, len(sub.AllKeys()), "config not found: %q", name)
+
+	cfg := NewConfig()
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	cfg.OutputIDs = []string{"fake"}
+	return cfg.Build(componenttest.NewNopTelemetrySettings())
+}
+
+func TestBuildAcceptsMissingFields(t *testing.T) {
+	for _, name := range []string{"missing_from", "missing_to", "missing_both"} {
+		t.Run(name, func(t *testing.T) {
+			op, err := buildFromYAML(t, name)
+			require.NoError(t, err, "fix config.go rather than this test")
+			require.NotNil(t, op)
+		})
+	}
+}
+
+func TestBuildAcceptsValidFields(t *testing.T) {
+	for _, name := range []string{
+		"move_body_to_body",
+		"move_body_to_attribute",
+		"move_attribute_to_body",
+		"move_attribute_to_resource",
+		"move_resource_to_attribute",
+		"move_nested_body_to_nested_attribute",
+		"move_nested_body_to_nested_resource",
+		"move_bracketed_attribute_to_resource",
+		"replace_body",
+	} {
+		t.Run(name, func(t *testing.T) {
+			op, err := buildFromYAML(t, name)
+			require.NoError(t, err)
+
+			transformer, ok := op.(*Transformer)
+			require.True(t, ok, "Build returned %T, want *Transformer", op)
+			require.NotNil(t, transformer.From.FieldInterface)
+			require.NotNil(t, transformer.To.FieldInterface)
+		})
+	}
+}

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/move/testdata/config.yaml
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/move/testdata/config.yaml
@@ -58,3 +58,12 @@ replace_body:
   type: move
   from: body.nested
   to: body
+
+missing_from:
+  type: move
+  to: body.new
+missing_to:
+  type: move
+  from: body.key
+missing_both:
+  type: move

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/config_build_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/config_build_test.go
@@ -56,7 +56,7 @@ func TestBuildAcceptsRootKeywords(t *testing.T) {
 			require.True(t, ok, "Build returned %T, want *Transformer", op)
 			require.Equal(t, tc.wantAllResource, transformer.Field.allResource)
 			require.Equal(t, tc.wantAllAttributes, transformer.Field.allAttributes)
-			require.Nil(t, transformer.Field.Field.FieldInterface)
+			require.Nil(t, transformer.Field.FieldInterface)
 		})
 	}
 }
@@ -77,7 +77,7 @@ func TestBuildAcceptsExplicitFields(t *testing.T) {
 
 			transformer, ok := op.(*Transformer)
 			require.True(t, ok, "Build returned %T, want *Transformer", op)
-			require.NotNil(t, transformer.Field.Field.FieldInterface)
+			require.NotNil(t, transformer.Field.FieldInterface)
 			require.False(t, transformer.Field.allResource)
 			require.False(t, transformer.Field.allAttributes)
 		})
@@ -99,7 +99,7 @@ func TestRootableFieldEmptiness(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			isEmpty := tc.field.Field.FieldInterface == nil &&
+			isEmpty := tc.field.FieldInterface == nil &&
 				!tc.field.allResource && !tc.field.allAttributes
 			require.Equal(t, tc.wantEmpty, isEmpty)
 		})

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/config_build_test.go
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/config_build_test.go
@@ -1,0 +1,107 @@
+// SigNoz keeps accepting a config with no field; do not tighten this to an error assertion.
+package remove
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+// Unmarshalling (rather than setting struct fields) is what produces the zero-value Field the guard inspects.
+func buildFromYAML(t *testing.T, name string) (any, error) {
+	t.Helper()
+
+	confMaps, err := confmaptest.LoadConf(filepath.Join(".", "testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	sub, err := confMaps.Sub(name)
+	require.NoError(t, err)
+	require.NotZero(t, len(sub.AllKeys()), "config not found: %q", name)
+
+	cfg := NewConfig()
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	cfg.OutputIDs = []string{"fake"}
+	return cfg.Build(componenttest.NewNopTelemetrySettings())
+}
+
+func TestBuildAcceptsMissingField(t *testing.T) {
+	op, err := buildFromYAML(t, "missing_field")
+	require.NoError(t, err, "fix config.go rather than this test")
+	require.NotNil(t, op)
+}
+
+// The `resource`/`attributes` keywords leave the embedded Field zero-valued, so checking it alone rejects valid config.
+func TestBuildAcceptsRootKeywords(t *testing.T) {
+	cases := []struct {
+		name              string
+		wantAllResource   bool
+		wantAllAttributes bool
+	}{
+		{"remove_entire_resource", true, false},
+		{"remove_entire_attributes", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op, err := buildFromYAML(t, tc.name)
+			require.NoError(t, err)
+
+			transformer, ok := op.(*Transformer)
+			require.True(t, ok, "Build returned %T, want *Transformer", op)
+			require.Equal(t, tc.wantAllResource, transformer.Field.allResource)
+			require.Equal(t, tc.wantAllAttributes, transformer.Field.allAttributes)
+			require.Nil(t, transformer.Field.Field.FieldInterface)
+		})
+	}
+}
+
+func TestBuildAcceptsExplicitFields(t *testing.T) {
+	for _, name := range []string{
+		"remove_body",
+		"remove_nested_body",
+		"remove_entire_body",
+		"remove_single_attribute",
+		"remove_nested_attribute",
+		"remove_single_resource",
+		"remove_nested_resource",
+	} {
+		t.Run(name, func(t *testing.T) {
+			op, err := buildFromYAML(t, name)
+			require.NoError(t, err)
+
+			transformer, ok := op.(*Transformer)
+			require.True(t, ok, "Build returned %T, want *Transformer", op)
+			require.NotNil(t, transformer.Field.Field.FieldInterface)
+			require.False(t, transformer.Field.allResource)
+			require.False(t, transformer.Field.allAttributes)
+		})
+	}
+}
+
+// Mirrors rootableField.IsEmpty (contrib v0.157.0); asserted against the struct since this package predates it.
+func TestRootableFieldEmptiness(t *testing.T) {
+	cases := []struct {
+		name      string
+		field     rootableField
+		wantEmpty bool
+	}{
+		{"zero_value", rootableField{}, true},
+		{"all_resource", rootableField{allResource: true}, false},
+		{"all_attributes", rootableField{allAttributes: true}, false},
+		{"named_body_field", rootableField{Field: entry.NewBodyField("foo")}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isEmpty := tc.field.Field.FieldInterface == nil &&
+				!tc.field.allResource && !tc.field.allAttributes
+			require.Equal(t, tc.wantEmpty, isEmpty)
+		})
+	}
+}

--- a/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/testdata/config.yaml
+++ b/processor/signozlogspipelineprocessor/stanza/operator/operators/remove/testdata/config.yaml
@@ -25,3 +25,6 @@ remove_single_attribute:
 remove_single_resource:
   type: remove
   field: resource.key
+
+missing_field:
+  type: remove


### PR DESCRIPTION
## Pull Request

Adding unit test cases for stanza operators build function

### Summary
These tests will help us bump the collector version to match contrib's version.

#### Why these tests are important
Currently there is a bug in the stanza operator's Build function which fails to validate the config for copy, move, remove ops. Because we have been using this processor in the product for logs pipeline, there can be cases where config is invalid (i.e. missing `from` in copy), but because of the validation bug this is never flagged. We are okay with not fixing the issue for now, and neither we want to break the user experience by fixing the validation issue which will create a breaking change. These tests help us verify that there is no behaviour change with upgrade.

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes SigNoz/engineering-pod#456) -->
Closes https://github.com/SigNoz/platform-pod/issues/2901

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No
