### PR TITLE
chore: add created_at and inserted_at to logs and traces

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -481,5 +481,72 @@ ORDER BY name ASC`,
 			},
 		},
 	},
-	// Next migration id will be 2002
+	{
+		MigrationID: 2002,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column: Column{
+					Name:  "inserted_at",
+					Type:  DateTime64ColumnType{Precision: 3},
+					Codec: "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column: Column{
+					Name:  "inserted_at",
+					Type:  DateTime64ColumnType{Precision: 3},
+					Codec: "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column: Column{
+					Name:    "created_at",
+					Type:    DateTime64ColumnType{Precision: 3},
+					Default: "now64(3)",
+					Codec:   "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column: Column{
+					Name:    "created_at",
+					Type:    DateTime64ColumnType{Precision: 3},
+					Default: "now64(3)",
+					Codec:   "Delta(8), ZSTD(1)",
+				},
+			},
+		},
+		DownItems: []Operation{
+			// drop from the distributed tables first, otherwise they are
+			// left referencing columns that no longer exist on the local tables
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column:   Column{Name: "inserted_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column:   Column{Name: "inserted_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column:   Column{Name: "created_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column:   Column{Name: "created_at"},
+			},
+		},
+	},
+	// Next migration id will be 2003
 }

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1234,4 +1234,71 @@ var TracesMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1014,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column: Column{
+					Name:  "inserted_at",
+					Type:  DateTime64ColumnType{Precision: 3},
+					Codec: "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column: Column{
+					Name:  "inserted_at",
+					Type:  DateTime64ColumnType{Precision: 3},
+					Codec: "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column: Column{
+					Name:    "created_at",
+					Type:    DateTime64ColumnType{Precision: 3},
+					Default: "now64(3)",
+					Codec:   "Delta(8), ZSTD(1)",
+				},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column: Column{
+					Name:    "created_at",
+					Type:    DateTime64ColumnType{Precision: 3},
+					Default: "now64(3)",
+					Codec:   "Delta(8), ZSTD(1)",
+				},
+			},
+		},
+		DownItems: []Operation{
+			// drop from the distributed tables first, otherwise they are
+			// left referencing columns that no longer exist on the local tables
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column:   Column{Name: "inserted_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column:   Column{Name: "inserted_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "distributed_signoz_index_v3",
+				Column:   Column{Name: "created_at"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_traces",
+				Table:    "signoz_index_v3",
+				Column:   Column{Name: "created_at"},
+			},
+		},
+	},
 }

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -88,8 +88,10 @@ const (
 		resource,
 		scope_name,
 		scope_version,
-		scope_string
+		scope_string,
+		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -131,8 +133,10 @@ const (
 		resource,
 		scope_name,
 		scope_version,
-		scope_string
+		scope_string,
+		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -630,6 +634,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 					rec.scopeName,
 					rec.scopeVersion,
 					rec.scopeMap.StringData,
+					time.Now(),
 				)
 				if err := insertLogsStmtV2.Append(args...); err != nil {
 					return fmt.Errorf("StatementAppendLogsV2:%w", err)

--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -70,8 +70,10 @@ const (
 		db_name,
 		db_operation,
 		has_error,
-		is_remote
+		is_remote,
+		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -202,6 +202,7 @@ func (w *SpanWriter) writeIndexBatchV3(ctx context.Context, batchSpans []*SpanV3
 			span.DBOperation,
 			span.HasError,
 			span.IsRemote,
+			time.Now(),
 		)
 		if err != nil {
 			return fmt.Errorf("could not append span to batch: %w", err)


### PR DESCRIPTION
## Pull Request

### Summary
Adds created_at and inserted_at to logs and traces

* inserted_at is by collector
* created_at is by clickhouse

### Related Issues
Closes https://github.com/SigNoz/engineering-pod/issues/5855

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No