### PR TITLE
feat(signozllmpricing): surface matched pricing rule name on priced spans

### DIFF
--- a/processor/signozllmpricingprocessor/config.go
+++ b/processor/signozllmpricingprocessor/config.go
@@ -63,6 +63,12 @@ type OutputMapping struct {
 	CacheRead  string `mapstructure:"cache_read"`
 	CacheWrite string `mapstructure:"cache_write"`
 	Total      string `mapstructure:"total"`
+
+	// RuleName is the span attribute key where the name of the pricing rule
+	// that priced the span is written. Optional: when empty, no rule name is
+	// written. Useful for auditing which glob pattern actually matched a given
+	// model string when several rules overlap.
+	RuleName string `mapstructure:"rule_name"`
 }
 
 func (c *CacheMode) String() string {

--- a/processor/signozllmpricingprocessor/config_test.go
+++ b/processor/signozllmpricingprocessor/config_test.go
@@ -68,6 +68,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, "_signoz.gen_ai.cost_cache_read", cfg.OutputAttrs.CacheRead)
 		assert.Equal(t, "_signoz.gen_ai.cost_cache_write", cfg.OutputAttrs.CacheWrite)
 		assert.Equal(t, "_signoz.gen_ai.total_cost", cfg.OutputAttrs.Total)
+		assert.Equal(t, "_signoz.gen_ai.pricing_rule", cfg.OutputAttrs.RuleName)
 	})
 
 	t.Run("minimal", func(t *testing.T) {
@@ -78,6 +79,7 @@ func TestLoadConfig(t *testing.T) {
 		// Optional output attrs are empty — only total is required.
 		assert.Empty(t, cfg.OutputAttrs.In)
 		assert.Empty(t, cfg.OutputAttrs.CacheRead)
+		assert.Empty(t, cfg.OutputAttrs.RuleName)
 		assert.Equal(t, "_signoz.gen_ai.total_cost", cfg.OutputAttrs.Total)
 	})
 }

--- a/processor/signozllmpricingprocessor/processor.go
+++ b/processor/signozllmpricingprocessor/processor.go
@@ -42,6 +42,7 @@ type llmCostProcessor struct {
 	outCacheReadAttr  string
 	outCacheWriteAttr string
 	outTotalAttr      string
+	outRuleNameAttr   string
 
 	divisor float64 // 1e6 for per_million_tokens
 	rules   []compiledRule
@@ -79,6 +80,7 @@ func newProcessor(cfg *Config) *llmCostProcessor {
 		outCacheReadAttr:  cfg.OutputAttrs.CacheRead,
 		outCacheWriteAttr: cfg.OutputAttrs.CacheWrite,
 		outTotalAttr:      cfg.OutputAttrs.Total,
+		outRuleNameAttr:   cfg.OutputAttrs.RuleName,
 		divisor:           divisor,
 		rules:             rules,
 	}
@@ -124,7 +126,7 @@ func (p *llmCostProcessor) processSpan(attrs pcommon.Map) {
 	}
 
 	c := p.compute(rule, in, out, cacheRead, cacheWrite)
-	p.writeAttrs(attrs, c)
+	p.writeAttrs(attrs, c, rule.name)
 }
 
 // matchRule returns the first rule whose pattern matches model, or nil.
@@ -183,14 +185,16 @@ func (p *llmCostProcessor) compute(rule *compiledRule, in, out, cacheRead, cache
 	return c
 }
 
-// writeAttrs writes the computed costs to the span attribute map.
-// Fields with an empty destination key are skipped.
-func (p *llmCostProcessor) writeAttrs(attrs pcommon.Map, c costs) {
+// writeAttrs writes the computed costs to the span attribute map, along with
+// the name of the rule that produced them. Fields with an empty destination key
+// are skipped.
+func (p *llmCostProcessor) writeAttrs(attrs pcommon.Map, c costs, ruleName string) {
 	putIfKey(attrs, p.outInAttr, c.input)
 	putIfKey(attrs, p.outOutAttr, c.output)
 	putIfKey(attrs, p.outCacheReadAttr, c.cacheRead)
 	putIfKey(attrs, p.outCacheWriteAttr, c.cacheWrite)
 	putIfKey(attrs, p.outTotalAttr, c.total)
+	putStrIfKey(attrs, p.outRuleNameAttr, ruleName)
 }
 
 // getTokenCount reads a numeric attribute as float64. Returns 0 if absent or
@@ -216,5 +220,14 @@ func getTokenCount(attrs pcommon.Map, key string) float64 {
 func putIfKey(attrs pcommon.Map, key string, val float64) {
 	if key != "" {
 		attrs.PutDouble(key, val)
+	}
+}
+
+// putStrIfKey writes a string attribute only when both the key and the value
+// are non-empty. An unnamed rule writes nothing rather than an empty attribute,
+// since `name` is optional in the rule config.
+func putStrIfKey(attrs pcommon.Map, key, val string) {
+	if key != "" && val != "" {
+		attrs.PutStr(key, val)
 	}
 }

--- a/processor/signozllmpricingprocessor/rulename_test.go
+++ b/processor/signozllmpricingprocessor/rulename_test.go
@@ -1,0 +1,149 @@
+package signozllmpricingprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+const ruleNameAttr = "_signoz.gen_ai.pricing_rule"
+
+// cfgWithRuleName returns testCfg with the rule-name output attribute enabled.
+func cfgWithRuleName() *Config {
+	cfg := *testCfg
+	cfg.OutputAttrs = testCfg.OutputAttrs
+	cfg.OutputAttrs.RuleName = ruleNameAttr
+	return &cfg
+}
+
+func getStr(t *testing.T, m pcommon.Map, key string) string {
+	t.Helper()
+	v, ok := m.Get(key)
+	require.True(t, ok, "expected attribute %q to be present", key)
+	return v.Str()
+}
+
+// The matched rule's name must land on the configured key in subtract mode.
+func TestRuleName_SubtractMode(t *testing.T) {
+	td := buildTrace(map[string]any{
+		"gen_ai.request.model":           "gpt-4o-mini",
+		"gen_ai.usage.input_tokens":      int64(1000),
+		"gen_ai.usage.output_tokens":     int64(500),
+		"gen_ai.usage.cache_read_tokens": int64(200),
+	})
+
+	_, err := newProcessor(cfgWithRuleName()).ProcessTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	a := attrs(td)
+	assert.Equal(t, "gpt-4o", getStr(t, a, ruleNameAttr))
+	// Costs must still be computed exactly as before.
+	assert.InDelta(t, 0.012, getDouble(t, a, "_signoz.gen_ai.total_cost"), 1e-9)
+}
+
+// ...and in additive mode, which takes a different branch through compute.
+func TestRuleName_AdditiveMode(t *testing.T) {
+	td := buildTrace(map[string]any{
+		"gen_ai.request.model":            "claude-3-5-sonnet",
+		"gen_ai.usage.input_tokens":       int64(1000),
+		"gen_ai.usage.output_tokens":      int64(500),
+		"gen_ai.usage.cache_read_tokens":  int64(200),
+		"gen_ai.usage.cache_write_tokens": int64(100),
+	})
+
+	_, err := newProcessor(cfgWithRuleName()).ProcessTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	a := attrs(td)
+	assert.Equal(t, "claude", getStr(t, a, ruleNameAttr))
+	assert.InDelta(t, 0.010935, getDouble(t, a, "_signoz.gen_ai.total_cost"), 1e-9)
+}
+
+// Which of several overlapping patterns actually fired is the point of the
+// feature: "gpt-4o*" and "*" both match, and the name proves the first won.
+func TestRuleName_DisambiguatesOverlappingPatterns(t *testing.T) {
+	cfg := *cfgWithRuleName()
+	cfg.DefaultPricing = PricingConfig{Rules: []PricingRule{
+		{Name: "gpt-4o", Pattern: []string{"gpt-4o*"}, In: 5.0, Out: 15.0},
+		{Name: "fallback", Pattern: []string{"*"}, In: 1.0, Out: 2.0},
+	}}
+
+	for _, tc := range []struct{ model, wantRule string }{
+		{"gpt-4o-2024-11-20", "gpt-4o"},
+		{"some-other-model", "fallback"},
+	} {
+		t.Run(tc.model, func(t *testing.T) {
+			td := buildTrace(map[string]any{
+				"gen_ai.request.model":      tc.model,
+				"gen_ai.usage.input_tokens": int64(1000),
+			})
+			_, err := newProcessor(&cfg).ProcessTraces(context.Background(), td)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRule, getStr(t, attrs(td), ruleNameAttr))
+		})
+	}
+}
+
+// Unconfigured destination key → nothing written, consistent with the other
+// optional output attributes.
+func TestRuleName_NotWrittenWhenKeyUnconfigured(t *testing.T) {
+	td := buildTrace(map[string]any{
+		"gen_ai.request.model":      "gpt-4o",
+		"gen_ai.usage.input_tokens": int64(1000),
+	})
+
+	// testCfg leaves OutputAttrs.RuleName empty.
+	_, err := newProcessor(testCfg).ProcessTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	_, ok := attrs(td).Get(ruleNameAttr)
+	assert.False(t, ok, "rule name must not be written when the key is unconfigured")
+}
+
+// A rule with no name configured writes nothing rather than an empty string,
+// since `name` is optional.
+func TestRuleName_UnnamedRuleWritesNothing(t *testing.T) {
+	cfg := *cfgWithRuleName()
+	cfg.DefaultPricing = PricingConfig{Rules: []PricingRule{
+		{Pattern: []string{"*"}, In: 1.0, Out: 2.0}, // no Name
+	}}
+
+	td := buildTrace(map[string]any{
+		"gen_ai.request.model":      "gpt-4o",
+		"gen_ai.usage.input_tokens": int64(1000),
+	})
+
+	_, err := newProcessor(&cfg).ProcessTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	a := attrs(td)
+	_, ok := a.Get(ruleNameAttr)
+	assert.False(t, ok, "an unnamed rule must not write an empty rule-name attribute")
+	// The span is still priced.
+	assert.InDelta(t, 1000*1.0/1e6, getDouble(t, a, "_signoz.gen_ai.total_cost"), 1e-9)
+}
+
+// A skipped span must not get a rule-name attribute.
+func TestRuleName_NotWrittenWhenSpanSkipped(t *testing.T) {
+	for name, spanAttrs := range map[string]map[string]any{
+		"no_rule_match": {
+			"gen_ai.request.model":      "unknown-model-xyz",
+			"gen_ai.usage.input_tokens": int64(1000),
+		},
+		"zero_tokens": {
+			"gen_ai.request.model": "gpt-4o",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			td := buildTrace(spanAttrs)
+			_, err := newProcessor(cfgWithRuleName()).ProcessTraces(context.Background(), td)
+			require.NoError(t, err)
+
+			_, ok := attrs(td).Get(ruleNameAttr)
+			assert.False(t, ok, "rule name must not be written for an unpriced span")
+		})
+	}
+}

--- a/processor/signozllmpricingprocessor/testdata/config.yaml
+++ b/processor/signozllmpricingprocessor/testdata/config.yaml
@@ -30,6 +30,7 @@ signozllmpricing:
     cache_read: "_signoz.gen_ai.cost_cache_read"
     cache_write: "_signoz.gen_ai.cost_cache_write"
     total: "_signoz.gen_ai.total_cost"
+    rule_name: "_signoz.gen_ai.pricing_rule"
 
 # Minimal valid — only total output attr required.
 signozllmpricing/minimal:


### PR DESCRIPTION
## Summary

`PricingRule.Name` is accepted in config and compiled into `compiledRule.name`, but never read after that — it isn't written to any output attribute, isn't logged, and isn't used in matching. It's effectively dead configuration today.

This adds an optional `output_attrs.rule_name` key. When set, the name of the rule that priced a span is written to that attribute.

Closes #871

## Why

For a cost-attribution processor, "which pricing rule priced this span, and under what name" is useful provenance. With `path.Match` glob patterns it isn't obvious at a glance which rule a given model string matched, particularly once multiple overlapping patterns exist across `default_pricing.rules`.

```yaml
output_attrs:
  total: "_signoz.gen_ai.total_cost"
  rule_name: "_signoz.gen_ai.pricing_rule"   # new, optional
```

A span priced by the `gpt-4o` rule now carries `_signoz.gen_ai.pricing_rule = "gpt-4o"`, so cost can be grouped and audited per rule.

## Behavior

Deliberately consistent with how the processor already treats its other optional output attributes:

- **Key unconfigured** → nothing written (same as `in`/`out`/`cache_read`/`cache_write`).
- **Rule has no `name`** → nothing written, rather than an empty attribute. `name` is optional in the rule config, so a new `putStrIfKey` helper skips empty values as well as empty keys. (The existing `putIfKey` is `float64`-typed and couldn't be reused directly.)
- **Span was skipped** → nothing written, since the write happens in `writeAttrs` alongside the costs.

No change to any cost computation, and no change to existing default behavior — omitting `rule_name` leaves output byte-identical to before.

## Scope note

This is specifically about provenance/auditability of which rule fired. It is not a new fallback mechanism — a catch-all pattern (e.g. `"*"`) already provides the fallback-pricing safety net.

Also worth noting: #871 suggested pairing this with the skip-reason telemetry in #872 so cost-per-rule becomes queryable alongside skip counts. I deliberately did **not** couple the two here — this PR is independently reviewable and doesn't depend on #872 landing or on its approach being accepted. If #872 does land, adding `rule_name` as a dimension on its priced-spans counter is a small follow-up, and I'm happy to send it.

## Testing

New `rulename_test.go` covers: subtract mode, additive mode (the two distinct branches through `compute`), overlapping-pattern disambiguation (`gpt-4o*` vs `*`, asserting first-match-wins is what's reported), unconfigured key, unnamed rule, and both skip paths. `config_test.go` asserts `rule_name` round-trips through `confmap` in the full config and stays empty in the minimal one.

```
$ go test -count=1 -race -cover ./processor/signozllmpricingprocessor/...
ok  github.com/SigNoz/signoz-otel-collector/processor/signozllmpricingprocessor  1.445s  coverage: 89.0% of statements
```

Coverage moves from 88.6% to 89.0%.

```
$ go build ./cmd/signozotelcollector    # OK
$ go vet ./processor/signozllmpricingprocessor/...    # clean
$ gofmt -e -s -l ./processor/signozllmpricingprocessor/    # clean
$ golangci-lint run ./processor/signozllmpricingprocessor/...
0 issues.
```

I checked these tests actually bite by removing the rule-name write and confirming they fail, rather than trusting a green run.

Two notes on tooling, both pre-existing on `main` and unrelated to this change — flagging only so the evidence above is read accurately:

- `make lint` can't run as written: the Makefile passes `--config .golangci.yml`, but no `.golangci.yml` is tracked in the repo, so it exits before linting. CI uses the shared `signoz/primus.workflows` lint job instead, so I ran `golangci-lint` with default linters as the closest local proxy.
- `make install-tools` installs golangci-lint from `github.com/golangci/golangci-lint/cmd/golangci-lint@v2.6.0`; for v2 that path needs the `/v2/` module prefix, so I installed `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0`.

There's no README under `processor/signozllmpricingprocessor/`, so the new field is documented via a doc comment on `OutputMapping.RuleName` and exercised in `testdata/config.yaml`. Happy to add a README if you'd like one.

## Resource impact

Negligible. One extra string attribute write per **priced** span, and only when `rule_name` is configured — the name is already resolved and held on the matched `compiledRule`, so there's no additional lookup, matching work, or allocation. Unpriced spans and configs that omit `rule_name` are entirely unaffected.

## Scope caveat

Per #871 — I don't have visibility into whether this is already tracked in `engineering-pod`. Happy to adjust the config key name, the skip-empty-name behavior, or the approach, or to close this if it overlaps something already planned internally.
