### PR TITLE
fix(clickhouselogsexporter): avoid deadlock when consumer fails

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -717,7 +717,8 @@ producerIteration:
 					if err != nil {
 						return err
 					}
-					recordStream <- &Record{
+					select {
+					case recordStream <- &Record{
 						tsBucketStart:    uint64(lBucketStart),
 						resourceFP:       fp,
 						ts:               ts,
@@ -738,6 +739,9 @@ producerIteration:
 						attrsMap:         attrsMap,
 						logFields:        attributeMap{StringData: map[string]string{"severity_text": record.SeverityText()}, NumberData: map[string]float64{"severity_number": float64(record.SeverityNumber())}},
 						recordSize:       int64(len([]byte(record.Body().AsString())) + len(attrBytes) + len(resBytes)),
+					}:
+					case <-groupCtx.Done():
+						return nil
 					}
 					return nil
 				})

--- a/exporter/clickhouselogsexporter/exporter_test.go
+++ b/exporter/clickhouselogsexporter/exporter_test.go
@@ -2,6 +2,7 @@ package clickhouselogsexporter
 
 import (
 	"context"
+	"errors"
 	"log"
 	"testing"
 	"time"
@@ -315,6 +316,42 @@ func TestExporterConcurrency(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestExporterConcurrencyStopsWhenConsumerFails(t *testing.T) {
+	mock, err := cmock.NewClickHouseWithQueryMatcher(nil, sqlmock.QueryMatcherRegexp)
+	require.NoError(t, err)
+
+	tagStatementV2 := mock.ExpectPrepareBatch("INSERT INTO signoz_logs.distributed_tag_attributes_v2")
+	attributeKeysStmt := mock.ExpectPrepareBatch("INSERT INTO signoz_logs.distributed_logs_attribute_keys")
+	resourceKeysStmt := mock.ExpectPrepareBatch("INSERT INTO signoz_logs.distributed_logs_resource_keys")
+	logsStatementV2 := mock.ExpectPrepareBatch("INSERT INTO signoz_logs.distributed_logs_v2.*")
+
+	tagStatementV2.ExpectAppend()
+	attributeKeysStmt.ExpectAppend()
+	resourceKeysStmt.ExpectAppend()
+	logsStatementV2.ExpectAppend().WillReturnError(errors.New("append failed"))
+	mock.ExpectClose()
+
+	exporter := setupTestExporterWithConcurrency(t, mock, 3)
+	logs := plogsgen.Generate(plogsgen.WithLogRecordCount(10000))
+
+	result := make(chan error, 1)
+	go func() {
+		result <- exporter.pushLogsData(context.Background(), logs)
+	}()
+
+	select {
+	case err := <-result:
+		require.ErrorContains(t, err, "StatementAppendLogsV2:append failed")
+	case <-time.After(time.Second):
+		t.Fatal("pushLogsData did not stop after the consumer failed")
+	}
+
+	require.NoError(t, exporter.Shutdown(context.Background()))
+	eventually(t, func() bool {
+		return mock.ExpectationsWereMet() == nil
+	})
 }
 
 func TestProcessBody(t *testing.T) {


### PR DESCRIPTION
## Pull Request

### Summary

Make the ClickHouse logs exporter's producer send cancellation-aware. If the consumer fails, producers now stop when the errgroup context is cancelled instead of blocking forever on a full `recordStream` channel.

The regression test makes the first logs batch append fail while enough records are being produced to fill the channel. Before this change, `pushLogsData` does not return. With this change, all producers exit and the original consumer error is returned.

### Root Cause

`pushToClickhouse` runs one consumer and bounded producer goroutines in an errgroup. When the consumer returns an error, the errgroup context is cancelled. Producers that are already running still perform an unconditional send to `recordStream`.

This deadlocks the exporter request: after the consumer exits, the channel fills and those producers block permanently. Their deferred limiter release and `producersWG.Done()` never run, so the stream closer and `group.Wait()` also never complete. Exporter workers accumulate until the outer sending queue is full and subsequent logs are rejected, while the collector process remains healthy.

### Validation

- `go test ./exporter/clickhouselogsexporter -run TestExporterConcurrencyStopsWhenConsumerFails -count=10 -timeout=30s`
- `go test -race ./exporter/clickhouselogsexporter -run TestExporterConcurrencyStopsWhenConsumerFails -count=1 -timeout=60s`
- `go test ./exporter/clickhouselogsexporter -count=1 -timeout=120s`

The new regression test consistently timed out before the fix and passes after it.

### Resource Impact

**Will this change affect the application's resource usage?**

- [ ] Yes
- [x] No

The change only affects the error path by allowing blocked producers to terminate.
