### PR TITLE
test: fix flaky usage-stats race in logs and traces exporter tests

### DIFF
--- a/exporter/clickhouselogsexporter/exporter_test.go
+++ b/exporter/clickhouselogsexporter/exporter_test.go
@@ -15,6 +15,7 @@ import (
 	cmock "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -157,6 +158,11 @@ func TestExporterPushLogsData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to push logs data: %v", err)
 	}
+
+	eventually(t, func() bool {
+		rows, err := view.RetrieveData(SigNozLogsCount)
+		return err == nil && len(rows) > 0
+	})
 
 	err = exporter.Shutdown(context.Background())
 	assert.Nil(t, err)

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	cmock "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -768,6 +769,11 @@ func TestExporterPushTracesData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to push traces data: %v", err)
 	}
+
+	eventually(t, func() bool {
+		rows, err := view.RetrieveData(SigNozSpansCount)
+		return err == nil && len(rows) > 0
+	})
 
 	err = exporter.Shutdown(context.Background())
 	assert.Nil(t, err)


### PR DESCRIPTION
## Pull Request

### Summary

`TestExporterPushLogsData` and `TestExporterPushTracesData` are both flaky, for the same reason.

Each expects the usage insert to run before the mock connection closes. But `stats.RecordWithTags` hands the measurement to the opencensus view worker **asynchronously**, and `worker.Read()` — what `usageCollector.Stop()` flushes through — reads the view directly without draining that queue. So the flush can find no usage rows, skip the insert, and leave the test failing on an expectation that was never met.

Both tests now wait for the view to report the data before calling `Shutdown`. `RetrieveData` round-trips through the worker channel, so it doubles as the barrier that guarantees the measurement has been applied.

### Related Issues
Closes #634

### Resource Impact

**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

Test-only.

### Testing

| | before | after |
|---|---|---|
| `clickhouselogsexporter` (full package) | 1 pass / 9 fail | 10 / 10 |
| `clickhousetracesexporter` (full package) | 4 pass / 1 fail | 10 / 10 |

Both pass when run alone, which is what made this confusing — and why the same tree could pass and fail CI on consecutive runs. The logs one reproduces reliably with the command from #634:

```bash
go test -timeout 30s -v -run 'TestExporterInit|TestExporterPushLogsData' ./exporter/clickhouselogsexporter -count=1
```

It also drops from 10.00s to 0.00s, since it no longer burns the full `eventually` timeout waiting for an insert that never comes. A full `go test ./...` sweep is clean.

### Note

`signozclickhousemetrics`'s `Test_shutdown` has the same setup — `ExpectExec` for the usage insert, then `Shutdown` — but never calls `ExpectationsWereMet()`, so the expectation can't fail and the test can't flake. Left alone here, but it isn't verifying the usage insert it appears to.

There's also a small production echo: usage recorded in the last moments before shutdown can be missed by the final flush, for the same reason. Not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
