### PR TITLE
feat(log-attr-json): store log attributes as json

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -548,5 +548,68 @@ ORDER BY name ASC`,
 			},
 		},
 	},
-	// Next migration id will be 2003
+	{
+		// object_serialization_version / object_shared_data_serialization_version are already
+		// set on logs_v2 by migration 2001, so they are not re-applied here.
+		MigrationID: 2003,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column: Column{
+					Name:  constants.AttributesColumn,
+					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer[uint](0)},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes_bool"},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column: Column{
+					Name:  constants.AttributesColumn,
+					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer[uint](0)},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes_bool"},
+			},
+		},
+		DownItems: []Operation{
+			// drop from the distributed table first, otherwise distributed_logs_v2 is
+			// left referencing a column that no longer exists on logs_v2
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column:   Column{Name: constants.AttributesColumn},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column:   Column{Name: constants.AttributesColumn},
+			},
+		},
+	},
+	{
+		MigrationID: 2004,
+		UpItems: []Operation{
+			AlterTableAddIndex{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Index: Index{
+					Name:        "attributes_paths_tokenbf",
+					Expression:  JSONPathsIndexExpr(constants.AttributesColumn),
+					Type:        "tokenbf_v1(1024, 2, 0)",
+					Granularity: 1,
+				},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropIndex{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Index:    Index{Name: "attributes_paths_tokenbf"},
+			},
+		},
+	},
+	// Next migration id will be 2005
 }

--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -549,15 +549,13 @@ ORDER BY name ASC`,
 		},
 	},
 	{
-		// object_serialization_version / object_shared_data_serialization_version are already
-		// set on logs_v2 by migration 2001, so they are not re-applied here.
 		MigrationID: 2003,
 		UpItems: []Operation{
 			AlterTableAddColumn{
 				Database: "signoz_logs",
 				Table:    "logs_v2",
 				Column: Column{
-					Name:  constants.AttributesColumn,
+					Name:  "attributes",
 					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer[uint](0)},
 					Codec: "ZSTD(1)",
 				},
@@ -567,7 +565,7 @@ ORDER BY name ASC`,
 				Database: "signoz_logs",
 				Table:    "distributed_logs_v2",
 				Column: Column{
-					Name:  constants.AttributesColumn,
+					Name:  "attributes",
 					Type:  JSONColumnType{MaxDynamicPaths: utils.ToPointer[uint](0)},
 					Codec: "ZSTD(1)",
 				},
@@ -580,12 +578,12 @@ ORDER BY name ASC`,
 			AlterTableDropColumn{
 				Database: "signoz_logs",
 				Table:    "distributed_logs_v2",
-				Column:   Column{Name: constants.AttributesColumn},
+				Column:   Column{Name: "attributes"},
 			},
 			AlterTableDropColumn{
 				Database: "signoz_logs",
 				Table:    "logs_v2",
-				Column:   Column{Name: constants.AttributesColumn},
+				Column:   Column{Name: "attributes"},
 			},
 		},
 	},
@@ -597,7 +595,7 @@ ORDER BY name ASC`,
 				Table:    "logs_v2",
 				Index: Index{
 					Name:        "attributes_paths_tokenbf",
-					Expression:  JSONPathsIndexExpr(constants.AttributesColumn),
+					Expression:  JSONPathsIndexExpr("attributes"),
 					Type:        "tokenbf_v1(1024, 2, 0)",
 					Granularity: 1,
 				},
@@ -611,5 +609,4 @@ ORDER BY name ASC`,
 			},
 		},
 	},
-	// Next migration id will be 2005
 }

--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
@@ -2,8 +2,32 @@ package schemamigrator
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
+
+// defaultPromotedTraceAttributes are the span attributes promoted into the
+// attributes_promoted JSON column by default. They match the keys that were
+// materialized from the attributes map before traces moved to JSON storage.
+var defaultPromotedTraceAttributes = []string{
+	"http.route",
+	"messaging.system",
+	"messaging.operation",
+	"db.system",
+	"rpc.system",
+	"rpc.service",
+	"rpc.method",
+	"peer.service",
+}
+
+func promotedTraceAttributeSeedValues() string {
+	releaseTime := time.Now().UnixNano()
+	tuples := make([]string, 0, len(defaultPromotedTraceAttributes))
+	for _, name := range defaultPromotedTraceAttributes {
+		tuples = append(tuples, fmt.Sprintf("('traces', 'attributes_promoted', 'JSON', 'attribute', '%s', 0, %d)", name, releaseTime))
+	}
+	return strings.Join(tuples, ", ")
+}
 
 var MetadataMigrations = []SchemaMigrationRecord{
 	{
@@ -150,5 +174,19 @@ var MetadataMigrations = []SchemaMigrationRecord{
 				Table:    "column_evolution_metadata",
 			},
 		},
+	},
+	{
+		MigrationID: 1002,
+		UpItems: []Operation{
+			InsertIntoTable{
+				Database:    "signoz_metadata",
+				Table:       "distributed_column_evolution_metadata",
+				LightWeight: true,
+				Synchronous: true,
+				Columns:     []string{"signal", "column_name", "column_type", "field_context", "field_name", "version", "release_time"},
+				Values:      promotedTraceAttributeSeedValues(),
+			},
+		},
+		DownItems: []Operation{},
 	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
@@ -17,6 +17,7 @@ func TestMetadataMigrationsExactNature(t *testing.T) {
 		[]SchemaMigrationRecord{
 			MetadataMigrations[0],
 			MetadataMigrations[1],
+			MetadataMigrations[2],
 		},
 		[]SchemaMigrationRecord{},
 	)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -5,6 +5,7 @@ const (
 	BodyV2ColumnPrefix       = "body_v2."
 	BodyPromotedColumn       = "body_promoted"
 	BodyPromotedColumnPrefix = "body_promoted."
+	AttributesColumn         = "attributes"
 
 	SignozMetadataDB             = "signoz_metadata"
 	DistTableColumnEvolution     = SignozMetadataDB + ".distributed_column_evolution_metadata"

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -5,7 +5,7 @@ const (
 	BodyV2ColumnPrefix       = "body_v2."
 	BodyPromotedColumn       = "body_promoted"
 	BodyPromotedColumnPrefix = "body_promoted."
-	AttributesColumn         = "attributes"
+	LogsAttributesColumn     = "attributes"
 
 	SignozMetadataDB             = "signoz_metadata"
 	DistTableColumnEvolution     = SignozMetadataDB + ".distributed_column_evolution_metadata"

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -85,6 +85,7 @@ const (
 		attributes_string,
 		attributes_number,
 		attributes_bool,
+		attributes,
 		resources_string,
 		resource,
 		scope_name,
@@ -92,6 +93,7 @@ const (
 		scope_string,
 		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -130,6 +132,7 @@ const (
 		attributes_string,
 		attributes_number,
 		attributes_bool,
+		attributes,
 		resources_string,
 		resource,
 		scope_name,
@@ -137,6 +140,7 @@ const (
 		scope_string,
 		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -192,6 +196,7 @@ type Record struct {
 	body             string
 	bodyJSON         string
 	bodyJSONPromoted string
+	attributesJSON   string
 	scopeName        string
 	scopeVersion     string
 	// attribute/tag maps to be appended by the single consumer
@@ -631,6 +636,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 					rec.attrsMap.StringData,
 					rec.attrsMap.NumberData,
 					rec.attrsMap.BoolData,
+					rec.attributesJSON,
 					rec.resourceMap.StringData,
 					rec.resourceMap.StringData,
 					rec.scopeName,
@@ -720,6 +726,8 @@ producerIteration:
 					// record size calculation
 					attrBytes, _ := json.Marshal(record.Attributes().AsRaw())
 
+					attributesJSON := e.getAttributesJSON(record.Attributes(), id.String())
+
 					body, bodyJSON, promoted := e.processBody(groupCtx, record.Body())
 					recordStream <- &Record{
 						tsBucketStart:    uint64(lBucketStart),
@@ -735,6 +743,7 @@ producerIteration:
 						body:             body,
 						bodyJSON:         bodyJSON,
 						bodyJSONPromoted: promoted,
+						attributesJSON:   attributesJSON,
 						scopeName:        scopeName,
 						scopeVersion:     scopeVersion,
 						resourceMap:      resourcesMap,
@@ -881,6 +890,51 @@ func getStringifiedBody(body pcommon.Value) string {
 		strBody = body.AsString()
 	}
 	return strBody
+}
+
+// getAttributesJSON serializes log attributes to a JSON string for the native ClickHouse
+// JSON column, which parses it server-side. A marshal failure is logged and falls back to
+// an empty object rather than failing the batch.
+func (e *clickhouseLogsExporter) getAttributesJSON(attrs pcommon.Map, logID string) string {
+	raw := attrs.AsRaw()
+	b, err := json.Marshal(raw)
+	if err != nil {
+		// NaN/Inf doubles break json.Marshal for the whole map; sanitize lazily and retry.
+		sanitizeJSONFloats(raw)
+		b, err = json.Marshal(raw)
+	}
+	if err != nil {
+		e.logger.Warn("failed to marshal log attributes to json, storing empty object",
+			zap.Error(err),
+			zap.String("log_id", logID),
+		)
+		return "{}"
+	}
+	return string(b)
+}
+
+// sanitizeJSONFloats replaces NaN/Inf float64 values (recursively, in place) with nil so
+// json.Marshal does not reject the whole value.
+func sanitizeJSONFloats(v any) any {
+	switch val := v.(type) {
+	case float64:
+		if utils.IsValidFloat(val) {
+			return val
+		}
+		return nil
+	case map[string]any:
+		for k, vv := range val {
+			val[k] = sanitizeJSONFloats(vv)
+		}
+		return val
+	case []any:
+		for i, vv := range val {
+			val[i] = sanitizeJSONFloats(vv)
+		}
+		return val
+	default:
+		return v
+	}
 }
 
 func (e *clickhouseLogsExporter) addAttrsToAttributeKeysStatement(

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -900,7 +900,7 @@ func (e *clickhouseLogsExporter) getAttributesJSON(attrs pcommon.Map, logID stri
 	b, err := json.Marshal(raw)
 	if err != nil {
 		// NaN/Inf doubles break json.Marshal for the whole map; sanitize lazily and retry.
-		sanitizeJSONFloats(raw)
+		utils.SanitizeJSONFloats(raw)
 		b, err = json.Marshal(raw)
 	}
 	if err != nil {
@@ -911,30 +911,6 @@ func (e *clickhouseLogsExporter) getAttributesJSON(attrs pcommon.Map, logID stri
 		return "{}"
 	}
 	return string(b)
-}
-
-// sanitizeJSONFloats replaces NaN/Inf float64 values (recursively, in place) with nil so
-// json.Marshal does not reject the whole value.
-func sanitizeJSONFloats(v any) any {
-	switch val := v.(type) {
-	case float64:
-		if utils.IsValidFloat(val) {
-			return val
-		}
-		return nil
-	case map[string]any:
-		for k, vv := range val {
-			val[k] = sanitizeJSONFloats(vv)
-		}
-		return val
-	case []any:
-		for i, vv := range val {
-			val[i] = sanitizeJSONFloats(vv)
-		}
-		return val
-	default:
-		return v
-	}
 }
 
 func (e *clickhouseLogsExporter) addAttrsToAttributeKeysStatement(

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -178,7 +178,7 @@ func getAttributesJSON(attrs pcommon.Map, traceID pcommon.TraceID, spanID pcommo
 	b, err := json.Marshal(raw)
 	if err != nil {
 		// handling NaN/Inf double, which breaks encoding/json marshal, failing the whole map.
-		sanitizeJSONFloats(raw)
+		utils.SanitizeJSONFloats(raw)
 		b, err = json.Marshal(raw)
 	}
 	if err != nil {
@@ -190,30 +190,6 @@ func getAttributesJSON(attrs pcommon.Map, traceID pcommon.TraceID, spanID pcommo
 		return "{}"
 	}
 	return string(b)
-}
-
-// sanitizeJSONFloats hanldes NaN/Inf float64 values, encoding/json errors out
-// for these values, so a single malformed double attribute could not fail the whole span.
-func sanitizeJSONFloats(v any) any {
-	switch val := v.(type) {
-	case float64:
-		if utils.IsValidFloat(val) {
-			return val
-		}
-		return nil
-	case map[string]any:
-		for k, vv := range val {
-			val[k] = sanitizeJSONFloats(vv)
-		}
-		return val
-	case []any:
-		for i, vv := range val {
-			val[i] = sanitizeJSONFloats(vv)
-		}
-		return val
-	default:
-		return v
-	}
 }
 
 type attributesData struct {

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
@@ -1010,7 +1010,7 @@ func Test_getAttributesJSON(t *testing.T) {
 			want: map[string]any{"mixed_slice": []any{[]any{"a"}, "oops"}},
 		},
 		{
-			// The exhaustive NaN/Inf/nesting matrix lives in Test_sanitizeJSONFloats.
+			// The exhaustive NaN/Inf/nesting matrix lives in utils.TestSanitizeJSONFloats.
 			name: "NaN double is sanitized to null, siblings preserved",
 			attrs: makeMap(func(m pcommon.Map) {
 				m.PutDouble("nan", math.NaN())
@@ -1026,58 +1026,6 @@ func Test_getAttributesJSON(t *testing.T) {
 
 			var got map[string]any
 			require.NoError(t, json.Unmarshal([]byte(gotJSON), &got))
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func Test_sanitizeJSONFloats(t *testing.T) {
-	tests := []struct {
-		name string
-		in   any
-		want any
-	}{
-		{name: "valid float unchanged", in: 3.14, want: 3.14},
-		{name: "NaN becomes nil", in: math.NaN(), want: nil},
-		{name: "+Inf becomes nil", in: math.Inf(1), want: nil},
-		{name: "-Inf becomes nil", in: math.Inf(-1), want: nil},
-		{name: "non-float scalar untouched", in: "hello", want: "hello"},
-		{
-			name: "map with mixed valid/invalid floats",
-			in: map[string]any{
-				"good": 1.0,
-				"bad":  math.NaN(),
-				"str":  "x",
-			},
-			want: map[string]any{
-				"good": 1.0,
-				"bad":  nil,
-				"str":  "x",
-			},
-		},
-		{
-			name: "slice with mixed valid/invalid floats",
-			in:   []any{1.0, math.NaN(), "x"},
-			want: []any{1.0, nil, "x"},
-		},
-		{
-			name: "deeply nested slice-of-map-of-slice",
-			in: []any{
-				map[string]any{
-					"scores": []any{math.Inf(-1), 2.0},
-				},
-			},
-			want: []any{
-				map[string]any{
-					"scores": []any{nil, 2.0},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeJSONFloats(tt.in)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/utils/json.go
+++ b/utils/json.go
@@ -1,0 +1,25 @@
+package utils
+
+// SanitizeJSONFloats replaces NaN/Inf float64 values (recursively, in place) with nil so
+// json.Marshal does not reject the whole value.
+func SanitizeJSONFloats(v any) any {
+	switch val := v.(type) {
+	case float64:
+		if IsValidFloat(val) {
+			return val
+		}
+		return nil
+	case map[string]any:
+		for k, vv := range val {
+			val[k] = SanitizeJSONFloats(vv)
+		}
+		return val
+	case []any:
+		for i, vv := range val {
+			val[i] = SanitizeJSONFloats(vv)
+		}
+		return val
+	default:
+		return v
+	}
+}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeJSONFloats(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{name: "valid float unchanged", in: 3.14, want: 3.14},
+		{name: "NaN becomes nil", in: math.NaN(), want: nil},
+		{name: "+Inf becomes nil", in: math.Inf(1), want: nil},
+		{name: "-Inf becomes nil", in: math.Inf(-1), want: nil},
+		{name: "non-float scalar untouched", in: "hello", want: "hello"},
+		{
+			name: "map with mixed valid/invalid floats",
+			in: map[string]any{
+				"good": 1.0,
+				"bad":  math.NaN(),
+				"str":  "x",
+			},
+			want: map[string]any{
+				"good": 1.0,
+				"bad":  nil,
+				"str":  "x",
+			},
+		},
+		{
+			name: "slice with mixed valid/invalid floats",
+			in:   []any{1.0, math.NaN(), "x"},
+			want: []any{1.0, nil, "x"},
+		},
+		{
+			name: "deeply nested slice-of-map-of-slice",
+			in: []any{
+				map[string]any{
+					"scores": []any{math.Inf(-1), 2.0},
+				},
+			},
+			want: []any{
+				map[string]any{
+					"scores": []any{nil, 2.0},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeJSONFloats(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Pull Request

### Summary
Store log attributes as a native ClickHouse JSON column, alongside the existing `attributes_string/number/bool` map columns. The logs counterpart of #850, based on `ns/trace-json`.

### Related Issues
Follows #850

### Resource Impact
**Will this change affect the application's resource usage?**
- [x] Yes
- [ ] No

If **Yes**, describe:
- **Resources impacted:** Disk (extra JSON column + skip index), minor CPU (one JSON serialization per record).
- **Expected change:** Comparable to the traces change in #850. Billed record size is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)