### PR TITLE
fix(clickhouselogsexporter): wrap non-map log bodies instead of failing the batch

### DIFF
--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -59,6 +59,7 @@ const (
 	distributedLogsResourceKeys      = "distributed_logs_resource_keys"
 	distributedColumnEvolutionTable  = constants.SignozMetadataDB + ".distributed_column_evolution_metadata"
 	distributedLogsResourceV2Seconds = 1800
+	bodyNonMapKey                    = "message"
 	// language=ClickHouse SQL
 	insertLogsResourceSQLTemplate = `INSERT INTO %s.%s (
 		labels,
@@ -299,6 +300,7 @@ type clickhouseLogsExporter struct {
 	closeChan chan struct{}
 
 	durationHistogram metric.Float64Histogram
+	nonMapBodyCounter metric.Int64Counter
 
 	keysCache *ttlcache.Cache[string, struct{}]
 	rfCache   *ttlcache.Cache[string, struct{}]
@@ -718,10 +720,7 @@ producerIteration:
 					// record size calculation
 					attrBytes, _ := json.Marshal(record.Attributes().AsRaw())
 
-					body, bodyJSON, promoted, err := e.processBody(record.Body())
-					if err != nil {
-						return err
-					}
+					body, bodyJSON, promoted := e.processBody(groupCtx, record.Body())
 					recordStream <- &Record{
 						tsBucketStart:    uint64(lBucketStart),
 						resourceFP:       fp,
@@ -837,29 +836,29 @@ producerIteration:
 	return nil
 }
 
-func (e *clickhouseLogsExporter) processBody(body pcommon.Value) (string, string, string, error) {
+func (e *clickhouseLogsExporter) processBody(ctx context.Context, body pcommon.Value) (string, string, string) {
 	promoted := pcommon.NewValueMap()
 	bodyJSON := pcommon.NewValueMap()
 	if e.bodyJSONEnabled {
 		if body.Type() == pcommon.ValueTypeMap {
-			// promoted paths extraction using cached set
-			promotedSet := e.promotedPaths.Load().(map[string]struct{})
-
-			// set values to promoted and bodyJSON
-			promoted = buildPromoted(body, promotedSet)
 			// switch the reference to bodyJSON
 			bodyJSON = body
-
-			if !e.bodyJSONOldBodyEnabled {
-				// set body to empty string
-				body = pcommon.NewValueEmpty()
-			}
 		} else {
-			return "", "", "", fmt.Errorf("body expected to be map, found %s", body.Type().String())
+			bodyJSON.Map().PutStr(bodyNonMapKey, getStringifiedBody(body))
+			e.nonMapBodyCounter.Add(ctx, 1)
+		}
+
+		// promoted paths extraction using cached set
+		promotedSet := e.promotedPaths.Load().(map[string]struct{})
+		promoted = buildPromoted(bodyJSON, promotedSet)
+
+		if !e.bodyJSONOldBodyEnabled {
+			// set body to empty string
+			body = pcommon.NewValueEmpty()
 		}
 	}
 
-	return getStringifiedBody(body), getStringifiedBody(bodyJSON), getStringifiedBody(promoted), nil
+	return getStringifiedBody(body), getStringifiedBody(bodyJSON), getStringifiedBody(promoted)
 }
 
 func send(statement driver.Batch, tableName string, durationCh chan<- statementSendDuration, chErr chan<- error, wg *sync.WaitGroup) {

--- a/exporter/clickhouselogsexporter/exporter_test.go
+++ b/exporter/clickhouselogsexporter/exporter_test.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap"
 
 	"github.com/SigNoz/signoz-otel-collector/exporter/clickhouselogsexporter/internal/metadata"
@@ -324,7 +326,6 @@ func TestProcessBody(t *testing.T) {
 		bodyJSONOldBodyEnabled bool
 		promotedPaths          map[string]struct{}
 		body                   func() pcommon.Value
-		expectedError          bool
 		expectedBody           string
 		expectedBodyJSON       string
 		expectedPromoted       string
@@ -357,7 +358,7 @@ func TestProcessBody(t *testing.T) {
 			expectedPromoted: "{}",
 		},
 		{
-			name:                   "bodyJSONEnabled_true_non_map_body",
+			name:                   "bodyJSONEnabled_true_string_body",
 			bodyJSONEnabled:        true,
 			bodyJSONOldBodyEnabled: false,
 			promotedPaths:          map[string]struct{}{},
@@ -365,8 +366,80 @@ func TestProcessBody(t *testing.T) {
 				v := pcommon.NewValueStr("test log message")
 				return v
 			},
-			expectedBody:  "test log message",
-			expectedError: true,
+			expectedBody:     "",
+			expectedBodyJSON: `{"message":"test log message"}`,
+			expectedPromoted: "{}",
+		},
+		{
+			name:                   "bodyJSONEnabled_true_string_body_old_body_enabled",
+			bodyJSONEnabled:        true,
+			bodyJSONOldBodyEnabled: true,
+			promotedPaths: map[string]struct{}{
+				"message": {},
+			},
+			body: func() pcommon.Value {
+				v := pcommon.NewValueStr("test log message")
+				return v
+			},
+			expectedBody:     "test log message",
+			expectedBodyJSON: `{"message":"test log message"}`,
+			expectedPromoted: `{"message":"test log message"}`,
+		},
+		{
+			name:                   "bodyJSONEnabled_true_int_body",
+			bodyJSONEnabled:        true,
+			bodyJSONOldBodyEnabled: true,
+			promotedPaths: map[string]struct{}{
+				"message": {},
+			},
+			body: func() pcommon.Value {
+				v := pcommon.NewValueInt(42)
+				return v
+			},
+			expectedBody:     "42",
+			expectedBodyJSON: `{"message":"42"}`,
+			expectedPromoted: `{"message":"42"}`,
+		},
+		{
+			name:                   "bodyJSONEnabled_true_slice_body",
+			bodyJSONEnabled:        true,
+			bodyJSONOldBodyEnabled: false,
+			promotedPaths:          map[string]struct{}{},
+			body: func() pcommon.Value {
+				v := pcommon.NewValueSlice()
+				v.Slice().AppendEmpty().SetStr("a")
+				v.Slice().AppendEmpty().SetInt(1)
+				return v
+			},
+			expectedBody:     "",
+			expectedBodyJSON: `{"message":"[\"a\",1]"}`,
+			expectedPromoted: "{}",
+		},
+		{
+			name:                   "bodyJSONEnabled_true_bytes_body",
+			bodyJSONEnabled:        true,
+			bodyJSONOldBodyEnabled: false,
+			promotedPaths:          map[string]struct{}{},
+			body: func() pcommon.Value {
+				v := pcommon.NewValueBytes()
+				v.Bytes().Append([]byte("raw bytes")...)
+				return v
+			},
+			expectedBody:     "",
+			expectedBodyJSON: `{"message":"raw bytes"}`,
+			expectedPromoted: "{}",
+		},
+		{
+			name:                   "bodyJSONEnabled_true_empty_body",
+			bodyJSONEnabled:        true,
+			bodyJSONOldBodyEnabled: false,
+			promotedPaths:          map[string]struct{}{},
+			body: func() pcommon.Value {
+				return pcommon.NewValueEmpty()
+			},
+			expectedBody:     "",
+			expectedBodyJSON: `{"message":""}`,
+			expectedPromoted: "{}",
 		},
 		{
 			name:                   "bodyJSONEnabled_true_map_body_with_promoted_paths",
@@ -487,12 +560,7 @@ func TestProcessBody(t *testing.T) {
 			body := tc.body()
 
 			// Process body
-			bodyStr, bodyJSONStr, promotedStr, err := exporter.processBody(body)
-			if tc.expectedError {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+			bodyStr, bodyJSONStr, promotedStr := exporter.processBody(context.Background(), body)
 
 			err = exporter.Shutdown(context.Background())
 			require.NoError(t, err)
@@ -503,4 +571,64 @@ func TestProcessBody(t *testing.T) {
 			assert.Equal(t, tc.expectedPromoted, promotedStr, "promoted string mismatch")
 		})
 	}
+}
+
+func TestProcessBodyNonMapCounter(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	opts := testOptions(t)
+	opts = append(opts,
+		WithClickHouseClient(nil),
+		WithNewUsageCollector(uuid.New(), nil),
+		WithMeter(provider.Meter(metadata.ScopeName)),
+	)
+
+	exp, err := newExporter(
+		exporter.Settings{},
+		&Config{
+			DSN:                       "clickhouse://localhost:9000/test",
+			BodyJSONEnabled:           true,
+			PromotedPathsSyncInterval: utils.ToPointer(5 * time.Minute),
+			LogLevelConcurrency:       utils.ToPointer(1),
+			AttributesLimits: AttributesLimits{
+				FetchKeysInterval: 2 * time.Second,
+				MaxDistinctValues: 25000,
+			},
+		},
+		opts...,
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mapBody := pcommon.NewValueMap()
+	mapBody.Map().PutStr("message", "already a map")
+
+	exp.processBody(ctx, pcommon.NewValueStr("first"))
+	exp.processBody(ctx, pcommon.NewValueStr("second"))
+	exp.processBody(ctx, pcommon.NewValueInt(42))
+	exp.processBody(ctx, mapBody)
+
+	require.NoError(t, exp.Shutdown(ctx))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	var recorded int64
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "exporter_non_map_body_records" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "expected an int64 sum")
+			require.Len(t, sum.DataPoints, 1)
+			recorded = sum.DataPoints[0].Value
+			found = true
+		}
+	}
+
+	require.True(t, found, "counter was not recorded")
+	assert.Equal(t, int64(3), recorded)
 }

--- a/exporter/clickhouselogsexporter/options.go
+++ b/exporter/clickhouselogsexporter/options.go
@@ -55,6 +55,15 @@ func WithMeter(meter metric.Meter) LogExporterOption {
 			panic(fmt.Errorf("error creating duration histogram: %w", err))
 		}
 		e.durationHistogram = durationHistogram
+
+		nonMapBodyCounter, err := meter.Int64Counter(
+			"exporter_non_map_body_records",
+			metric.WithDescription("Number of log records with a non-map body"),
+		)
+		if err != nil {
+			panic(fmt.Errorf("error creating non map body counter: %w", err))
+		}
+		e.nonMapBodyCounter = nonMapBodyCounter
 	}
 }
 


### PR DESCRIPTION
## Pull Request

### Summary

With `body_json_enabled`, `processBody` returned an error for any log record whose body wasn't a map. That error failed the entire `pushLogsData` call, so **one plain-string record dropped every other record batched with it** — and the retry hit the same record and failed the same way, making the loss permanent.

Non-map bodies are now wrapped as `{"message": <stringified body>}` and written to `body_v2`. Map bodies are untouched.

Why `message`:
- It's the only typed path on the column — `JSON(max_dynamic_paths=0, message String)` — so the value gets a dedicated subcolumn instead of falling into shared data.
- The `normalize` operator already does the same thing (`normalize/transformer.go:45-55`), so the exporter now agrees with the pipeline that usually runs ahead of it instead of inventing a second convention.

`processBody` can no longer fail, so its `error` return is dropped.

Wrapping is silent where the old error was at least noisy, so this also adds a counter — `exporter_non_map_body_records` (Prometheus renders it `..._total`) — to show how much traffic isn't JSON.

### Related Issues
Closes #

### Resource Impact

**Will this change affect the application's resource usage?**
- [x] Yes
- [ ] No

- **Resources impacted:** Disk (ClickHouse)
- **Expected change:** Records that used to be dropped now get written, so stored volume rises by however much non-map traffic a deployment sends. Each wrapped record adds ~14 bytes of envelope. CPU unchanged — same single stringify pass per record.
- **Benchmarks:** Not run. Before/after at a fixed ingestion rate would be comparing "data lost" to "data stored", not the same workload. Happy to measure the envelope overhead if that's useful.

### Testing

Ran both this branch and `origin/main` against a local ClickHouse with a deliberately broken pipeline (`normalize`, then a `move` of `body.message` back onto `body`) — the realistic trigger, since the server prepends `normalize` and it takes a user operator to undo it.

One batch of 3 records, only 1 mangled:

| | `origin/main` | this branch |
|---|---|---|
| `rejected_items` | 3 | — |
| rows in ClickHouse | 0 | 3 |

Also sent all 10 body shapes (string, int, double, bool, slice, bytes, empty, map, plus quote- and newline-heavy strings) straight to the exporter. All inserted cleanly, `body_v2.message` is `String` for every one. Worth checking because `bodyJSON` reaches ClickHouse as a string into a JSON column, so a malformed body would have recreated the same failure one layer down — pdata's encoder sanitizes invalid UTF-8 and control chars, so it can't.

`TestProcessBody` covers string (both `body_json_old_body_enabled` settings), int, slice, bytes and empty. `TestProcessBodyNonMapCounter` asserts the counter moves for non-map bodies and stays put for maps. Confirmed on a running collector too: 3 records in (2 non-map), `exporter_non_map_body_records_total 2` on the telemetry endpoint.

`TestExporterPushLogsData` fails in full-package runs here — an unrelated pre-existing race, fixed in #888. Merge that one first and CI here goes green.

### Follow-ups for reviewers

1. **`metadataexporter` still assumes a map.** `json_writer.go:299` skips non-map bodies, so `body_v2.message` now has data that never gets registered in `distributed_field_keys` — present in the data, missing from autocomplete. Probably wants the same wrapping.
2. **Body search must use the subcolumn.** Measured: `body_v2.message LIKE '%GET /health%'` matches, `toString(body_v2) LIKE '%GET /health%'` doesn't — serializing escapes `/` and `"`. Pre-existing, but this change is what sends slash-heavy access logs into that column, so worth confirming query-service filters on the subcolumn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
