### PR TITLE
feat(log-attr-json): add attributes_promoted column for logs

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/logs_migrations.go
@@ -609,4 +609,63 @@ ORDER BY name ASC`,
 			},
 		},
 	},
+	{
+		MigrationID: 2005,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column: Column{
+					Name:  "attributes_promoted",
+					Type:  JSONColumnType{},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes"},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column: Column{
+					Name:  "attributes_promoted",
+					Type:  JSONColumnType{},
+					Codec: "ZSTD(1)",
+				},
+				After: &Column{Name: "attributes"},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "distributed_logs_v2",
+				Column:   Column{Name: "attributes_promoted"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Column:   Column{Name: "attributes_promoted"},
+			},
+		},
+	},
+	{
+		MigrationID: 2006,
+		UpItems: []Operation{
+			AlterTableAddIndex{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Index: Index{
+					Name:        "attributes_promoted_paths_tokenbf",
+					Expression:  JSONPathsIndexExpr("attributes_promoted"),
+					Type:        "tokenbf_v1(1024, 2, 0)",
+					Granularity: 1,
+				},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropIndex{
+				Database: "signoz_logs",
+				Table:    "logs_v2",
+				Index:    Index{Name: "attributes_promoted_paths_tokenbf"},
+			},
+		},
+	},
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -16,4 +16,5 @@ const (
 	FieldKeysTableLastSeenColumn = "last_seen"
 
 	TracesColumnAttributesPromoted = "attributes_promoted"
+	LogsColumnAttributesPromoted   = "attributes_promoted"
 )

--- a/exporter/clickhouselogsexporter/exporter.go
+++ b/exporter/clickhouselogsexporter/exporter.go
@@ -86,6 +86,7 @@ const (
 		attributes_number,
 		attributes_bool,
 		attributes,
+		attributes_promoted,
 		resources_string,
 		resource,
 		scope_name,
@@ -93,6 +94,7 @@ const (
 		scope_string,
 		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -133,6 +135,7 @@ const (
 		attributes_number,
 		attributes_bool,
 		attributes,
+		attributes_promoted,
 		resources_string,
 		resource,
 		scope_name,
@@ -140,6 +143,7 @@ const (
 		scope_string,
 		inserted_at
 		) VALUES (
+			?,
 			?,
 			?,
 			?,
@@ -183,22 +187,23 @@ type attributeMap struct {
 // Record represents a prepared log record, ready to be appended to ClickHouse batches.
 type Record struct {
 	// batch columns
-	tsBucketStart    uint64
-	resourceFP       string
-	ts               uint64
-	ots              uint64
-	id               string
-	traceID          string
-	spanID           string
-	traceFlags       uint32
-	severityText     string
-	severityNum      uint8
-	body             string
-	bodyJSON         string
-	bodyJSONPromoted string
-	attributesJSON   string
-	scopeName        string
-	scopeVersion     string
+	tsBucketStart          uint64
+	resourceFP             string
+	ts                     uint64
+	ots                    uint64
+	id                     string
+	traceID                string
+	spanID                 string
+	traceFlags             uint32
+	severityText           string
+	severityNum            uint8
+	body                   string
+	bodyJSON               string
+	bodyJSONPromoted       string
+	attributesJSON         string
+	attributesJSONPromoted string
+	scopeName              string
+	scopeVersion           string
 	// attribute/tag maps to be appended by the single consumer
 	resourceMap attributeMap
 	scopeMap    attributeMap
@@ -318,7 +323,9 @@ type clickhouseLogsExporter struct {
 
 	// promotedPaths holds a set of JSON paths that should be promoted.
 	// Accessed via atomic.Value to allow lock-free reads on hot path.
-	promotedPaths             atomic.Value // stores map[string]struct{}
+	promotedPaths          atomic.Value // stores map[string]struct{} for body paths
+	promotedAttributePaths atomic.Value // stores map[string]struct{} for attribute paths
+
 	promotedPathsSyncInterval time.Duration
 }
 
@@ -353,6 +360,7 @@ func newExporter(_ exporter.Settings, cfg *Config, opts ...LogExporterOption) (*
 
 	// Ensure promotedPaths is always initialized so reads and type assertions are safe
 	e.promotedPaths.Store(map[string]struct{}{})
+	e.promotedAttributePaths.Store(map[string]struct{}{})
 
 	return e, nil
 }
@@ -414,38 +422,50 @@ func (e *clickhouseLogsExporter) fetchShouldSkipKeys() {
 
 // fetchPromotedPaths periodically loads promoted JSON paths from ClickHouse into memory.
 func (e *clickhouseLogsExporter) fetchPromotedPaths() {
-	// if body JSON columns are activated, fetch promoted paths periodically
-	if e.bodyJSONEnabled {
-		ticker := time.NewTicker(e.promotedPathsSyncInterval)
-		e.shutdownFuncs = append(e.shutdownFuncs, func() error {
-			ticker.Stop()
-			return nil
-		})
+	ticker := time.NewTicker(e.promotedPathsSyncInterval)
+	e.shutdownFuncs = append(e.shutdownFuncs, func() error {
+		ticker.Stop()
+		return nil
+	})
 
-		e.doFetchPromotedPaths() // Immediate first fetch
-		e.wg.Add(1)
-		go func() {
-			defer e.wg.Done()
-			for {
-				select {
-				case <-e.closeChan:
-					return
-				case <-ticker.C:
-					e.doFetchPromotedPaths()
-				}
+	e.doFetchPromotedPaths() // Immediate first fetch
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		for {
+			select {
+			case <-e.closeChan:
+				return
+			case <-ticker.C:
+				e.doFetchPromotedPaths()
 			}
-		}()
-	}
+		}
+	}()
 }
 
 func (e *clickhouseLogsExporter) doFetchPromotedPaths() {
-	// Query Evolution Table for promoted paths
-	// Format: signal, col_name, col_type, field_context, field_name, release_time
-	// Example: logs, body_promoted, JSON, body, user.name, Jan 10
+	// body promoted paths are only relevant when the body JSON columns are enabled;
+	// attribute promoted paths are always fetched since the attributes column is always written.
+	if e.bodyJSONEnabled {
+		if paths, err := e.fetchPromotedPathsForColumn(constants.BodyPromotedColumn, "body"); err == nil {
+			e.promotedPaths.Store(paths)
+		}
+	}
+	if paths, err := e.fetchPromotedPathsForColumn(constants.LogsColumnAttributesPromoted, "attribute"); err == nil {
+		e.promotedAttributePaths.Store(paths)
+	}
+}
+
+// fetchPromotedPathsForColumn loads the promoted JSON paths for a given column
+// and field context from the evolution table.
+// Format: signal, col_name, col_type, field_context, field_name, release_time
+// Example: logs, body_promoted, JSON, body, user.name, Jan 10
+func (e *clickhouseLogsExporter) fetchPromotedPathsForColumn(columnName, fieldContext string) (map[string]struct{}, error) {
 	query := fmt.Sprintf(
-		`SELECT field_name FROM %s WHERE signal = 'logs' AND column_name = '%s' AND field_context = 'body' AND field_name != '__all__' SETTINGS max_threads = 1`,
+		`SELECT field_name FROM %s WHERE signal = 'logs' AND column_name = '%s' AND field_context = '%s' AND field_name != '__all__' SETTINGS max_threads = 1`,
 		distributedColumnEvolutionTable,
-		constants.BodyPromotedColumn,
+		columnName,
+		fieldContext,
 	)
 	e.logger.Debug("fetching promoted paths from evolution table", zap.String("query", query))
 
@@ -454,14 +474,13 @@ func (e *clickhouseLogsExporter) doFetchPromotedPaths() {
 	}{}
 	if err := e.db.Select(context.Background(), &rows, query); err != nil {
 		e.logger.Error("error while fetching promoted paths from evolution table", zap.Error(err))
-		return
+		return nil, err
 	}
 	updated := make(map[string]struct{}, len(rows))
 	for _, r := range rows {
 		updated[r.FieldName] = struct{}{}
 	}
-
-	e.promotedPaths.Store(updated)
+	return updated, nil
 }
 
 // Shutdown will shutdown the exporter.
@@ -637,6 +656,7 @@ func (e *clickhouseLogsExporter) pushToClickhouse(ctx context.Context, ld plog.L
 					rec.attrsMap.NumberData,
 					rec.attrsMap.BoolData,
 					rec.attributesJSON,
+					rec.attributesJSONPromoted,
 					rec.resourceMap.StringData,
 					rec.resourceMap.StringData,
 					rec.scopeName,
@@ -727,30 +747,33 @@ producerIteration:
 					attrBytes, _ := json.Marshal(record.Attributes().AsRaw())
 
 					attributesJSON := e.getAttributesJSON(record.Attributes(), id.String())
+					promotedAttrPaths := e.promotedAttributePaths.Load().(map[string]struct{})
+					attributesJSONPromoted := e.getAttributesJSON(utils.BuildPromotedPaths(record.Attributes(), promotedAttrPaths).Map(), id.String())
 
 					body, bodyJSON, promoted := e.processBody(groupCtx, record.Body())
 					recordStream <- &Record{
-						tsBucketStart:    uint64(lBucketStart),
-						resourceFP:       fp,
-						ts:               ts,
-						ots:              ots,
-						id:               id.String(),
-						traceID:          utils.TraceIDToHexOrEmptyString(record.TraceID()),
-						spanID:           utils.SpanIDToHexOrEmptyString(record.SpanID()),
-						traceFlags:       uint32(record.Flags()),
-						severityText:     record.SeverityText(),
-						severityNum:      uint8(record.SeverityNumber()),
-						body:             body,
-						bodyJSON:         bodyJSON,
-						bodyJSONPromoted: promoted,
-						attributesJSON:   attributesJSON,
-						scopeName:        scopeName,
-						scopeVersion:     scopeVersion,
-						resourceMap:      resourcesMap,
-						scopeMap:         scopeMap,
-						attrsMap:         attrsMap,
-						logFields:        attributeMap{StringData: map[string]string{"severity_text": record.SeverityText()}, NumberData: map[string]float64{"severity_number": float64(record.SeverityNumber())}},
-						recordSize:       int64(len([]byte(record.Body().AsString())) + len(attrBytes) + len(resBytes)),
+						tsBucketStart:          uint64(lBucketStart),
+						resourceFP:             fp,
+						ts:                     ts,
+						ots:                    ots,
+						id:                     id.String(),
+						traceID:                utils.TraceIDToHexOrEmptyString(record.TraceID()),
+						spanID:                 utils.SpanIDToHexOrEmptyString(record.SpanID()),
+						traceFlags:             uint32(record.Flags()),
+						severityText:           record.SeverityText(),
+						severityNum:            uint8(record.SeverityNumber()),
+						body:                   body,
+						bodyJSON:               bodyJSON,
+						bodyJSONPromoted:       promoted,
+						attributesJSON:         attributesJSON,
+						attributesJSONPromoted: attributesJSONPromoted,
+						scopeName:              scopeName,
+						scopeVersion:           scopeVersion,
+						resourceMap:            resourcesMap,
+						scopeMap:               scopeMap,
+						attrsMap:               attrsMap,
+						logFields:              attributeMap{StringData: map[string]string{"severity_text": record.SeverityText()}, NumberData: map[string]float64{"severity_number": float64(record.SeverityNumber())}},
+						recordSize:             int64(len([]byte(record.Body().AsString())) + len(attrBytes) + len(resBytes)),
 					}
 					return nil
 				})
@@ -900,7 +923,7 @@ func (e *clickhouseLogsExporter) getAttributesJSON(attrs pcommon.Map, logID stri
 	b, err := json.Marshal(raw)
 	if err != nil {
 		// NaN/Inf doubles break json.Marshal for the whole map; sanitize lazily and retry.
-		utils.SanitizeJSONFloats(raw)
+		sanitizeJSONFloats(raw)
 		b, err = json.Marshal(raw)
 	}
 	if err != nil {
@@ -911,6 +934,30 @@ func (e *clickhouseLogsExporter) getAttributesJSON(attrs pcommon.Map, logID stri
 		return "{}"
 	}
 	return string(b)
+}
+
+// sanitizeJSONFloats replaces NaN/Inf float64 values (recursively, in place) with nil so
+// json.Marshal does not reject the whole value.
+func sanitizeJSONFloats(v any) any {
+	switch val := v.(type) {
+	case float64:
+		if utils.IsValidFloat(val) {
+			return val
+		}
+		return nil
+	case map[string]any:
+		for k, vv := range val {
+			val[k] = sanitizeJSONFloats(vv)
+		}
+		return val
+	case []any:
+		for i, vv := range val {
+			val[i] = sanitizeJSONFloats(vv)
+		}
+		return val
+	default:
+		return v
+	}
 }
 
 func (e *clickhouseLogsExporter) addAttrsToAttributeKeysStatement(


### PR DESCRIPTION
## Summary
Adds the `attributes_promoted` JSON column for logs, extracting configured hot attribute paths into a dedicated column (with dynamic subcolumns + skip index) for faster querying. The logs counterpart of the traces `attributes_promoted` work (#835), reusing the existing `body_promoted` extraction logic.

Stacked on `ns/log-attr-json` (#885).

## Related Issues
Follows #885, mirrors #835

## Resource Impact
- [x] Yes

Extra JSON column + skip index (disk), and one promoted-path extraction + JSON serialization per record (minor CPU). Billed record size unchanged.
