### PR TITLE
Added local address configuration, otlp_json support and TLS certificate reload support in signozkafkareceiver

### DIFF
--- a/internal/kafka/authentication_test.go
+++ b/internal/kafka/authentication_test.go
@@ -5,8 +5,19 @@ package kafka
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
@@ -153,4 +164,92 @@ func TestAuthentication(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTLSCertificateReload(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+
+	// Generate and write the initial certificate.
+	cert1 := generateSelfSignedCert(t, "initial")
+	writeCertAndKey(t, certFile, keyFile, cert1)
+
+	tlsConfig := configtls.ClientConfig{
+		Config: configtls.Config{
+			CertFile:       certFile,
+			KeyFile:        keyFile,
+			ReloadInterval: 100 * time.Millisecond,
+		},
+		InsecureSkipVerify: true,
+	}
+
+	saramaCfg := &sarama.Config{}
+	err := configureTLS(tlsConfig, saramaCfg)
+	require.NoError(t, err)
+	require.NotNil(t, saramaCfg.Net.TLS.Config)
+
+	// Verify the initial certificate is served.
+	getCert := saramaCfg.Net.TLS.Config.GetClientCertificate
+	require.NotNil(t, getCert, "GetClientCertificate should be set when ReloadInterval is configured")
+
+	initial, err := getCert(&tls.CertificateRequestInfo{})
+	require.NoError(t, err)
+	initialLeaf, err := x509.ParseCertificate(initial.Certificate[0])
+	require.NoError(t, err)
+	assert.Equal(t, "initial", initialLeaf.Subject.CommonName)
+
+	// Replace cert files with a new certificate.
+	cert2 := generateSelfSignedCert(t, "reloaded")
+	writeCertAndKey(t, certFile, keyFile, cert2)
+
+	// Wait for the reload interval to trigger.
+	assert.Eventually(t, func() bool {
+		reloaded, err := getCert(&tls.CertificateRequestInfo{})
+		if err != nil {
+			return false
+		}
+		leaf, err := x509.ParseCertificate(reloaded.Certificate[0])
+		if err != nil {
+			return false
+		}
+		return leaf.Subject.CommonName == "reloaded"
+	}, 2*time.Second, 50*time.Millisecond, "certificate should be reloaded from disk")
+}
+
+type selfSignedCert struct {
+	certPEM []byte
+	keyPEM  []byte
+}
+
+func generateSelfSignedCert(t *testing.T, cn string) selfSignedCert {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return selfSignedCert{certPEM: certPEM, keyPEM: keyPEM}
+}
+
+func writeCertAndKey(t *testing.T, certFile, keyFile string, cert selfSignedCert) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(certFile, cert.certPEM, 0600))
+	require.NoError(t, os.WriteFile(keyFile, cert.keyPEM, 0600))
 }

--- a/receiver/signozkafkareceiver/config.go
+++ b/receiver/signozkafkareceiver/config.go
@@ -56,6 +56,12 @@ type Config struct {
 	GroupID string `mapstructure:"group_id"`
 	// The consumer client ID that receiver will use (default "otel-collector")
 	ClientID string `mapstructure:"client_id"`
+	// LocalAddress is the local IP address (or IP:port) that the client should
+	// bind to (i.e. use as the source address) when connecting to the Kafka
+	// brokers. This is useful on multi-homed hosts where a specific interface
+	// must be used to reach the Kafka cluster. If empty, the OS selects the
+	// source address. Example: "10.0.0.5" or "10.0.0.5:0".
+	LocalAddress string `mapstructure:"local_address"`
 	// The initial offset to use if no offset was previously committed.
 	// Must be `latest` or `earliest` (default "latest").
 	InitialOffset string `mapstructure:"initial_offset"`

--- a/receiver/signozkafkareceiver/config_test.go
+++ b/receiver/signozkafkareceiver/config_test.go
@@ -42,9 +42,10 @@ func TestLoadConfig(t *testing.T) {
 				Authentication: kafka.Authentication{
 					TLS: &configtls.ClientConfig{
 						Config: configtls.Config{
-							CAFile:   "ca.pem",
-							CertFile: "cert.pem",
-							KeyFile:  "key.pem",
+							CAFile:         "ca.pem",
+							CertFile:       "cert.pem",
+							KeyFile:        "key.pem",
+							ReloadInterval: 24 * time.Hour,
 						},
 					},
 				},

--- a/receiver/signozkafkareceiver/kafka_receiver.go
+++ b/receiver/signozkafkareceiver/kafka_receiver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +32,7 @@ const (
 
 var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
 var errInvalidInitialOffset = fmt.Errorf("invalid initial offset")
+var errInvalidLocalAddress = fmt.Errorf("invalid local_address")
 
 // errHighMemoryUsage is a sentinel error for high memory usage
 var errHighMemoryUsage = errors.New("data refused due to high memory usage")
@@ -101,6 +103,9 @@ func newTracesReceiver(config Config, set receiver.Settings, unmarshalers map[st
 	if initialOffset, err := toSaramaInitialOffset(config.InitialOffset); err == nil {
 		c.Consumer.Offsets.Initial = initialOffset
 	} else {
+		return nil, err
+	}
+	if err := setSaramaLocalAddr(c, config.LocalAddress); err != nil {
 		return nil, err
 	}
 	if config.ProtocolVersion != "" {
@@ -216,6 +221,9 @@ func newMetricsReceiver(config Config, set receiver.Settings, unmarshalers map[s
 	} else {
 		return nil, err
 	}
+	if err := setSaramaLocalAddr(c, config.LocalAddress); err != nil {
+		return nil, err
+	}
 	if config.ProtocolVersion != "" {
 		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
 		if err != nil {
@@ -326,6 +334,9 @@ func newLogsReceiver(config Config, set receiver.Settings, unmarshalers map[stri
 	}
 	unmarshaler, err := getLogsUnmarshaler(config.Encoding, unmarshalers)
 	if err != nil {
+		return nil, err
+	}
+	if err = setSaramaLocalAddr(c, config.LocalAddress); err != nil {
 		return nil, err
 	}
 	if config.ProtocolVersion != "" {
@@ -893,4 +904,25 @@ func setSaramaConsumerConfig(sc *sarama.Config, c *SaramaConsumerConfig) *sarama
 		sc.ChannelBufferSize = c.MessagesChannelSize
 	}
 	return sc
+}
+
+// setSaramaLocalAddr configures the local (source) address that sarama will
+// bind to when dialing the Kafka brokers. The value may be a bare IP address
+// (e.g. "10.0.0.5") or an IP:port pair (e.g. "10.0.0.5:0"). When empty, the
+// sarama default is left untouched and the OS chooses the source address.
+func setSaramaLocalAddr(sc *sarama.Config, localAddress string) error {
+	if localAddress == "" {
+		return nil
+	}
+	host, port, err := net.SplitHostPort(localAddress)
+	if err != nil {
+		host = localAddress
+		port = "0"
+	}
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return fmt.Errorf("%w: %v", errInvalidLocalAddress, err)
+	}
+	sc.Net.LocalAddr = addr
+	return nil
 }

--- a/receiver/signozkafkareceiver/kafka_receiver_test.go
+++ b/receiver/signozkafkareceiver/kafka_receiver_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -84,6 +85,102 @@ func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
+}
+
+func TestNewTracesReceiver_local_address_err(t *testing.T) {
+	c := Config{
+		Encoding:     defaultEncoding,
+		LocalAddress: "not a valid address",
+	}
+	r, err := newTracesReceiver(c, receivertest.NewNopSettings(metadata.Type), defaultTracesUnmarshalers(), consumertest.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.ErrorIs(t, err, errInvalidLocalAddress)
+}
+
+func TestNewMetricsReceiver_local_address_err(t *testing.T) {
+	c := Config{
+		Encoding:     defaultEncoding,
+		LocalAddress: "not a valid address",
+	}
+	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(metadata.Type), defaultMetricsUnmarshalers(), consumertest.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.ErrorIs(t, err, errInvalidLocalAddress)
+}
+
+func TestNewLogsReceiver_local_address_err(t *testing.T) {
+	c := Config{
+		Encoding:     defaultEncoding,
+		LocalAddress: "not a valid address",
+	}
+	r, err := newLogsReceiver(c, receivertest.NewNopSettings(metadata.Type), defaultLogsUnmarshalers(), consumertest.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.ErrorIs(t, err, errInvalidLocalAddress)
+}
+
+func TestSetSaramaLocalAddr(t *testing.T) {
+	tests := []struct {
+		name         string
+		localAddress string
+		wantErr      bool
+		wantSet      bool
+		wantIP       string
+		wantPort     int
+	}{
+		{
+			name:         "empty leaves LocalAddr unset",
+			localAddress: "",
+			wantErr:      false,
+			wantSet:      false,
+		},
+		{
+			name:         "bare IP defaults port to 0",
+			localAddress: "127.0.0.1",
+			wantErr:      false,
+			wantSet:      true,
+			wantIP:       "127.0.0.1",
+			wantPort:     0,
+		},
+		{
+			name:         "IP with explicit port",
+			localAddress: "127.0.0.1:12345",
+			wantErr:      false,
+			wantSet:      true,
+			wantIP:       "127.0.0.1",
+			wantPort:     12345,
+		},
+		{
+			name:         "invalid address returns error",
+			localAddress: "not a valid address",
+			wantErr:      true,
+			wantSet:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := sarama.NewConfig()
+			err := setSaramaLocalAddr(sc, tt.localAddress)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errInvalidLocalAddress)
+				assert.Nil(t, sc.Net.LocalAddr)
+				return
+			}
+			require.NoError(t, err)
+			if !tt.wantSet {
+				assert.Nil(t, sc.Net.LocalAddr)
+				return
+			}
+			require.NotNil(t, sc.Net.LocalAddr)
+			tcpAddr, ok := sc.Net.LocalAddr.(*net.TCPAddr)
+			require.True(t, ok, "expected *net.TCPAddr, got %T", sc.Net.LocalAddr)
+			assert.Equal(t, tt.wantIP, tcpAddr.IP.String())
+			assert.Equal(t, tt.wantPort, tcpAddr.Port)
+		})
+	}
 }
 
 func TestTracesReceiverStart(t *testing.T) {

--- a/receiver/signozkafkareceiver/testdata/config.yaml
+++ b/receiver/signozkafkareceiver/testdata/config.yaml
@@ -10,6 +10,7 @@ signozkafkareceiver:
       ca_file: ca.pem
       cert_file: cert.pem
       key_file: key.pem
+      reload_interval: 24h
   metadata:
     retry:
       max: 10

--- a/receiver/signozkafkareceiver/unmarshaler.go
+++ b/receiver/signozkafkareceiver/unmarshaler.go
@@ -49,6 +49,7 @@ type LogsUnmarshalerWithEnc interface {
 // defaultTracesUnmarshalers returns map of supported encodings with TracesUnmarshaler.
 func defaultTracesUnmarshalers() map[string]TracesUnmarshaler {
 	otlpPb := newPdataTracesUnmarshaler(&ptrace.ProtoUnmarshaler{}, defaultEncoding)
+	otlpJSON := newPdataTracesUnmarshaler(&ptrace.JSONUnmarshaler{}, "otlp_json")
 	jaegerProto := jaegerProtoSpanUnmarshaler{}
 	jaegerJSON := jaegerJSONSpanUnmarshaler{}
 	zipkinProto := newPdataTracesUnmarshaler(zipkinv2.NewProtobufTracesUnmarshaler(false, false), "zipkin_proto")
@@ -56,6 +57,7 @@ func defaultTracesUnmarshalers() map[string]TracesUnmarshaler {
 	zipkinThrift := newPdataTracesUnmarshaler(zipkinv1.NewThriftTracesUnmarshaler(), "zipkin_thrift")
 	return map[string]TracesUnmarshaler{
 		otlpPb.Encoding():       otlpPb,
+		otlpJSON.Encoding():     otlpJSON,
 		jaegerProto.Encoding():  jaegerProto,
 		jaegerJSON.Encoding():   jaegerJSON,
 		zipkinProto.Encoding():  zipkinProto,
@@ -66,18 +68,22 @@ func defaultTracesUnmarshalers() map[string]TracesUnmarshaler {
 
 func defaultMetricsUnmarshalers() map[string]MetricsUnmarshaler {
 	otlpPb := newPdataMetricsUnmarshaler(&pmetric.ProtoUnmarshaler{}, defaultEncoding)
+	otlpJSON := newPdataMetricsUnmarshaler(&pmetric.JSONUnmarshaler{}, "otlp_json")
 	return map[string]MetricsUnmarshaler{
-		otlpPb.Encoding(): otlpPb,
+		otlpPb.Encoding():   otlpPb,
+		otlpJSON.Encoding(): otlpJSON,
 	}
 }
 
 func defaultLogsUnmarshalers() map[string]LogsUnmarshaler {
 	otlpPb := NewPdataLogsUnmarshaler(&plog.ProtoUnmarshaler{}, defaultEncoding)
+	otlpJSON := NewPdataLogsUnmarshaler(&plog.JSONUnmarshaler{}, "otlp_json")
 	raw := newRawLogsUnmarshaler()
 	text := newTextLogsUnmarshaler()
 	return map[string]LogsUnmarshaler{
-		otlpPb.Encoding(): otlpPb,
-		raw.Encoding():    raw,
-		text.Encoding():   text,
+		otlpPb.Encoding():   otlpPb,
+		otlpJSON.Encoding(): otlpJSON,
+		raw.Encoding():      raw,
+		text.Encoding():     text,
 	}
 }

--- a/receiver/signozkafkareceiver/unmarshaler_test.go
+++ b/receiver/signozkafkareceiver/unmarshaler_test.go
@@ -13,6 +13,7 @@ import (
 func TestDefaultTracesUnMarshaler(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",
+		"otlp_json",
 		"jaeger_proto",
 		"jaeger_json",
 		"zipkin_proto",
@@ -33,6 +34,7 @@ func TestDefaultTracesUnMarshaler(t *testing.T) {
 func TestDefaultMetricsUnMarshaler(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",
+		"otlp_json",
 	}
 	marshalers := defaultMetricsUnmarshalers()
 	assert.Equal(t, len(expectedEncodings), len(marshalers))
@@ -48,6 +50,7 @@ func TestDefaultMetricsUnMarshaler(t *testing.T) {
 func TestDefaultLogsUnMarshaler(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",
+		"otlp_json",
 		"raw",
 		"text",
 	}


### PR DESCRIPTION
## Summary

This PR adds three enhancements to the `signozkafkareceiver`:

1. **Local address configuration** — allows binding the Kafka client to a specific local network address (source IP) when establishing broker connections.
2. **`otlp_json` encoding support** — adds a new unmarshaler so the receiver can decode OTLP payloads serialized as JSON, in addition to the existing `otlp_proto`.
3. **TLS certificate hot-reload** — the receiver now reloads TLS client certificates from disk without requiring a restart, so rotated certs are picked up automatically.