### PR TITLE
fix(metadataexporter): guard nil cache entry and fix signal limits is…

### DIFF
--- a/exporter/metadataexporter/cache/inmemory.go
+++ b/exporter/metadataexporter/cache/inmemory.go
@@ -181,22 +181,46 @@ func (c *InMemoryKeyCache) AttrsExistForResource(ctx context.Context, resourceFp
 }
 
 func (c *InMemoryKeyCache) ResourcesLimitExceeded(ctx context.Context, ds pipeline.Signal) bool {
-	cache, _, _ := c.getCacheAndLimits(ds)
-	return uint64(len(cache.Keys())) >= c.maxTracesResourceFp
+	cache, maxResourceCount, _ := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
+	return uint64(len(cache.Keys())) >= maxResourceCount
 }
 
 func (c *InMemoryKeyCache) TotalCardinalityLimitExceeded(ctx context.Context, ds pipeline.Signal) bool {
+	cache, _, _ := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
+
+	var maxTotalCardinality uint64
+	switch ds {
+	case pipeline.SignalTraces:
+		maxTotalCardinality = c.tracesMaxTotalCardinality
+	case pipeline.SignalMetrics:
+		maxTotalCardinality = c.metricsMaxTotalCardinality
+	case pipeline.SignalLogs:
+		maxTotalCardinality = c.logsMaxTotalCardinality
+	}
+
 	// combine the cardinality of all resources
 	var totalCardinality uint64
-	for _, resourceFp := range c.tracesCache.Keys() {
-		entry := c.tracesCache.Get(resourceFp)
+	for _, resourceFp := range cache.Keys() {
+		entry := cache.Get(resourceFp)
+		if entry == nil {
+			continue
+		}
 		totalCardinality += uint64(len(entry.Value().attrs))
 	}
-	return totalCardinality >= c.maxTracesCardinalityPerResource
+	return totalCardinality >= maxTotalCardinality
 }
 
 func (c *InMemoryKeyCache) CardinalityLimitExceededMulti(ctx context.Context, resourceFps []uint64, ds pipeline.Signal) ([]bool, error) {
-	cache, _, _ := c.getCacheAndLimits(ds)
+	cache, _, maxAttrCount := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return make([]bool, len(resourceFps)), nil
+	}
 
 	out := make([]bool, len(resourceFps))
 	for i, resourceFp := range resourceFps {
@@ -205,18 +229,21 @@ func (c *InMemoryKeyCache) CardinalityLimitExceededMulti(ctx context.Context, re
 			out[i] = false
 			continue
 		}
-		out[i] = uint64(len(entry.Value().attrs)) >= c.maxTracesCardinalityPerResource
+		out[i] = uint64(len(entry.Value().attrs)) >= maxAttrCount
 	}
 	return out, nil
 }
 
 func (c *InMemoryKeyCache) CardinalityLimitExceeded(ctx context.Context, resourceFp uint64, ds pipeline.Signal) bool {
-	cache, _, _ := c.getCacheAndLimits(ds)
+	cache, _, maxAttrCount := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
 	entry := cache.Get(resourceFp)
 	if entry == nil {
 		return false
 	}
-	return uint64(len(entry.Value().attrs)) >= c.maxTracesCardinalityPerResource
+	return uint64(len(entry.Value().attrs)) >= maxAttrCount
 }
 
 func (c *InMemoryKeyCache) Debug(ctx context.Context) {

--- a/exporter/metadataexporter/cache/inmemory_test.go
+++ b/exporter/metadataexporter/cache/inmemory_test.go
@@ -288,3 +288,120 @@ func TestInMemoryKeyCache_Debug(t *testing.T) {
 	// Just verify we don't panic or error
 	cache.Debug(ctx)
 }
+
+func TestInMemoryKeyCache_SignalLimitsIsolation(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	opts := InMemoryKeyCacheOptions{
+		// Different resource capacities for each signal:
+		MaxTracesResourceFp:  2,
+		MaxMetricsResourceFp: 2,
+		MaxLogsResourceFp:    3,
+
+		// Different per-resource cardinality capacities:
+		MaxTracesCardinalityPerResource:  5,
+		MaxMetricsCardinalityPerResource: 10,
+		MaxLogsCardinalityPerResource:    15,
+
+		// Different total cardinality limits:
+		TracesMaxTotalCardinality:  10,
+		MetricsMaxTotalCardinality: 20,
+		LogsMaxTotalCardinality:    30,
+
+		TracesFingerprintCacheTTL:  10 * time.Second,
+		MetricsFingerprintCacheTTL: 10 * time.Second,
+		LogsFingerprintCacheTTL:    10 * time.Second,
+		TenantID:                   "tenant1",
+		Logger:                     logger,
+	}
+
+	cache, err := NewInMemoryKeyCache(opts)
+	require.NoError(t, err)
+
+	// --- 1. Test Resource Limits Isolation ---
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalTraces))
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalMetrics))
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalLogs))
+
+	// Traces capacity = 2
+	_ = cache.AddAttrsToResource(ctx, 101, []uint64{1}, pipeline.SignalTraces)
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalTraces), "traces should not be full yet")
+	
+	_ = cache.AddAttrsToResource(ctx, 102, []uint64{1}, pipeline.SignalTraces)
+	assert.True(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalTraces), "traces should be full")
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalMetrics), "metrics should not be full")
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalLogs), "logs should not be full")
+
+	// --- 2. Test Per-Resource Cardinality Limits Isolation ---
+	// Traces max attr limit = 5, Metrics max attr limit = 10
+	err = cache.AddAttrsToResource(ctx, 101, []uint64{2, 3, 4, 5, 6}, pipeline.SignalTraces)
+	assert.Error(t, err, "should exceed traces limit of 5 attributes")
+
+	err = cache.AddAttrsToResource(ctx, 201, []uint64{1, 2, 3, 4, 5, 6, 7}, pipeline.SignalMetrics)
+	assert.NoError(t, err, "should not exceed metrics limit of 10 attributes")
+
+	// --- 3. Test Total Cardinality Limit Isolation ---
+	// Traces total cap = 10, Metrics total cap = 20
+	// Currently, resource 101 has 1 attribute, resource 102 has 1 attribute.
+	assert.False(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalTraces))
+
+	// Add 4 more attributes to 101 (total = 5, which is the per-resource limit)
+	_ = cache.AddAttrsToResource(ctx, 101, []uint64{2, 3, 4, 5}, pipeline.SignalTraces)
+
+	// Add 4 more attributes to 102 (total = 5, which is the per-resource limit)
+	_ = cache.AddAttrsToResource(ctx, 102, []uint64{10, 11, 12, 13}, pipeline.SignalTraces)
+
+	assert.True(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalTraces), "traces total cardinality should be exceeded")
+	assert.False(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalMetrics), "metrics total cardinality should not be exceeded")
+}
+
+func TestInMemoryKeyCache_ConcurrentEvictionNoPanic(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	opts := InMemoryKeyCacheOptions{
+		MaxTracesResourceFp:             100,
+		MaxTracesCardinalityPerResource: 5,
+		TracesFingerprintCacheTTL:       5 * time.Millisecond, // very short TTL
+		TenantID:                        "tenant1",
+		Logger:                          logger,
+	}
+
+	cache, err := NewInMemoryKeyCache(opts)
+	require.NoError(t, err)
+
+	stopChan := make(chan struct{})
+
+	// Goroutine 1: Rapidly set entries to expire
+	go func() {
+		var i uint64
+		for {
+			select {
+			case <-stopChan:
+				return
+			default:
+				_ = cache.AddAttrsToResource(ctx, i, []uint64{1}, pipeline.SignalTraces)
+				i = (i + 1) % 100
+				time.Sleep(50 * time.Microsecond)
+			}
+		}
+	}()
+
+	// Goroutine 2: Constantly query TotalCardinalityLimitExceeded
+	go func() {
+		for {
+			select {
+			case <-stopChan:
+				return
+			default:
+				_ = cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalTraces)
+				time.Sleep(50 * time.Microsecond)
+			}
+		}
+	}()
+
+	// Run for 500ms to verify no panics occur
+	time.Sleep(500 * time.Millisecond)
+	close(stopChan)
+}


### PR DESCRIPTION
## Pull Request

### Summary
This PR addresses two main issues in the `InMemoryKeyCache` component of `metadataexporter`:

1. **Nil Pointer Dereference Crash**: Guarded against `nil` entries inside the `TotalCardinalityLimitExceeded` method. When cache entries expire asynchronously via the `ttlcache` TTL manager, calling `cache.Get(resourceFp)` for an expired/evicted key returns `nil`. Attempting to call `entry.Value()` on a nil pointer dereferences it and panics, crashing the collector.
2. **Hardcoded Signal Limits**: Fixed logical bugs in the caching checking methods (`ResourcesLimitExceeded`, `TotalCardinalityLimitExceeded`, `CardinalityLimitExceededMulti`, and `CardinalityLimitExceeded`). These methods previously hardcoded trace-specific limits (e.g. `c.maxTracesResourceFp` and `c.maxTracesCardinalityPerResource`) even when the pipeline signal (`ds pipeline.Signal`) was `SignalMetrics` or `SignalLogs`, leading to incorrect limit calculations and limit leaks across different signals.

New unit tests have been added to verify:
* **`TestInMemoryKeyCache_ConcurrentEvictionNoPanic`**: Verifies no crash occurs when cache items are evicting concurrently during limit calculations.
* **`TestInMemoryKeyCache_SignalLimitsIsolation`**: Validates correct capacity limit and resource calculations under individual Traces, Metrics, and Logs signals.

### Related Issues
Closes SigNoz/signoz#12596

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [x] No

If **Yes**, describe:
- **Resources impacted:** N/A
- **Expected change:** N/A
- **Benchmarks:** N/A