### PR TITLE
fix: Support ClickHouse 26.7 aggregating tables

### DIFF
--- a/cmd/signozschemamigrator/main.go
+++ b/cmd/signozschemamigrator/main.go
@@ -132,6 +132,11 @@ func registerSyncMigrate(cmd *cobra.Command) {
 			}
 			logger.Info("Opened connection")
 
+			var allowDimensionsOutsideSortingKeySettingCount uint64
+			if err := conn.QueryRow(cmd.Context(), `SELECT count() FROM system.merge_tree_settings WHERE name = 'allow_dimensions_outside_sorting_key'`).Scan(&allowDimensionsOutsideSortingKeySettingCount); err != nil {
+				return fmt.Errorf("failed to detect ClickHouse AggregatingMergeTree compatibility settings: %w", err)
+			}
+
 			manager, err := schema_migrator.NewMigrationManager(
 				schema_migrator.WithClusterName(clusterName),
 				schema_migrator.WithReplicationEnabled(replicationEnabled),
@@ -139,6 +144,7 @@ func registerSyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
 				schema_migrator.WithDevelopment(development),
+				schema_migrator.WithAllowDimensionsOutsideSortingKey(allowDimensionsOutsideSortingKeySettingCount > 0),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create migration manager: %w", err)
@@ -230,6 +236,11 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 			}
 			logger.Info("Opened connection")
 
+			var allowDimensionsOutsideSortingKeySettingCount uint64
+			if err := conn.QueryRow(cmd.Context(), `SELECT count() FROM system.merge_tree_settings WHERE name = 'allow_dimensions_outside_sorting_key'`).Scan(&allowDimensionsOutsideSortingKeySettingCount); err != nil {
+				return fmt.Errorf("failed to detect ClickHouse AggregatingMergeTree compatibility settings: %w", err)
+			}
+
 			manager, err := schema_migrator.NewMigrationManager(
 				schema_migrator.WithClusterName(clusterName),
 				schema_migrator.WithReplicationEnabled(replicationEnabled),
@@ -237,6 +248,7 @@ func registerAsyncMigrate(cmd *cobra.Command) {
 				schema_migrator.WithConnOptions(*opts),
 				schema_migrator.WithLogger(logger),
 				schema_migrator.WithDevelopment(development),
+				schema_migrator.WithAllowDimensionsOutsideSortingKey(allowDimensionsOutsideSortingKeySettingCount > 0),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create migration manager: %w", err)

--- a/cmd/signozschemamigrator/schema_migrator/manager.go
+++ b/cmd/signozschemamigrator/schema_migrator/manager.go
@@ -77,11 +77,12 @@ type MigrationManager struct {
 	connOpts clickhouse.Options
 	conns    map[string]clickhouse.Conn
 
-	clusterName        string
-	replicationEnabled bool
-	logger             *zap.Logger
-	backoff            *backoff.ExponentialBackOff
-	development        bool
+	clusterName                      string
+	replicationEnabled               bool
+	logger                           *zap.Logger
+	backoff                          *backoff.ExponentialBackOff
+	development                      bool
+	allowDimensionsOutsideSortingKey bool
 }
 
 type Option func(*MigrationManager)
@@ -115,6 +116,33 @@ func WithDevelopment(development bool) Option {
 	return func(mgr *MigrationManager) {
 		mgr.development = development
 	}
+}
+
+func WithAllowDimensionsOutsideSortingKey(enabled bool) Option {
+	return func(mgr *MigrationManager) {
+		mgr.allowDimensionsOutsideSortingKey = enabled
+	}
+}
+
+func (m *MigrationManager) applyCompatibilitySettings(operation Operation) {
+	if !m.allowDimensionsOutsideSortingKey {
+		return
+	}
+
+	createTable, ok := operation.(*CreateTableOperation)
+	if !ok {
+		return
+	}
+
+	aggregatingMergeTree, ok := createTable.Engine.(*AggregatingMergeTree)
+	if !ok {
+		return
+	}
+
+	aggregatingMergeTree.Settings = append(aggregatingMergeTree.Settings, TableSetting{
+		Name:  "allow_dimensions_outside_sorting_key",
+		Value: "1",
+	})
 }
 
 func WithReplicationEnabled(replicationEnabled bool) Option {
@@ -1073,6 +1101,7 @@ func (m *MigrationManager) RunOperation(ctx context.Context, operation Operation
 		}
 	}
 
+	m.applyCompatibilitySettings(operation)
 	sql = operation.ToSQL()
 	m.logger.Info("Running operation", zap.String("sql", sql))
 	err := m.conn.Exec(ctx, sql)
@@ -1142,6 +1171,7 @@ func (m *MigrationManager) RunOperationWithoutUpdate(ctx context.Context, operat
 		}
 	}
 
+	m.applyCompatibilitySettings(operation)
 	sql = operation.ToSQL()
 	m.logger.Info("Running operation", zap.String("sql", sql))
 	err := m.conn.Exec(ctx, sql)

--- a/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/table_operations_test.go
@@ -486,3 +486,25 @@ func TestCreateTableReplacingMergeTreeWithVersion(t *testing.T) {
 	replicated := op.WithReplication()
 	require.Equal(t, "CREATE TABLE IF NOT EXISTS db.table (id Int16, updated_at DateTime64(3)) ENGINE = ReplicatedReplacingMergeTree(updated_at) ORDER BY id", replicated.ToSQL())
 }
+
+func TestAggregatingMergeTreeCompatibilitySetting(t *testing.T) {
+	newOperation := func() Operation {
+		return CreateTableOperation{
+			Database: "db",
+			Table:    "table",
+			Columns: []Column{
+				{Name: "key", Type: ColumnTypeUInt64},
+				{Name: "dimension", Type: ColumnTypeString},
+			},
+			Engine: AggregatingMergeTree{MergeTree: MergeTree{OrderBy: "key"}},
+		}.OnCluster("cluster")
+	}
+
+	unsupported := newOperation()
+	(&MigrationManager{}).applyCompatibilitySettings(unsupported)
+	require.NotContains(t, unsupported.ToSQL(), "allow_dimensions_outside_sorting_key")
+
+	supported := newOperation()
+	(&MigrationManager{allowDimensionsOutsideSortingKey: true}).applyCompatibilitySettings(supported)
+	require.Contains(t, supported.ToSQL(), "SETTINGS allow_dimensions_outside_sorting_key = 1")
+}


### PR DESCRIPTION
## Pull Request

### Summary
Clickhouse version 26.7 introduced strict validation for "aggregateMergeTree" tables which rejects schema that contains column that are neither part of the sorting key or aggregate measure unless the "allow_dimension_outside_sorting_keys" is enabled. Making the signoz schema migration to fail with 'Bad_Arguments'

Current Change : 
Detects wether the connected clickhouse version supports "allow_dimension_outside_sorting_key".
Enables the setting only for the aggregateMergeTree tables.
Applies behaviour to both synchronous and Asynchronous migrations.

### Related Issues
Closes #12257

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

If **Yes**, describe:
- **Resources impacted:** (CPU, Memory, Disk, Network, etc.)
- **Expected change:** (e.g., +10% CPU, -150MB RAM)
- **Benchmarks:** Provide before/after results and how they were measured.
  
<!-- Ideally the test should be done where you keep ingestion rate and configuration same
and observe the changes in CPU, Memory, Ingestion Rate and the Lag on Kafka>