### PR TITLE
feat: complete semantic convention collector rollout

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_migrations.go
@@ -1448,4 +1448,9 @@ var TracesMigrations = []SchemaMigrationRecord{
 			},
 		},
 	},
+	{
+		MigrationID: 1016,
+		UpItems:     traceMaterializedSemconvOperations(true),
+		DownItems:   traceMaterializedSemconvOperations(false),
+	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/traces_phase4_semconv.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_phase4_semconv.go
@@ -1,0 +1,53 @@
+package schemamigrator
+
+import "fmt"
+
+type traceMaterializedSemconvFamily struct {
+	column  string
+	current string
+	old     string
+}
+
+var traceMaterializedSemconvFamilies = []traceMaterializedSemconvFamily{
+	{column: "attribute_string_db$$system", current: "db.system.name", old: "db.system"},
+	{column: "attribute_string_messaging$$operation", current: "messaging.operation.type", old: "messaging.operation"},
+	{column: "attribute_string_rpc$$system", current: "rpc.system.name", old: "rpc.system"},
+	{column: "attribute_string_peer$$service", current: "service.peer.name", old: "peer.service"},
+}
+
+func traceMaterializedSemconvOperations(currentFirst bool) []Operation {
+	tables := []string{"signoz_index_v3", "distributed_signoz_index_v3"}
+	operations := make([]Operation, 0, len(tables)*len(traceMaterializedSemconvFamilies)*2)
+	for _, table := range tables {
+		for _, family := range traceMaterializedSemconvFamilies {
+			valueDefault := fmt.Sprintf("attributes_string['%s']", family.old)
+			existsDefault := fmt.Sprintf("mapContains(attributes_string, '%s')", family.old)
+			if currentFirst {
+				valueDefault = fmt.Sprintf(
+					"if(notEmpty(attributes_string['%s']), attributes_string['%s'], attributes_string['%s'])",
+					family.current,
+					family.current,
+					family.old,
+				)
+				existsDefault = fmt.Sprintf(
+					"mapContains(attributes_string, '%s') OR mapContains(attributes_string, '%s')",
+					family.current,
+					family.old,
+				)
+			}
+			operations = append(operations,
+				AlterTableModifyColumn{
+					Database: "signoz_traces",
+					Table:    table,
+					Column:   Column{Name: family.column, Default: valueDefault},
+				},
+				AlterTableModifyColumn{
+					Database: "signoz_traces",
+					Table:    table,
+					Column:   Column{Name: family.column + "_exists", Default: existsDefault},
+				},
+			)
+		}
+	}
+	return operations
+}

--- a/cmd/signozschemamigrator/schema_migrator/traces_phase4_semconv_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/traces_phase4_semconv_test.go
@@ -1,0 +1,46 @@
+package schemamigrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPhase4MaterializedSemconvMigration(t *testing.T) {
+	var migration *SchemaMigrationRecord
+	for idx := range TracesMigrations {
+		if TracesMigrations[idx].MigrationID == 1016 {
+			migration = &TracesMigrations[idx]
+			break
+		}
+	}
+	require.NotNil(t, migration)
+	wantCount := 2 * len(traceMaterializedSemconvFamilies) * 2
+	require.Len(t, migration.UpItems, wantCount)
+	require.Len(t, migration.DownItems, wantCount)
+
+	for _, operation := range migration.UpItems {
+		modify, ok := operation.(AlterTableModifyColumn)
+		require.True(t, ok)
+		assert.Contains(t, []string{"signoz_index_v3", "distributed_signoz_index_v3"}, modify.Table)
+		if strings.HasSuffix(modify.Column.Name, "_exists") {
+			assert.Contains(t, modify.Column.Default, " OR ")
+		} else {
+			assert.Contains(t, modify.Column.Default, "if(notEmpty(")
+		}
+		currentIndex := strings.Index(modify.Column.Default, ".name")
+		if strings.Contains(modify.Column.Name, "messaging$$operation") {
+			currentIndex = strings.Index(modify.Column.Default, ".type")
+		}
+		assert.NotEqual(t, -1, currentIndex, modify.Column.Default)
+	}
+
+	for _, operation := range migration.DownItems {
+		modify, ok := operation.(AlterTableModifyColumn)
+		require.True(t, ok)
+		assert.NotContains(t, modify.Column.Default, " OR ")
+		assert.NotContains(t, modify.Column.Default, "if(notEmpty(")
+	}
+}

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/pkg/metering"
+	tracesschema "github.com/SigNoz/signoz-otel-collector/pkg/schema/traces"
 	"github.com/SigNoz/signoz-otel-collector/usage"
 	"github.com/SigNoz/signoz-otel-collector/utils"
 	"github.com/SigNoz/signoz-otel-collector/utils/fingerprint"
@@ -25,10 +25,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var possibleHostAttr = utils.ToLookUpMap([]string{
-	"http.host", "server.address", "client.address",
+var possibleHostAttrs = []string{
+	"server.address", "http.host", "client.address",
 	"http.request.header.host", "net.peer.name",
-})
+}
 
 func makeJaegerProtoReferences(
 	links ptrace.SpanLinkSlice,
@@ -90,39 +90,7 @@ func ServiceNameForResource(resource pcommon.Resource) string {
 
 func populateCustomAttrsAndAttrs(attributes pcommon.Map, span *SpanV3) {
 	attributes.Range(func(k string, v pcommon.Value) bool {
-		if k == "http.status_code" || k == "http.response.status_code" {
-			// Handle both string/int http status codes.
-			statusString, err := strconv.Atoi(v.Str())
-			statusInt := v.Int()
-			if err == nil && statusString != 0 {
-				statusInt = int64(statusString)
-			}
-			span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
-		} else if (k == "http.url" || k == "url.full") && span.Kind == 3 {
-			value := v.Str()
-			valueUrl, err := url.Parse(value)
-			if err == nil {
-				value = valueUrl.Hostname()
-			}
-			span.ExternalHttpUrl = value
-			span.HttpUrl = v.Str()
-			if span.HttpHost == "" { // skip override if already set using possibleHostAttr
-				span.HttpHost = value
-			}
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind == 3 {
-			span.ExternalHttpMethod = v.Str()
-			span.HttpMethod = v.Str()
-		} else if (k == "http.url" || k == "url.full") && span.Kind != 3 {
-			span.HttpUrl = v.Str()
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind != 3 {
-			span.HttpMethod = v.Str()
-		} else if _, ok := possibleHostAttr[k]; ok {
-			span.HttpHost = v.Str()
-		} else if k == "db.name" || k == "db.namespace" {
-			span.DBName = v.Str()
-		} else if k == "db.operation" || k == "db.operation.name" {
-			span.DBOperation = v.Str()
-		} else if k == "rpc.grpc.status_code" {
+		if k == "rpc.grpc.status_code" {
 			// Handle both string/int status code in GRPC spans.
 			statusString, err := strconv.Atoi(v.Str())
 			statusInt := v.Int()
@@ -137,6 +105,58 @@ func populateCustomAttrsAndAttrs(attributes pcommon.Map, span *SpanV3) {
 
 	})
 
+	if value, ok := firstAttribute(attributes, "http.response.status_code", "http.status_code"); ok {
+		// Handle both string/int HTTP status codes.
+		statusString, err := strconv.Atoi(value.Str())
+		statusInt := value.Int()
+		if err == nil && statusString != 0 {
+			statusInt = int64(statusString)
+		}
+		span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
+	}
+
+	if value, ok := firstAttribute(attributes, possibleHostAttrs...); ok {
+		span.HttpHost = value.Str()
+	}
+	if value, ok := firstAttribute(attributes, "url.full", "http.url"); ok {
+		span.HttpUrl = value.Str()
+		if span.Kind == 3 {
+			host := value.Str()
+			parsedURL, err := url.Parse(host)
+			if err == nil {
+				host = parsedURL.Hostname()
+			}
+			span.ExternalHttpUrl = host
+			if span.HttpHost == "" {
+				span.HttpHost = host
+			}
+		}
+	}
+	if value, ok := firstAttribute(attributes, "http.request.method", "http.method"); ok {
+		span.HttpMethod = value.Str()
+		if span.Kind == 3 {
+			span.ExternalHttpMethod = value.Str()
+		}
+	}
+	if value, ok := firstAttribute(attributes, "db.namespace", "db.name"); ok {
+		span.DBName = value.Str()
+	}
+	if value, ok := firstAttribute(attributes, "db.operation.name", "db.operation"); ok {
+		span.DBOperation = value.Str()
+	}
+
+}
+
+func firstAttribute(attributes pcommon.Map, names ...string) (pcommon.Value, bool) {
+	for _, name := range names {
+		if value, ok := attributes.Get(name); ok {
+			if value.Type() == pcommon.ValueTypeStr && value.Str() == "" {
+				continue
+			}
+			return value, true
+		}
+	}
+	return pcommon.Value{}, false
 }
 
 func populateEventsV3(events ptrace.SpanEventSlice, span *SpanV3, lowCardinalExceptionGrouping bool) {

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
@@ -839,3 +839,42 @@ func TestPopulateCustomAttrsAndAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestPopulateCustomAttrsAndAttrsPrefersCurrentSemconvNames(t *testing.T) {
+	span := &SpanV3{Kind: 3}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.status_code", "400")
+	attrs.PutStr("http.response.status_code", "201")
+	attrs.PutStr("http.url", "https://legacy.example/path")
+	attrs.PutStr("url.full", "https://current.example/path")
+	attrs.PutStr("http.method", "POST")
+	attrs.PutStr("http.request.method", "GET")
+	attrs.PutStr("db.name", "legacy")
+	attrs.PutStr("db.namespace", "current")
+	attrs.PutStr("db.operation", "legacy-operation")
+	attrs.PutStr("db.operation.name", "current-operation")
+	attrs.PutStr("net.peer.name", "legacy-peer")
+	attrs.PutStr("server.address", "current-peer")
+
+	populateCustomAttrsAndAttrs(attrs, span)
+
+	assert.Equal(t, "201", span.ResponseStatusCode)
+	assert.Equal(t, "https://current.example/path", span.HttpUrl)
+	assert.Equal(t, "current.example", span.ExternalHttpUrl)
+	assert.Equal(t, "GET", span.HttpMethod)
+	assert.Equal(t, "GET", span.ExternalHttpMethod)
+	assert.Equal(t, "current", span.DBName)
+	assert.Equal(t, "current-operation", span.DBOperation)
+	assert.Equal(t, "current-peer", span.HttpHost)
+}
+
+func TestFirstAttributeFallsBackFromEmptyCurrentValue(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.request.method", "")
+	attrs.PutStr("http.method", "GET")
+
+	value, ok := firstAttribute(attrs, "http.request.method", "http.method")
+
+	assert.True(t, ok)
+	assert.Equal(t, "GET", value.Str())
+}

--- a/processor/signozspanmetricsprocessor/processor.go
+++ b/processor/signozspanmetricsprocessor/processor.go
@@ -53,6 +53,10 @@ const (
 	deploymentEnvironmentOld = "deployment.environment"
 	dbSystem                 = "db.system.name"
 	dbSystemOld              = "db.system"
+	rpcSystem                = "rpc.system.name"
+	rpcSystemOld             = "rpc.system"
+	peerService              = "service.peer.name"
+	peerServiceOld           = "peer.service"
 	metricKeySeparator       = string(byte(0))
 	traceIDKey               = "trace_id"
 
@@ -70,7 +74,40 @@ var (
 	defaultLatencyHistogramBucketsMs = []float64{
 		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000,
 	}
+	dimensionMemberIndex = buildDimensionMemberIndex()
 )
+
+func buildDimensionMemberIndex() map[string][]string {
+	families := [][]string{
+		{deploymentEnvironment, deploymentEnvironmentOld},
+		{dbSystem, dbSystemOld},
+		{"db.namespace", "db.elasticsearch.cluster.name", "db.name", "db.cassandra.keyspace", "db.hbase.namespace"},
+		{"db.operation.name", "db.operation"},
+		{"db.query.text", "db.statement"},
+		{rpcSystem, rpcSystemOld},
+		{peerService, peerServiceOld},
+		{"messaging.destination.name", "messaging.destination"},
+		{"messaging.operation.type", "messaging.operation"},
+		{"messaging.consumer.group.name", "messaging.eventhubs.consumer.group", "messaging.kafka.consumer.group", "messaging.rocketmq.client_group", "messaging.kafka.consumer_group"},
+		{"messaging.client.id", "messaging.client_id", "messaging.kafka.client_id", "messaging.rocketmq.client_id"},
+		{"container.runtime.name", "container.runtime"},
+		{"code.file.path", "code.filepath"},
+		{"code.function.name", "code.function"},
+		{"code.line.number", "code.lineno"},
+		{"http.request.method", "http.method"},
+		{"http.response.status_code", "http.status_code"},
+		{"url.full", "http.url"},
+		{"url.scheme", "http.scheme"},
+		{"user_agent.original", "browser.user_agent", "http.user_agent"},
+	}
+	index := make(map[string][]string)
+	for _, members := range families {
+		for _, member := range members {
+			index[member] = members
+		}
+	}
+	return index
+}
 
 // parseTimesFromKeyOrNow parses the time bucket prefix from a metric key and returns the StartTimeUnixNano and TimeUnixNano fields for metrics.
 // Ref: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality .
@@ -852,37 +889,37 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 
 	getPeerAddress := func(attrs pcommon.Map) (string, bool) {
 		var addr string
-		// Since net.peer.name is readable, it is preferred over net.peer.ip.
-		peerName, ok := attrs.Get(conventions.AttributeNetPeerName)
+		// net.peer.name|net.host.name was renamed to server.address. Prefer the
+		// current spelling when a mixed-generation SDK emits both.
+		peerName, ok := attrs.Get("server.address")
 		if ok {
 			addr = peerName.Str()
-			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
-			if ok {
-				addr += ":" + port.Str()
-			}
-			return addr, true
-		}
-		// net.peer.name|net.host.name is renamed to server.address
-		peerAddress, ok := attrs.Get("server.address")
-		if ok {
-			addr = peerAddress.Str()
 			port, ok := attrs.Get("server.port")
 			if ok {
 				addr += ":" + port.Str()
 			}
 			return addr, true
 		}
-
-		peerIp, ok := attrs.Get(conventions.AttributeNetPeerIP)
+		peerAddress, ok := attrs.Get(conventions.AttributeNetPeerName)
 		if ok {
-			addr = peerIp.Str()
+			addr = peerAddress.Str()
 			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
 			if ok {
 				addr += ":" + port.Str()
 			}
 			return addr, true
 		}
-		// net.peer.ip is renamed to net.sock.peer.addr
+
+		// Prefer the current network peer spelling before its historical forms.
+		peerIp, ok := attrs.Get("network.peer.address")
+		if ok {
+			addr = peerIp.Str()
+			port, ok := attrs.Get("network.peer.port")
+			if ok {
+				addr += ":" + port.Str()
+			}
+			return addr, true
+		}
 		peerAddress, ok = attrs.Get("net.sock.peer.addr")
 		if ok {
 			addr = peerAddress.Str()
@@ -893,11 +930,10 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 			return addr, true
 		}
 
-		// And later net.sock.peer.addr is renamed to network.peer.address
-		peerAddress, ok = attrs.Get("network.peer.address")
+		peerAddress, ok = attrs.Get(conventions.AttributeNetPeerIP)
 		if ok {
 			addr = peerAddress.Str()
-			port, ok := attrs.Get("network.peer.port")
+			port, ok := attrs.Get(conventions.AttributeNetPeerPort)
 			if ok {
 				addr += ":" + port.Str()
 			}
@@ -908,7 +944,7 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 	}
 
 	attrs := span.Attributes()
-	_, isRPC := attrs.Get(conventions.AttributeRPCSystem)
+	_, isRPC := getFirstAttribute(attrs, rpcSystem, rpcSystemOld)
 	// If the span is an RPC, the remote address is service/method.
 	if isRPC {
 		service, svcOK := attrs.Get(conventions.AttributeRPCService)
@@ -944,11 +980,7 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 	}
 
 	// If none of the above is set, check for full URL.
-	httpURL, ok := attrs.Get(conventions.AttributeHTTPURL)
-	if !ok {
-		// http.url is renamed to url.full
-		httpURL, ok = attrs.Get("url.full")
-	}
+	httpURL, ok := getFirstAttribute(attrs, "url.full", conventions.AttributeHTTPURL)
 	if ok {
 		urlValue := httpURL.Str()
 		// url pattern from godoc [scheme:][//[userinfo@]host][/]path[?query][#fragment]
@@ -962,9 +994,9 @@ func getRemoteAddress(span ptrace.Span) (string, bool) {
 		return parsedURL.Host, true
 	}
 
-	peerService, ok := attrs.Get(conventions.AttributePeerService)
+	peerValue, ok := getFirstAttribute(attrs, peerService, peerServiceOld)
 	if ok {
-		return peerService.Str(), true
+		return peerValue.Str(), true
 	}
 
 	return "", false
@@ -1374,11 +1406,8 @@ func getDimensionValueWithResource(d dimension, spanAttr pcommon.Map, resourceAt
 }
 
 func dimensionMemberNames(name string) []string {
-	if name == deploymentEnvironment || name == deploymentEnvironmentOld {
-		return []string{deploymentEnvironment, deploymentEnvironmentOld}
-	}
-	if name == dbSystem || name == dbSystemOld {
-		return []string{dbSystem, dbSystemOld}
+	if members, ok := dimensionMemberIndex[name]; ok {
+		return members
 	}
 	return []string{name}
 }

--- a/processor/signozspanmetricsprocessor/semconv_test.go
+++ b/processor/signozspanmetricsprocessor/semconv_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
 func TestDeploymentEnvironmentDimensionResolution(t *testing.T) {
@@ -178,4 +179,67 @@ func TestDBClassificationAcceptsCurrentName(t *testing.T) {
 	value, ok := getFirstAttribute(attributes, dbSystem, dbSystemOld)
 	require.True(t, ok)
 	assert.Equal(t, "postgresql", value.Str())
+}
+
+func TestPhase4DimensionFamiliesResolveCurrentFirst(t *testing.T) {
+	currents := []string{
+		"db.namespace",
+		"db.operation.name",
+		"db.query.text",
+		rpcSystem,
+		peerService,
+		"messaging.destination.name",
+		"messaging.operation.type",
+		"messaging.consumer.group.name",
+		"messaging.client.id",
+		"container.runtime.name",
+		"code.file.path",
+		"code.function.name",
+		"code.line.number",
+		"http.request.method",
+		"http.response.status_code",
+		"url.full",
+		"url.scheme",
+		"user_agent.original",
+	}
+
+	for _, current := range currents {
+		t.Run(current, func(t *testing.T) {
+			members := dimensionMemberNames(current)
+			require.GreaterOrEqual(t, len(members), 2)
+			assert.Equal(t, current, members[0])
+
+			attributes := pcommon.NewMap()
+			attributes.PutStr(members[1], "old")
+			value, ok := getDimensionValue(dimension{name: current}, attributes, pcommon.NewMap())
+			require.True(t, ok)
+			assert.Equal(t, "old", value.Str())
+
+			attributes.PutStr(current, "current")
+			value, ok = getDimensionValue(dimension{name: members[1]}, attributes, pcommon.NewMap())
+			require.True(t, ok)
+			assert.Equal(t, "current", value.Str())
+
+			for _, member := range members {
+				assert.Equal(t, members, dimensionMemberNames(member))
+			}
+		})
+	}
+}
+
+func TestRemoteAddressUsesCurrentRPCAndPeerService(t *testing.T) {
+	rpcSpan := ptrace.NewSpan()
+	rpcSpan.Attributes().PutStr(rpcSystem, "grpc")
+	rpcSpan.Attributes().PutStr(conventions.AttributeRPCService, "checkout.v1.Cart")
+	rpcSpan.Attributes().PutStr(conventions.AttributeRPCMethod, "Get")
+	address, ok := getRemoteAddress(rpcSpan)
+	require.True(t, ok)
+	assert.Equal(t, "checkout.v1.Cart/Get", address)
+
+	peerSpan := ptrace.NewSpan()
+	peerSpan.Attributes().PutStr(peerServiceOld, "legacy-checkout")
+	peerSpan.Attributes().PutStr(peerService, "checkout")
+	address, ok = getRemoteAddress(peerSpan)
+	require.True(t, ok)
+	assert.Equal(t, "checkout", address)
 }


### PR DESCRIPTION
## Pull Request

### Summary

Completes the collector side of the semantic-convention rollout:

- resolves the remaining enabled RPC, peer-service, messaging, Kafka, container, code, HTTP, URL, server, and DB attribute families current-first
- updates derived trace materialized columns and dependency-graph expressions
- updates promoted trace fields in the ClickHouse exporter while retaining historical fallbacks
- treats an empty current-name string as absent so a populated historical value can still be used
- adds current-only, legacy-only, dual-emission, conflict, and exporter precedence coverage

### Stack

Native GitHub stack 3 of 3:

1. #877 — deployment environment
2. #878 — DB system
3. **#879 — remaining collector families**

### Related Issues

- Backend companion: SigNoz/signoz#12447
- Depends on #878

### Resource Impact

**Will this change affect the application's resource usage?**

- [ ] Yes
- [x] No

All resolution uses short, fixed alias lists. No extra queries, telemetry copies, or unbounded scans are introduced.

### Testing

- `go test ./processor/signozspanmetricsprocessor`
- `go test ./cmd/signozschemamigrator/schema_migrator`
- `go test ./exporter/clickhousetracesexporter -count=1`