### PR TITLE
feat: resolve semantic-convention families in derived telemetry

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1301,4 +1301,156 @@ var TracesMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1015,
+		UpItems: []Operation{
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_db_calls_mv_v2",
+				Query: `SELECT
+							resource_string_service$$name AS src,
+							attribute_string_db$$system AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(duration_nano)) AS duration_quantiles_state,
+							countIf(status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(timestamp) AS timestamp,
+							if(notEmpty(resources_string['deployment.environment.name']), resources_string['deployment.environment.name'], resources_string['deployment.environment']) AS deployment_environment,
+							resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3
+						WHERE (dest != '') AND (kind != 2)
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_messaging_calls_mv_v2",
+				Query: `SELECT
+							resource_string_service$$name AS src,
+							attribute_string_messaging$$system AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(duration_nano)) AS duration_quantiles_state,
+							countIf(status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(timestamp) AS timestamp,
+							if(notEmpty(resources_string['deployment.environment.name']), resources_string['deployment.environment.name'], resources_string['deployment.environment']) AS deployment_environment,
+							resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3
+						WHERE (dest != '') AND (kind != 2)
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_service_calls_mv_v2",
+				Query: `SELECT
+							A.resource_string_service$$name AS src,
+							B.resource_string_service$$name AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(B.duration_nano)) AS duration_quantiles_state,
+							countIf(B.status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(B.timestamp) AS timestamp,
+							if(notEmpty(B.resources_string['deployment.environment.name']), B.resources_string['deployment.environment.name'], B.resources_string['deployment.environment']) AS deployment_environment,
+							B.resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							B.resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3 AS A, signoz_traces.signoz_index_v3 AS B
+						WHERE (A.resource_string_service$$name != B.resource_string_service$$name) AND (A.span_id = B.parent_span_id)
+							AND B.span_id != '' AND A.span_id != ''
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name;`,
+			},
+		},
+		DownItems: []Operation{
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_db_calls_mv_v2",
+				Query: `SELECT
+							resource_string_service$$name AS src,
+							attribute_string_db$$system AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(duration_nano)) AS duration_quantiles_state,
+							countIf(status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(timestamp) AS timestamp,
+							resources_string['deployment.environment'] AS deployment_environment,
+							resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3
+						WHERE (dest != '') AND (kind != 2)
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_messaging_calls_mv_v2",
+				Query: `SELECT
+							resource_string_service$$name AS src,
+							attribute_string_messaging$$system AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(duration_nano)) AS duration_quantiles_state,
+							countIf(status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(timestamp) AS timestamp,
+							resources_string['deployment.environment'] AS deployment_environment,
+							resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3
+						WHERE (dest != '') AND (kind != 2)
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name`,
+			},
+			ModifyQueryMaterializedViewOperation{
+				Database: "signoz_traces",
+				ViewName: "dependency_graph_minutes_service_calls_mv_v2",
+				Query: `SELECT
+							A.resource_string_service$$name AS src,
+							B.resource_string_service$$name AS dest,
+							quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(toFloat64(B.duration_nano)) AS duration_quantiles_state,
+							countIf(B.status_code = 2) AS error_count,
+							count(*) AS total_count,
+							toStartOfMinute(B.timestamp) AS timestamp,
+							B.resources_string['deployment.environment'] AS deployment_environment,
+							B.resources_string['k8s.cluster.name'] AS k8s_cluster_name,
+							B.resources_string['k8s.namespace.name'] AS k8s_namespace_name
+						FROM signoz_traces.signoz_index_v3 AS A, signoz_traces.signoz_index_v3 AS B
+						WHERE (A.resource_string_service$$name != B.resource_string_service$$name) AND (A.span_id = B.parent_span_id)
+							AND B.span_id != '' AND A.span_id != ''
+						GROUP BY
+							timestamp,
+							src,
+							dest,
+							deployment_environment,
+							k8s_cluster_name,
+							k8s_namespace_name;`,
+			},
+		},
+	},
+	{
+		MigrationID: 1016,
+		UpItems:     traceMaterializedSemconvOperations(true),
+		DownItems:   traceMaterializedSemconvOperations(false),
+	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations_test.go
@@ -25,10 +25,12 @@ func TestTracesMigrationsExactNature(t *testing.T) {
 			TracesMigrations[11],
 			TracesMigrations[12],
 			TracesMigrations[13],
+			TracesMigrations[15], // 1015 (sync)
 		},
 		[]SchemaMigrationRecord{
-			TracesMigrations[1], // 1001 (async)
-			TracesMigrations[3], // 1003 (async)
+			TracesMigrations[1],  // 1001 (async)
+			TracesMigrations[3],  // 1003 (async)
+			TracesMigrations[16], // 1016 (async)
 		},
 	)
 }

--- a/cmd/signozschemamigrator/schema_migrator/traces_semconv.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_semconv.go
@@ -1,0 +1,53 @@
+package schemamigrator
+
+import "fmt"
+
+type traceMaterializedSemconvFamily struct {
+	column  string
+	current string
+	old     string
+}
+
+var traceMaterializedSemconvFamilies = []traceMaterializedSemconvFamily{
+	{column: "attribute_string_db$$system", current: "db.system.name", old: "db.system"},
+	{column: "attribute_string_messaging$$operation", current: "messaging.operation.type", old: "messaging.operation"},
+	{column: "attribute_string_rpc$$system", current: "rpc.system.name", old: "rpc.system"},
+	{column: "attribute_string_peer$$service", current: "service.peer.name", old: "peer.service"},
+}
+
+func traceMaterializedSemconvOperations(currentFirst bool) []Operation {
+	tables := []string{"signoz_index_v3", "distributed_signoz_index_v3"}
+	operations := make([]Operation, 0, len(tables)*len(traceMaterializedSemconvFamilies)*2)
+	for _, table := range tables {
+		for _, family := range traceMaterializedSemconvFamilies {
+			valueDefault := fmt.Sprintf("attributes_string['%s']", family.old)
+			existsDefault := fmt.Sprintf("if(mapContains(attributes_string, '%s') != 0, true, false)", family.old)
+			if currentFirst {
+				valueDefault = fmt.Sprintf(
+					"if(notEmpty(attributes_string['%s']), attributes_string['%s'], attributes_string['%s'])",
+					family.current,
+					family.current,
+					family.old,
+				)
+				existsDefault = fmt.Sprintf(
+					"mapContains(attributes_string, '%s') OR mapContains(attributes_string, '%s')",
+					family.current,
+					family.old,
+				)
+			}
+			operations = append(operations,
+				AlterTableModifyColumn{
+					Database: "signoz_traces",
+					Table:    table,
+					Column:   Column{Name: family.column, Default: valueDefault},
+				},
+				AlterTableModifyColumn{
+					Database: "signoz_traces",
+					Table:    table,
+					Column:   Column{Name: family.column + "_exists", Default: existsDefault},
+				},
+			)
+		}
+	}
+	return operations
+}

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -31,7 +31,7 @@ processors:
     dimensions:
       - name: service.namespace
         default: default
-      - name: deployment.environment
+      - name: deployment.environment.name
         default: default
   # memory_limiter:
   #   # 80% of maximum memory up to 2G

--- a/config/default-config.yaml
+++ b/config/default-config.yaml
@@ -31,7 +31,7 @@ processors:
     dimensions:
       - name: service.namespace
         default: default
-      - name: deployment.environment
+      - name: deployment.environment.name
         default: default
   signozspanmetrics/delta:
     metrics_exporter: signozclickhousemetrics
@@ -44,7 +44,7 @@ processors:
     dimensions:
       - name: service.namespace
         default: default
-      - name: deployment.environment
+      - name: deployment.environment.name
         default: default
       # This is added to ensure the uniqueness of the timeseries
       # Otherwise, identical timeseries produced by multiple replicas of

--- a/example/example-config.yaml
+++ b/example/example-config.yaml
@@ -83,7 +83,7 @@ processors:
     dimensions:
       - name: service.namespace
         default: default
-      - name: deployment.environment
+      - name: deployment.environment.name
         default: default
   # memory_limiter:
   #   # 80% of maximum memory up to 2G

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/pkg/metering"
+	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/usage"
 	"github.com/SigNoz/signoz-otel-collector/utils"
 	"github.com/SigNoz/signoz-otel-collector/utils/fingerprint"
@@ -25,10 +25,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var possibleHostAttr = utils.ToLookUpMap([]string{
-	"http.host", "server.address", "client.address",
+var possibleHostAttrs = []string{
+	"server.address", "http.host", "client.address",
 	"http.request.header.host", "net.peer.name",
-})
+}
 
 func makeJaegerProtoReferences(
 	links ptrace.SpanLinkSlice,
@@ -90,39 +90,7 @@ func ServiceNameForResource(resource pcommon.Resource) string {
 
 func populateCustomAttrsAndAttrs(attributes pcommon.Map, span *SpanV3) {
 	attributes.Range(func(k string, v pcommon.Value) bool {
-		if k == "http.status_code" || k == "http.response.status_code" {
-			// Handle both string/int http status codes.
-			statusString, err := strconv.Atoi(v.Str())
-			statusInt := v.Int()
-			if err == nil && statusString != 0 {
-				statusInt = int64(statusString)
-			}
-			span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
-		} else if (k == "http.url" || k == "url.full") && span.Kind == 3 {
-			value := v.Str()
-			valueUrl, err := url.Parse(value)
-			if err == nil {
-				value = valueUrl.Hostname()
-			}
-			span.ExternalHttpUrl = value
-			span.HttpUrl = v.Str()
-			if span.HttpHost == "" { // skip override if already set using possibleHostAttr
-				span.HttpHost = value
-			}
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind == 3 {
-			span.ExternalHttpMethod = v.Str()
-			span.HttpMethod = v.Str()
-		} else if (k == "http.url" || k == "url.full") && span.Kind != 3 {
-			span.HttpUrl = v.Str()
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind != 3 {
-			span.HttpMethod = v.Str()
-		} else if _, ok := possibleHostAttr[k]; ok {
-			span.HttpHost = v.Str()
-		} else if k == "db.name" || k == "db.namespace" {
-			span.DBName = v.Str()
-		} else if k == "db.operation" || k == "db.operation.name" {
-			span.DBOperation = v.Str()
-		} else if k == "rpc.grpc.status_code" {
+		if k == "rpc.grpc.status_code" {
 			// Handle both string/int status code in GRPC spans.
 			statusString, err := strconv.Atoi(v.Str())
 			statusInt := v.Int()
@@ -137,6 +105,58 @@ func populateCustomAttrsAndAttrs(attributes pcommon.Map, span *SpanV3) {
 
 	})
 
+	if value, ok := firstAttribute(attributes, "http.response.status_code", "http.status_code"); ok {
+		// Handle both string/int HTTP status codes.
+		statusString, err := strconv.Atoi(value.Str())
+		statusInt := value.Int()
+		if err == nil && statusString != 0 {
+			statusInt = int64(statusString)
+		}
+		span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
+	}
+
+	if value, ok := firstAttribute(attributes, possibleHostAttrs...); ok {
+		span.HttpHost = value.Str()
+	}
+	if value, ok := firstAttribute(attributes, "url.full", "http.url"); ok {
+		span.HttpUrl = value.Str()
+		if span.Kind == 3 {
+			host := value.Str()
+			parsedURL, err := url.Parse(host)
+			if err == nil {
+				host = parsedURL.Hostname()
+			}
+			span.ExternalHttpUrl = host
+			if span.HttpHost == "" {
+				span.HttpHost = host
+			}
+		}
+	}
+	if value, ok := firstAttribute(attributes, "http.request.method", "http.method"); ok {
+		span.HttpMethod = value.Str()
+		if span.Kind == 3 {
+			span.ExternalHttpMethod = value.Str()
+		}
+	}
+	if value, ok := firstAttribute(attributes, "db.namespace", "db.name"); ok {
+		span.DBName = value.Str()
+	}
+	if value, ok := firstAttribute(attributes, "db.operation.name", "db.operation"); ok {
+		span.DBOperation = value.Str()
+	}
+
+}
+
+func firstAttribute(attributes pcommon.Map, names ...string) (pcommon.Value, bool) {
+	for _, name := range names {
+		if value, ok := attributes.Get(name); ok {
+			if value.Type() == pcommon.ValueTypeStr && value.Str() == "" {
+				continue
+			}
+			return value, true
+		}
+	}
+	return pcommon.Value{}, false
 }
 
 func populateEventsV3(events ptrace.SpanEventSlice, span *SpanV3, lowCardinalExceptionGrouping bool) {

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
@@ -839,3 +839,42 @@ func TestPopulateCustomAttrsAndAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestPopulateCustomAttrsAndAttrsPrefersCurrentSemconvNames(t *testing.T) {
+	span := &SpanV3{Kind: 3}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.status_code", "400")
+	attrs.PutStr("http.response.status_code", "201")
+	attrs.PutStr("http.url", "https://legacy.example/path")
+	attrs.PutStr("url.full", "https://current.example/path")
+	attrs.PutStr("http.method", "POST")
+	attrs.PutStr("http.request.method", "GET")
+	attrs.PutStr("db.name", "legacy")
+	attrs.PutStr("db.namespace", "current")
+	attrs.PutStr("db.operation", "legacy-operation")
+	attrs.PutStr("db.operation.name", "current-operation")
+	attrs.PutStr("net.peer.name", "legacy-peer")
+	attrs.PutStr("server.address", "current-peer")
+
+	populateCustomAttrsAndAttrs(attrs, span)
+
+	assert.Equal(t, "201", span.ResponseStatusCode)
+	assert.Equal(t, "https://current.example/path", span.HttpUrl)
+	assert.Equal(t, "current.example", span.ExternalHttpUrl)
+	assert.Equal(t, "GET", span.HttpMethod)
+	assert.Equal(t, "GET", span.ExternalHttpMethod)
+	assert.Equal(t, "current", span.DBName)
+	assert.Equal(t, "current-operation", span.DBOperation)
+	assert.Equal(t, "current-peer", span.HttpHost)
+}
+
+func TestFirstAttributeFallsBackFromEmptyCurrentValue(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.request.method", "")
+	attrs.PutStr("http.method", "GET")
+
+	value, ok := firstAttribute(attrs, "http.request.method", "http.method")
+
+	assert.True(t, ok)
+	assert.Equal(t, "GET", value.Str())
+}

--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -43,14 +43,22 @@ import (
 )
 
 const (
-	serviceNameKey          = conventions.AttributeServiceName
-	operationKey            = "operation"   // OpenTelemetry non-standard constant.
-	spanKindKey             = "span.kind"   // OpenTelemetry non-standard constant.
-	statusCodeKey           = "status.code" // OpenTelemetry non-standard constant.
-	tagHTTPStatusCode       = conventions.AttributeHTTPStatusCode
-	tagHTTPStatusCodeStable = "http.response.status_code"
-	metricKeySeparator      = string(byte(0))
-	traceIDKey              = "trace_id"
+	serviceNameKey           = conventions.AttributeServiceName
+	operationKey             = "operation"   // OpenTelemetry non-standard constant.
+	spanKindKey              = "span.kind"   // OpenTelemetry non-standard constant.
+	statusCodeKey            = "status.code" // OpenTelemetry non-standard constant.
+	tagHTTPStatusCode        = conventions.AttributeHTTPStatusCode
+	tagHTTPStatusCodeStable  = "http.response.status_code"
+	deploymentEnvironment    = "deployment.environment.name"
+	deploymentEnvironmentOld = "deployment.environment"
+	dbSystem                 = "db.system.name"
+	dbSystemOld              = "db.system"
+	rpcSystem                = "rpc.system.name"
+	rpcSystemOld             = "rpc.system"
+	peerService              = "service.peer.name"
+	peerServiceOld           = "peer.service"
+	metricKeySeparator       = string(byte(0))
+	traceIDKey               = "trace_id"
 
 	signozID = "signoz.collector.id"
 
@@ -66,7 +74,40 @@ var (
 	defaultLatencyHistogramBucketsMs = []float64{
 		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000,
 	}
+	dimensionMemberIndex = buildDimensionMemberIndex()
 )
+
+func buildDimensionMemberIndex() map[string][]string {
+	families := [][]string{
+		{deploymentEnvironment, deploymentEnvironmentOld},
+		{dbSystem, dbSystemOld},
+		{"db.namespace", "db.elasticsearch.cluster.name", "db.name", "db.cassandra.keyspace", "db.hbase.namespace"},
+		{"db.operation.name", "db.operation"},
+		{"db.query.text", "db.statement"},
+		{rpcSystem, rpcSystemOld},
+		{peerService, peerServiceOld},
+		{"messaging.destination.name", "messaging.destination"},
+		{"messaging.operation.type", "messaging.operation"},
+		{"messaging.consumer.group.name", "messaging.eventhubs.consumer.group", "messaging.kafka.consumer.group", "messaging.rocketmq.client_group", "messaging.kafka.consumer_group"},
+		{"messaging.client.id", "messaging.client_id", "messaging.kafka.client_id", "messaging.rocketmq.client_id"},
+		{"container.runtime.name", "container.runtime"},
+		{"code.file.path", "code.filepath"},
+		{"code.function.name", "code.function"},
+		{"code.line.number", "code.lineno"},
+		{"http.request.method", "http.method"},
+		{"http.response.status_code", "http.status_code"},
+		{"url.full", "http.url"},
+		{"url.scheme", "http.scheme"},
+		{"user_agent.original", "browser.user_agent", "http.user_agent"},
+	}
+	index := make(map[string][]string)
+	for _, members := range families {
+		for _, member := range members {
+			index[member] = members
+		}
+	}
+	return index
+}
 
 // parseTimesFromKeyOrNow parses the time bucket prefix from a metric key and returns the StartTimeUnixNano and TimeUnixNano fields for metrics.
 // Ref: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality .
@@ -281,7 +322,7 @@ func newProcessor(logger *zap.Logger, instanceID string, config component.Config
 	callDimensions = append(callDimensions, pConfig.Dimensions...)
 
 	dbCallDimensions := []Dimension{
-		{Name: conventions.AttributeDBSystem},
+		{Name: dbSystem},
 		{Name: conventions.AttributeDBName},
 	}
 	dbCallDimensions = append(dbCallDimensions, pConfig.Dimensions...)
@@ -848,37 +889,37 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 
 	getPeerAddress := func(attrs pcommon.Map) (string, bool) {
 		var addr string
-		// Since net.peer.name is readable, it is preferred over net.peer.ip.
-		peerName, ok := attrs.Get(conventions.AttributeNetPeerName)
+		// net.peer.name|net.host.name was renamed to server.address. Prefer the
+		// current spelling when a mixed-generation SDK emits both.
+		peerName, ok := attrs.Get("server.address")
 		if ok {
 			addr = peerName.Str()
-			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
-			if ok {
-				addr += ":" + port.Str()
-			}
-			return addr, true
-		}
-		// net.peer.name|net.host.name is renamed to server.address
-		peerAddress, ok := attrs.Get("server.address")
-		if ok {
-			addr = peerAddress.Str()
 			port, ok := attrs.Get("server.port")
 			if ok {
 				addr += ":" + port.Str()
 			}
 			return addr, true
 		}
-
-		peerIp, ok := attrs.Get(conventions.AttributeNetPeerIP)
+		peerAddress, ok := attrs.Get(conventions.AttributeNetPeerName)
 		if ok {
-			addr = peerIp.Str()
+			addr = peerAddress.Str()
 			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
 			if ok {
 				addr += ":" + port.Str()
 			}
 			return addr, true
 		}
-		// net.peer.ip is renamed to net.sock.peer.addr
+
+		// Prefer the current network peer spelling before its historical forms.
+		peerIp, ok := attrs.Get("network.peer.address")
+		if ok {
+			addr = peerIp.Str()
+			port, ok := attrs.Get("network.peer.port")
+			if ok {
+				addr += ":" + port.Str()
+			}
+			return addr, true
+		}
 		peerAddress, ok = attrs.Get("net.sock.peer.addr")
 		if ok {
 			addr = peerAddress.Str()
@@ -889,11 +930,10 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 			return addr, true
 		}
 
-		// And later net.sock.peer.addr is renamed to network.peer.address
-		peerAddress, ok = attrs.Get("network.peer.address")
+		peerAddress, ok = attrs.Get(conventions.AttributeNetPeerIP)
 		if ok {
 			addr = peerAddress.Str()
-			port, ok := attrs.Get("network.peer.port")
+			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
 			if ok {
 				addr += ":" + port.Str()
 			}
@@ -904,7 +944,7 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 	}
 
 	attrs := span.Attributes()
-	_, isRPC := attrs.Get(conventions.AttributeRPCSystem)
+	_, isRPC := getFirstAttribute(attrs, rpcSystem, rpcSystemOld)
 	// If the span is an RPC, the remote address is service/method.
 	if isRPC {
 		service, svcOK := attrs.Get(conventions.AttributeRPCService)
@@ -940,11 +980,7 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 	}
 
 	// If none of the above is set, check for full URL.
-	httpURL, ok := attrs.Get(conventions.AttributeHTTPURL)
-	if !ok {
-		// http.url is renamed to url.full
-		httpURL, ok = attrs.Get("url.full")
-	}
+	httpURL, ok := getFirstAttribute(attrs, "url.full", conventions.AttributeHTTPURL)
 	if ok {
 		urlValue := httpURL.Str()
 		// url pattern from godoc [scheme:][//[userinfo@]host][/]path[?query][#fragment]
@@ -958,9 +994,9 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 		return parsedURL.Host, true
 	}
 
-	peerService, ok := attrs.Get(conventions.AttributePeerService)
+	peerValue, ok := getFirstAttribute(attrs, peerService, peerServiceOld)
 	if ok {
-		return peerService.Str(), true
+		return peerValue.Str(), true
 	}
 
 	return "", false
@@ -1017,7 +1053,7 @@ func (p *processorImp) aggregateMetricsForSpan(serviceName string, span ptrace.S
 		p.updateExternalHistogram(externalCallKey, latencyInMilliseconds, span.TraceID(), span.SpanID())
 	}
 
-	_, dbCallPresent := spanAttr.Get("db.system")
+	_, dbCallPresent := getFirstAttribute(spanAttr, dbSystem, dbSystemOld)
 	if span.Kind() != ptrace.SpanKindServer && dbCallPresent {
 		dbCallKey := p.buildCustomMetricKey(serviceName, span, p.dbCallDimensions, resourceAttr, nil)
 		p.dbCallCache(serviceName, span, dbCallKey, resourceAttr)
@@ -1319,16 +1355,15 @@ func buildCustomKey(dest *bytes.Buffer, serviceName string, span ptrace.Span, op
 // The ok flag indicates if a dimension value was fetched in order to differentiate
 // an empty string value from a state where no value was found.
 func getDimensionValue(d dimension, spanAttr pcommon.Map, resourceAttr pcommon.Map) (v pcommon.Value, ok bool) {
-	// The more specific span attribute should take precedence.
-	if attr, exists := spanAttr.Get(d.name); exists {
-		return attr, true
-	} else if d.name == tagHTTPStatusCode {
-		if attr, exists := spanAttr.Get(tagHTTPStatusCodeStable); exists {
+	for _, name := range dimensionMemberNames(d.name) {
+		// Preserve span-over-resource precedence for the same semantic-convention
+		// member, while checking the current member before every old member.
+		if attr, exists := spanAttr.Get(name); exists {
 			return attr, true
 		}
-	}
-	if attr, exists := resourceAttr.Get(d.name); exists {
-		return attr, true
+		if attr, exists := resourceAttr.Get(name); exists {
+			return attr, true
+		}
 	}
 	// Set the default if configured, otherwise this metric will have no value set for the dimension.
 	if d.value != nil {
@@ -1338,24 +1373,42 @@ func getDimensionValue(d dimension, spanAttr pcommon.Map, resourceAttr pcommon.M
 }
 
 func getDimensionValueWithResource(d dimension, spanAttr pcommon.Map, resourceAttr pcommon.Map) (v pcommon.Value, ok bool, foundInResource bool) {
-	if attr, exists := spanAttr.Get(d.name); exists {
-		if _, exists := resourceAttr.Get(d.name); exists {
-			return attr, true, true
-		}
-		return attr, true, false
-	} else if d.name == tagHTTPStatusCode {
-		if attr, exists := spanAttr.Get(tagHTTPStatusCodeStable); exists {
-			return attr, true, false
+	members := dimensionMemberNames(d.name)
+	for _, name := range members {
+		if _, exists := resourceAttr.Get(name); exists {
+			foundInResource = true
+			break
 		}
 	}
-	if attr, exists := resourceAttr.Get(d.name); exists {
-		return attr, true, true
+	for _, name := range members {
+		if attr, exists := spanAttr.Get(name); exists {
+			return attr, true, foundInResource
+		}
+		if attr, exists := resourceAttr.Get(name); exists {
+			return attr, true, true
+		}
 	}
 	// Set the default if configured, otherwise this metric will have no value set for the dimension.
 	if d.value != nil {
 		return *d.value, true, false
 	}
 	return v, ok, foundInResource
+}
+
+func dimensionMemberNames(name string) []string {
+	if members, ok := dimensionMemberIndex[name]; ok {
+		return members
+	}
+	return []string{name}
+}
+
+func getFirstAttribute(attributes pcommon.Map, names ...string) (pcommon.Value, bool) {
+	for _, name := range names {
+		if value, ok := attributes.Get(name); ok {
+			return value, true
+		}
+	}
+	return pcommon.Value{}, false
 }
 
 // cache the dimension key-value map for the metricKey if there is a cache miss.

--- a/processor/signozspanmetricsprocessor/semconv_test.go
+++ b/processor/signozspanmetricsprocessor/semconv_test.go
@@ -1,0 +1,245 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signozspanmetricsprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+)
+
+func TestDeploymentEnvironmentDimensionResolution(t *testing.T) {
+	makeAttrs := func(values map[string]string) pcommon.Map {
+		attrs := pcommon.NewMap()
+		for key, value := range values {
+			attrs.PutStr(key, value)
+		}
+		return attrs
+	}
+
+	tests := []struct {
+		name      string
+		requested string
+		span      map[string]string
+		resource  map[string]string
+		want      string
+	}{
+		{
+			name:      "current only",
+			requested: deploymentEnvironment,
+			resource:  map[string]string{deploymentEnvironment: "production"},
+			want:      "production",
+		},
+		{
+			name:      "old only with current request",
+			requested: deploymentEnvironment,
+			resource:  map[string]string{deploymentEnvironmentOld: "production"},
+			want:      "production",
+		},
+		{
+			name:      "current only with old request",
+			requested: deploymentEnvironmentOld,
+			resource:  map[string]string{deploymentEnvironment: "production"},
+			want:      "production",
+		},
+		{
+			name:      "current wins conflict",
+			requested: deploymentEnvironment,
+			resource: map[string]string{
+				deploymentEnvironment:    "production",
+				deploymentEnvironmentOld: "staging",
+			},
+			want: "production",
+		},
+		{
+			name:      "current resource wins old span",
+			requested: deploymentEnvironment,
+			span:      map[string]string{deploymentEnvironmentOld: "staging"},
+			resource:  map[string]string{deploymentEnvironment: "production"},
+			want:      "production",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, ok := getDimensionValue(
+				dimension{name: test.requested},
+				makeAttrs(test.span),
+				makeAttrs(test.resource),
+			)
+			require.True(t, ok)
+			assert.Equal(t, test.want, value.Str())
+		})
+	}
+}
+
+func TestDeploymentEnvironmentDimensionTracksResourceOrigin(t *testing.T) {
+	span := pcommon.NewMap()
+	span.PutStr(deploymentEnvironment, "production")
+	resource := pcommon.NewMap()
+	resource.PutStr(deploymentEnvironmentOld, "staging")
+
+	value, ok, foundInResource := getDimensionValueWithResource(
+		dimension{name: deploymentEnvironment},
+		span,
+		resource,
+	)
+	require.True(t, ok)
+	assert.True(t, foundInResource)
+	assert.Equal(t, "production", value.Str())
+}
+
+func TestSpanmetricsEmitsCurrentDeploymentEnvironmentLabel(t *testing.T) {
+	processor := &processorImp{
+		attrsCardinality:                       map[string]map[string]struct{}{},
+		serviceToOperations:                    map[string]map[string]struct{}{},
+		maxNumberOfServicesToTrack:             100,
+		maxNumberOfOperationsToTrackPerService: 100,
+	}
+	resource := pcommon.NewMap()
+	resource.PutStr(deploymentEnvironmentOld, "production")
+
+	dimensions := processor.buildDimensionKVs(
+		"checkout",
+		ptrace.NewSpan(),
+		[]dimension{{name: deploymentEnvironment}},
+		resource,
+	)
+
+	value, ok := dimensions.Get(deploymentEnvironment)
+	require.True(t, ok)
+	assert.Equal(t, "production", value.Str())
+	_, oldExists := dimensions.Get(deploymentEnvironmentOld)
+	assert.False(t, oldExists)
+	resourceValue, ok := dimensions.Get(resourcePrefix + deploymentEnvironment)
+	require.True(t, ok)
+	assert.Equal(t, "production", resourceValue.Str())
+}
+
+func TestDBSystemDimensionResolution(t *testing.T) {
+	span := pcommon.NewMap()
+	span.PutStr(dbSystemOld, "mysql")
+	span.PutStr(dbSystem, "postgresql")
+
+	value, ok := getDimensionValue(dimension{name: dbSystem}, span, pcommon.NewMap())
+	require.True(t, ok)
+	assert.Equal(t, "postgresql", value.Str())
+
+	legacyOnly := pcommon.NewMap()
+	legacyOnly.PutStr(dbSystemOld, "redis")
+	value, ok = getDimensionValue(dimension{name: dbSystem}, legacyOnly, pcommon.NewMap())
+	require.True(t, ok)
+	assert.Equal(t, "redis", value.Str())
+}
+
+func TestSpanmetricsEmitsCurrentDBSystemLabel(t *testing.T) {
+	processor := &processorImp{
+		attrsCardinality:                       map[string]map[string]struct{}{},
+		serviceToOperations:                    map[string]map[string]struct{}{},
+		maxNumberOfServicesToTrack:             100,
+		maxNumberOfOperationsToTrackPerService: 100,
+	}
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr(dbSystemOld, "postgresql")
+
+	dimensions := processor.buildCustomDimensionKVs(
+		"checkout",
+		span,
+		[]dimension{{name: dbSystem}},
+		pcommon.NewMap(),
+		nil,
+	)
+
+	value, ok := dimensions.Get(dbSystem)
+	require.True(t, ok)
+	assert.Equal(t, "postgresql", value.Str())
+	_, oldExists := dimensions.Get(dbSystemOld)
+	assert.False(t, oldExists)
+}
+
+func TestDBClassificationAcceptsCurrentName(t *testing.T) {
+	attributes := pcommon.NewMap()
+	attributes.PutStr(dbSystem, "postgresql")
+	value, ok := getFirstAttribute(attributes, dbSystem, dbSystemOld)
+	require.True(t, ok)
+	assert.Equal(t, "postgresql", value.Str())
+}
+
+func TestPhase4DimensionFamiliesResolveCurrentFirst(t *testing.T) {
+	currents := []string{
+		"db.namespace",
+		"db.operation.name",
+		"db.query.text",
+		rpcSystem,
+		peerService,
+		"messaging.destination.name",
+		"messaging.operation.type",
+		"messaging.consumer.group.name",
+		"messaging.client.id",
+		"container.runtime.name",
+		"code.file.path",
+		"code.function.name",
+		"code.line.number",
+		"http.request.method",
+		"http.response.status_code",
+		"url.full",
+		"url.scheme",
+		"user_agent.original",
+	}
+
+	for _, current := range currents {
+		t.Run(current, func(t *testing.T) {
+			members := dimensionMemberNames(current)
+			require.GreaterOrEqual(t, len(members), 2)
+			assert.Equal(t, current, members[0])
+
+			attributes := pcommon.NewMap()
+			attributes.PutStr(members[1], "old")
+			value, ok := getDimensionValue(dimension{name: current}, attributes, pcommon.NewMap())
+			require.True(t, ok)
+			assert.Equal(t, "old", value.Str())
+
+			attributes.PutStr(current, "current")
+			value, ok = getDimensionValue(dimension{name: members[1]}, attributes, pcommon.NewMap())
+			require.True(t, ok)
+			assert.Equal(t, "current", value.Str())
+
+			for _, member := range members {
+				assert.Equal(t, members, dimensionMemberNames(member))
+			}
+		})
+	}
+}
+
+func TestRemoteAddressUsesCurrentRPCAndPeerService(t *testing.T) {
+	rpcSpan := ptrace.NewSpan()
+	rpcSpan.Attributes().PutStr(rpcSystem, "grpc")
+	rpcSpan.Attributes().PutStr(conventions.AttributeRPCService, "checkout.v1.Cart")
+	rpcSpan.Attributes().PutStr(conventions.AttributeRPCMethod, "Get")
+	address, ok := getRemoteAddress(rpcSpan)
+	require.True(t, ok)
+	assert.Equal(t, "checkout.v1.Cart/Get", address)
+
+	peerSpan := ptrace.NewSpan()
+	peerSpan.Attributes().PutStr(peerServiceOld, "legacy-checkout")
+	peerSpan.Attributes().PutStr(peerService, "checkout")
+	address, ok = getRemoteAddress(peerSpan)
+	require.True(t, ok)
+	assert.Equal(t, "checkout", address)
+}


### PR DESCRIPTION
#### Description

- Derived telemetry reads both spellings of a renamed attribute and prefers the current one. This one change covers the three surfaces, and it replaces #878 and #879.
- Migration 1015 (sync) points the dependency-graph materialized views at the current `deployment.environment` spelling first, with fallback to the old one. The expression stays a plain String, so keyless rows group under the empty value as before. Migration 1016 (async) rewrites the materialized-column defaults (`db.system`, `messaging.operation`, `rpc.system`, `peer.service`) to read the current spelling first. 1016 covers existing and fresh installs, so the shipped migration records stay untouched.
- The span-metrics processor resolves dimensions through a family index, current name first; the remote-address and status-code paths use the same order, and the hardcoded `http.status_code` fallback is gone.
- The traces exporter derives response status, URL, method, host, and db fields with deterministic current-first precedence; the old code depended on attribute iteration order when both spellings were present.
- The shipped configs name the span-metrics dimension `deployment.environment.name`; the family index accepts either spelling.

#### Additional Information

- The migration sanity tests classify 1015 as sync and 1016 as async; the string-matching migration tests are gone, because running the records is the real check.
- The dependency-graph views keep reading `resources_string`: the exporter writes both `resources_string` and the `resource` JSON column, every sibling dimension in those views reads the map, and the whole-view JSON cutover is a separate migration for when the map write stops.

