### PR TITLE
feat(clickhousetracesexporter): write calculated span fields as spanf…

### DIFF
--- a/exporter/clickhousetracesexporter/span_fields.go
+++ b/exporter/clickhousetracesexporter/span_fields.go
@@ -61,3 +61,33 @@ func appendSpanFieldString(rows []spanFieldRow, key, value string, calculated bo
 	}
 	return append(rows, spanFieldRow{key: key, dataType: utils.FieldDataTypeString, stringValue: value, calculated: calculated})
 }
+
+// calculatedSpanFieldColumns are the calculated columns and the data type they
+// are written with, which together form their entry in the skip list.
+var calculatedSpanFieldColumns = []struct {
+	key      string
+	dataType utils.FieldDataType
+}{
+	{key: "http_method", dataType: utils.FieldDataTypeString},
+	{key: "http_host", dataType: utils.FieldDataTypeString},
+	{key: "http_url", dataType: utils.FieldDataTypeString},
+	{key: "response_status_code", dataType: utils.FieldDataTypeString},
+	{key: "db_name", dataType: utils.FieldDataTypeString},
+	{key: "db_operation", dataType: utils.FieldDataTypeString},
+	{key: "external_http_method", dataType: utils.FieldDataTypeString},
+	{key: "external_http_url", dataType: utils.FieldDataTypeString},
+	{key: "is_remote", dataType: utils.FieldDataTypeString},
+	{key: "has_error", dataType: utils.FieldDataTypeBool},
+}
+
+// skippedSpanFieldColumns resolves the skip list for the calculated columns
+// once per batch, so the per-row check is a lookup by column name.
+func skippedSpanFieldColumns(shouldSkipKeys map[string]shouldSkipKey) map[string]struct{} {
+	skipped := make(map[string]struct{})
+	for _, column := range calculatedSpanFieldColumns {
+		if _, skip := shouldSkipKeys[utils.MakeKeyForAttributeKeys(column.key, utils.TagTypeSpanField, column.dataType)]; skip {
+			skipped[column.key] = struct{}{}
+		}
+	}
+	return skipped
+}

--- a/exporter/clickhousetracesexporter/span_fields.go
+++ b/exporter/clickhousetracesexporter/span_fields.go
@@ -1,0 +1,57 @@
+package clickhousetracesexporter
+
+import (
+	"strconv"
+
+	"github.com/SigNoz/signoz-otel-collector/utils"
+)
+
+// spanFieldRow is a tag_attributes_v2 row for a top-level span column, written
+// with tag_type=spanfield.
+type spanFieldRow struct {
+	key      string
+	dataType utils.FieldDataType
+	// stringValue is set for string rows and numberValue for float64 rows;
+	// bool rows carry neither, like bool span attributes.
+	stringValue string
+	numberValue float64
+	// calculated marks the columns derived from span attributes. They are
+	// subject to the attribute value length limit and the high-cardinality
+	// skip list; the intrinsic columns are always written.
+	calculated bool
+}
+
+// spanFieldRows omits string rows with an empty value. Numeric rows are always
+// returned since 0 is a valid kind and status code.
+func spanFieldRows(span *SpanV3) []spanFieldRow {
+	candidates := []spanFieldRow{
+		{key: "name", dataType: utils.FieldDataTypeString, stringValue: span.Name},
+		{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: span.SpanKind},
+		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.Kind)},
+		{key: "status_code_string", dataType: utils.FieldDataTypeString, stringValue: span.StatusCodeString},
+		{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.StatusCode)},
+		{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: span.HttpMethod, calculated: true},
+		{key: "http_host", dataType: utils.FieldDataTypeString, stringValue: span.HttpHost, calculated: true},
+		{key: "http_url", dataType: utils.FieldDataTypeString, stringValue: span.HttpUrl, calculated: true},
+		{key: "response_status_code", dataType: utils.FieldDataTypeString, stringValue: span.ResponseStatusCode, calculated: true},
+		{key: "db_name", dataType: utils.FieldDataTypeString, stringValue: span.DBName, calculated: true},
+		{key: "db_operation", dataType: utils.FieldDataTypeString, stringValue: span.DBOperation, calculated: true},
+		{key: "external_http_method", dataType: utils.FieldDataTypeString, stringValue: span.ExternalHttpMethod, calculated: true},
+		{key: "external_http_url", dataType: utils.FieldDataTypeString, stringValue: span.ExternalHttpUrl, calculated: true},
+		{key: "is_remote", dataType: utils.FieldDataTypeString, stringValue: span.IsRemote, calculated: true},
+		{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true},
+	}
+
+	rows := make([]spanFieldRow, 0, len(candidates))
+	for _, row := range candidates {
+		if row.dataType == utils.FieldDataTypeString && row.stringValue == "" {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func (r spanFieldRow) dedupeKey() string {
+	return r.key + "\x00" + string(r.dataType) + "\x00" + r.stringValue + "\x00" + strconv.FormatFloat(r.numberValue, 'f', -1, 64)
+}

--- a/exporter/clickhousetracesexporter/span_fields.go
+++ b/exporter/clickhousetracesexporter/span_fields.go
@@ -1,8 +1,6 @@
 package clickhousetracesexporter
 
 import (
-	"strconv"
-
 	"github.com/SigNoz/signoz-otel-collector/utils"
 )
 
@@ -21,37 +19,45 @@ type spanFieldRow struct {
 	calculated bool
 }
 
-// spanFieldRows omits string rows with an empty value. Numeric rows are always
-// returned since 0 is a valid kind and status code.
-func spanFieldRows(span *SpanV3) []spanFieldRow {
-	candidates := []spanFieldRow{
-		{key: "name", dataType: utils.FieldDataTypeString, stringValue: span.Name},
-		{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: span.SpanKind},
-		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.Kind)},
-		{key: "status_code_string", dataType: utils.FieldDataTypeString, stringValue: span.StatusCodeString},
-		{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.StatusCode)},
-		{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: span.HttpMethod, calculated: true},
-		{key: "http_host", dataType: utils.FieldDataTypeString, stringValue: span.HttpHost, calculated: true},
-		{key: "http_url", dataType: utils.FieldDataTypeString, stringValue: span.HttpUrl, calculated: true},
-		{key: "response_status_code", dataType: utils.FieldDataTypeString, stringValue: span.ResponseStatusCode, calculated: true},
-		{key: "db_name", dataType: utils.FieldDataTypeString, stringValue: span.DBName, calculated: true},
-		{key: "db_operation", dataType: utils.FieldDataTypeString, stringValue: span.DBOperation, calculated: true},
-		{key: "external_http_method", dataType: utils.FieldDataTypeString, stringValue: span.ExternalHttpMethod, calculated: true},
-		{key: "external_http_url", dataType: utils.FieldDataTypeString, stringValue: span.ExternalHttpUrl, calculated: true},
-		{key: "is_remote", dataType: utils.FieldDataTypeString, stringValue: span.IsRemote, calculated: true},
-		{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true},
-	}
+// spanFieldDedupeKey identifies a row within a write batch. It is a struct so
+// that map lookups do not allocate.
+type spanFieldDedupeKey struct {
+	key         string
+	dataType    utils.FieldDataType
+	stringValue string
+	numberValue float64
+}
 
-	rows := make([]spanFieldRow, 0, len(candidates))
-	for _, row := range candidates {
-		if row.dataType == utils.FieldDataTypeString && row.stringValue == "" {
-			continue
-		}
-		rows = append(rows, row)
-	}
+func (r spanFieldRow) dedupeKey() spanFieldDedupeKey {
+	return spanFieldDedupeKey{key: r.key, dataType: r.dataType, stringValue: r.stringValue, numberValue: r.numberValue}
+}
+
+// spanFieldRows appends the rows for one span's top-level columns to rows,
+// which the caller reuses across spans. String rows with an empty value are
+// omitted. Numeric rows are always returned since 0 is a valid kind and
+// status code.
+func spanFieldRows(span *SpanV3, rows []spanFieldRow) []spanFieldRow {
+	rows = appendSpanFieldString(rows, "name", span.Name, false)
+	rows = appendSpanFieldString(rows, "kind_string", span.SpanKind, false)
+	rows = append(rows, spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.Kind)})
+	rows = appendSpanFieldString(rows, "status_code_string", span.StatusCodeString, false)
+	rows = append(rows, spanFieldRow{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: float64(span.StatusCode)})
+	rows = appendSpanFieldString(rows, "http_method", span.HttpMethod, true)
+	rows = appendSpanFieldString(rows, "http_host", span.HttpHost, true)
+	rows = appendSpanFieldString(rows, "http_url", span.HttpUrl, true)
+	rows = appendSpanFieldString(rows, "response_status_code", span.ResponseStatusCode, true)
+	rows = appendSpanFieldString(rows, "db_name", span.DBName, true)
+	rows = appendSpanFieldString(rows, "db_operation", span.DBOperation, true)
+	rows = appendSpanFieldString(rows, "external_http_method", span.ExternalHttpMethod, true)
+	rows = appendSpanFieldString(rows, "external_http_url", span.ExternalHttpUrl, true)
+	rows = appendSpanFieldString(rows, "is_remote", span.IsRemote, true)
+	rows = append(rows, spanFieldRow{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true})
 	return rows
 }
 
-func (r spanFieldRow) dedupeKey() string {
-	return r.key + "\x00" + string(r.dataType) + "\x00" + r.stringValue + "\x00" + strconv.FormatFloat(r.numberValue, 'f', -1, 64)
+func appendSpanFieldString(rows []spanFieldRow, key, value string, calculated bool) []spanFieldRow {
+	if value == "" {
+		return rows
+	}
+	return append(rows, spanFieldRow{key: key, dataType: utils.FieldDataTypeString, stringValue: value, calculated: calculated})
 }

--- a/exporter/clickhousetracesexporter/span_fields_bench_test.go
+++ b/exporter/clickhousetracesexporter/span_fields_bench_test.go
@@ -1,0 +1,29 @@
+package clickhousetracesexporter
+
+import "testing"
+
+func BenchmarkSpanFieldRowsDedupe(b *testing.B) {
+	span := &SpanV3{
+		Name:               "GET /users/{id}",
+		Kind:               2,
+		SpanKind:           "Server",
+		StatusCodeString:   "Unset",
+		HttpMethod:         "GET",
+		HttpHost:           "api.example.com",
+		HttpUrl:            "https://api.example.com/users/42",
+		ResponseStatusCode: "200",
+		DBName:             "orders",
+		DBOperation:        "SELECT",
+		IsRemote:           "false",
+	}
+	seen := make(map[spanFieldDedupeKey]struct{}, 16)
+	rows := make([]spanFieldRow, 0, 16)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		rows = spanFieldRows(span, rows[:0])
+		for _, row := range rows {
+			seen[row.dedupeKey()] = struct{}{}
+		}
+	}
+}

--- a/exporter/clickhousetracesexporter/span_fields_test.go
+++ b/exporter/clickhousetracesexporter/span_fields_test.go
@@ -81,6 +81,40 @@ func TestSpanFieldRowsReusesTheBuffer(t *testing.T) {
 	assert.NotContains(t, second, spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "first"}, "the previous span's rows are gone")
 }
 
+func TestSkippedSpanFieldColumns(t *testing.T) {
+	shouldSkipKeys := map[string]shouldSkipKey{
+		utils.MakeKeyForAttributeKeys("http_url", utils.TagTypeSpanField, utils.FieldDataTypeString):          {},
+		utils.MakeKeyForAttributeKeys("external_http_url", utils.TagTypeSpanField, utils.FieldDataTypeString): {},
+		utils.MakeKeyForAttributeKeys("http_method", utils.TagTypeAttribute, utils.FieldDataTypeString):       {},
+	}
+
+	skipped := skippedSpanFieldColumns(shouldSkipKeys)
+
+	assert.Equal(t, map[string]struct{}{"http_url": {}, "external_http_url": {}}, skipped, "only spanfield entries of the skip list apply; the attribute entry for http_method does not")
+	assert.Empty(t, skippedSpanFieldColumns(nil), "no skip list means nothing is skipped")
+}
+
+func TestCalculatedSpanFieldColumnsMatchTheRows(t *testing.T) {
+	span := &SpanV3{
+		HttpMethod: "GET", HttpHost: "h", HttpUrl: "u", ResponseStatusCode: "200", DBName: "d", DBOperation: "o",
+		ExternalHttpMethod: "POST", ExternalHttpUrl: "eu", IsRemote: "true", HasError: true,
+	}
+
+	rows := spanFieldRows(span, nil)
+
+	calculatedRows := map[string]utils.FieldDataType{}
+	for _, row := range rows {
+		if row.calculated {
+			calculatedRows[row.key] = row.dataType
+		}
+	}
+	calculatedColumns := map[string]utils.FieldDataType{}
+	for _, column := range calculatedSpanFieldColumns {
+		calculatedColumns[column.key] = column.dataType
+	}
+	assert.Equal(t, calculatedColumns, calculatedRows, "the skip-list table and the rows must name the same calculated columns with the same types")
+}
+
 func TestSpanFieldRowDedupeKey(t *testing.T) {
 	sameValueDifferentColumns := []spanFieldRow{
 		{key: "name", dataType: utils.FieldDataTypeString, stringValue: "Server"},

--- a/exporter/clickhousetracesexporter/span_fields_test.go
+++ b/exporter/clickhousetracesexporter/span_fields_test.go
@@ -58,7 +58,7 @@ func TestSpanFieldRows(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rows := spanFieldRows(tt.span)
+			rows := spanFieldRows(tt.span, nil)
 
 			for _, want := range tt.wantRows {
 				assert.Contains(t, rows, want, "expected a row for %s", want.key)
@@ -70,6 +70,17 @@ func TestSpanFieldRows(t *testing.T) {
 	}
 }
 
+func TestSpanFieldRowsReusesTheBuffer(t *testing.T) {
+	buffer := make([]spanFieldRow, 0, 16)
+
+	first := spanFieldRows(&SpanV3{Name: "first"}, buffer[:0])
+	second := spanFieldRows(&SpanV3{Name: "second"}, first[:0])
+
+	assert.Equal(t, cap(buffer), cap(second), "rows are written into the caller's buffer")
+	assert.Contains(t, second, spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "second"})
+	assert.NotContains(t, second, spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "first"}, "the previous span's rows are gone")
+}
+
 func TestSpanFieldRowDedupeKey(t *testing.T) {
 	sameValueDifferentColumns := []spanFieldRow{
 		{key: "name", dataType: utils.FieldDataTypeString, stringValue: "Server"},
@@ -79,7 +90,12 @@ func TestSpanFieldRowDedupeKey(t *testing.T) {
 		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 1},
 		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2},
 	}
+	sameRowTwice := []spanFieldRow{
+		{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: "GET", calculated: true},
+		{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: "GET", calculated: true},
+	}
 
 	assert.NotEqual(t, sameValueDifferentColumns[0].dedupeKey(), sameValueDifferentColumns[1].dedupeKey(), "a value shared by two columns must yield two rows")
 	assert.NotEqual(t, sameColumnDifferentValues[0].dedupeKey(), sameColumnDifferentValues[1].dedupeKey(), "two values of one column must yield two rows")
+	assert.Equal(t, sameRowTwice[0].dedupeKey(), sameRowTwice[1].dedupeKey(), "the same row from two spans is written once per batch")
 }

--- a/exporter/clickhousetracesexporter/span_fields_test.go
+++ b/exporter/clickhousetracesexporter/span_fields_test.go
@@ -4,72 +4,82 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz-otel-collector/utils"
 )
 
 func TestSpanFieldRows(t *testing.T) {
-	span := &SpanV3{
-		Name:               "GET /users/{id}",
-		Kind:               2,
-		SpanKind:           "Server",
-		StatusCode:         0,
-		StatusCodeString:   "Unset",
-		HttpMethod:         "GET",
-		HttpHost:           "api.example.com",
-		HttpUrl:            "https://api.example.com/users/42",
-		ResponseStatusCode: "200",
-		DBName:             "",
-		DBOperation:        "",
-		ExternalHttpMethod: "",
-		ExternalHttpUrl:    "",
-		IsRemote:           "false",
-		HasError:           false,
+	tests := []struct {
+		name     string
+		span     *SpanV3
+		wantRows []spanFieldRow
+		skipRows []spanFieldRow
+	}{
+		{
+			name: "intrinsic columns are written even when zero",
+			span: &SpanV3{Name: "GET /users/{id}", Kind: 0, SpanKind: "Unspecified", StatusCode: 0, StatusCodeString: "Unset"},
+			wantRows: []spanFieldRow{
+				{key: "name", dataType: utils.FieldDataTypeString, stringValue: "GET /users/{id}"},
+				{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Unspecified"},
+				{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 0},
+				{key: "status_code_string", dataType: utils.FieldDataTypeString, stringValue: "Unset"},
+				{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: 0},
+			},
+		},
+		{
+			name: "calculated columns are written when set and flagged as calculated",
+			span: &SpanV3{HttpMethod: "GET", HttpHost: "api.example.com", HttpUrl: "https://api.example.com/users/42", ResponseStatusCode: "200", IsRemote: "false"},
+			wantRows: []spanFieldRow{
+				{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: "GET", calculated: true},
+				{key: "http_host", dataType: utils.FieldDataTypeString, stringValue: "api.example.com", calculated: true},
+				{key: "http_url", dataType: utils.FieldDataTypeString, stringValue: "https://api.example.com/users/42", calculated: true},
+				{key: "response_status_code", dataType: utils.FieldDataTypeString, stringValue: "200", calculated: true},
+				{key: "is_remote", dataType: utils.FieldDataTypeString, stringValue: "false", calculated: true},
+			},
+		},
+		{
+			name: "empty calculated columns are not written",
+			span: &SpanV3{HttpMethod: "GET"},
+			skipRows: []spanFieldRow{
+				{key: "db_name", dataType: utils.FieldDataTypeString, stringValue: "", calculated: true},
+				{key: "db_operation", dataType: utils.FieldDataTypeString, stringValue: "", calculated: true},
+				{key: "external_http_method", dataType: utils.FieldDataTypeString, stringValue: "", calculated: true},
+				{key: "external_http_url", dataType: utils.FieldDataTypeString, stringValue: "", calculated: true},
+			},
+		},
+		{
+			name: "has_error is written as a bool key without a value",
+			span: &SpanV3{HasError: true},
+			wantRows: []spanFieldRow{
+				{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true},
+			},
+		},
 	}
 
-	rows := spanFieldRows(span)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := spanFieldRows(tt.span)
 
-	byKey := make(map[string]spanFieldRow, len(rows))
-	for _, row := range rows {
-		_, dup := byKey[row.key]
-		require.False(t, dup, "row for %q returned twice", row.key)
-		byKey[row.key] = row
-	}
-
-	// intrinsic columns are always returned, including numeric zeros
-	assert.Equal(t, spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "GET /users/{id}"}, byKey["name"])
-	assert.Equal(t, spanFieldRow{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Server"}, byKey["kind_string"])
-	assert.Equal(t, spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2}, byKey["kind"])
-	assert.Equal(t, spanFieldRow{key: "status_code_string", dataType: utils.FieldDataTypeString, stringValue: "Unset"}, byKey["status_code_string"])
-	assert.Equal(t, spanFieldRow{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: 0}, byKey["status_code"])
-
-	// calculated columns are written when set and flagged so the writer applies attribute limits
-	assert.Equal(t, spanFieldRow{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: "GET", calculated: true}, byKey["http_method"])
-	assert.Equal(t, spanFieldRow{key: "http_host", dataType: utils.FieldDataTypeString, stringValue: "api.example.com", calculated: true}, byKey["http_host"])
-	assert.Equal(t, spanFieldRow{key: "http_url", dataType: utils.FieldDataTypeString, stringValue: "https://api.example.com/users/42", calculated: true}, byKey["http_url"])
-	assert.Equal(t, spanFieldRow{key: "response_status_code", dataType: utils.FieldDataTypeString, stringValue: "200", calculated: true}, byKey["response_status_code"])
-	assert.Equal(t, spanFieldRow{key: "is_remote", dataType: utils.FieldDataTypeString, stringValue: "false", calculated: true}, byKey["is_remote"])
-
-	// bool columns record the key and type only, like bool span attributes
-	assert.Equal(t, spanFieldRow{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true}, byKey["has_error"])
-
-	// empty calculated strings are not suggestions
-	for _, key := range []string{"db_name", "db_operation", "external_http_method", "external_http_url"} {
-		_, ok := byKey[key]
-		assert.False(t, ok, "expected no row for empty %q", key)
+			for _, want := range tt.wantRows {
+				assert.Contains(t, rows, want, "expected a row for %s", want.key)
+			}
+			for _, skip := range tt.skipRows {
+				assert.NotContains(t, rows, skip, "expected no row for empty %s", skip.key)
+			}
+		})
 	}
 }
 
-func TestSpanFieldRowDedupeKeyIsPerColumn(t *testing.T) {
-	// the same value under two columns must not collapse into one row
-	name := spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "Server"}
-	kind := spanFieldRow{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Server"}
-	assert.NotEqual(t, name.dedupeKey(), kind.dedupeKey())
+func TestSpanFieldRowDedupeKey(t *testing.T) {
+	sameValueDifferentColumns := []spanFieldRow{
+		{key: "name", dataType: utils.FieldDataTypeString, stringValue: "Server"},
+		{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Server"},
+	}
+	sameColumnDifferentValues := []spanFieldRow{
+		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 1},
+		{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2},
+	}
 
-	// and the same column with two values yields two rows
-	assert.NotEqual(t,
-		spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 1}.dedupeKey(),
-		spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2}.dedupeKey(),
-	)
+	assert.NotEqual(t, sameValueDifferentColumns[0].dedupeKey(), sameValueDifferentColumns[1].dedupeKey(), "a value shared by two columns must yield two rows")
+	assert.NotEqual(t, sameColumnDifferentValues[0].dedupeKey(), sameColumnDifferentValues[1].dedupeKey(), "two values of one column must yield two rows")
 }

--- a/exporter/clickhousetracesexporter/span_fields_test.go
+++ b/exporter/clickhousetracesexporter/span_fields_test.go
@@ -1,0 +1,75 @@
+package clickhousetracesexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz-otel-collector/utils"
+)
+
+func TestSpanFieldRows(t *testing.T) {
+	span := &SpanV3{
+		Name:               "GET /users/{id}",
+		Kind:               2,
+		SpanKind:           "Server",
+		StatusCode:         0,
+		StatusCodeString:   "Unset",
+		HttpMethod:         "GET",
+		HttpHost:           "api.example.com",
+		HttpUrl:            "https://api.example.com/users/42",
+		ResponseStatusCode: "200",
+		DBName:             "",
+		DBOperation:        "",
+		ExternalHttpMethod: "",
+		ExternalHttpUrl:    "",
+		IsRemote:           "false",
+		HasError:           false,
+	}
+
+	rows := spanFieldRows(span)
+
+	byKey := make(map[string]spanFieldRow, len(rows))
+	for _, row := range rows {
+		_, dup := byKey[row.key]
+		require.False(t, dup, "row for %q returned twice", row.key)
+		byKey[row.key] = row
+	}
+
+	// intrinsic columns are always returned, including numeric zeros
+	assert.Equal(t, spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "GET /users/{id}"}, byKey["name"])
+	assert.Equal(t, spanFieldRow{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Server"}, byKey["kind_string"])
+	assert.Equal(t, spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2}, byKey["kind"])
+	assert.Equal(t, spanFieldRow{key: "status_code_string", dataType: utils.FieldDataTypeString, stringValue: "Unset"}, byKey["status_code_string"])
+	assert.Equal(t, spanFieldRow{key: "status_code", dataType: utils.FieldDataTypeFloat64, numberValue: 0}, byKey["status_code"])
+
+	// calculated columns are written when set and flagged so the writer applies attribute limits
+	assert.Equal(t, spanFieldRow{key: "http_method", dataType: utils.FieldDataTypeString, stringValue: "GET", calculated: true}, byKey["http_method"])
+	assert.Equal(t, spanFieldRow{key: "http_host", dataType: utils.FieldDataTypeString, stringValue: "api.example.com", calculated: true}, byKey["http_host"])
+	assert.Equal(t, spanFieldRow{key: "http_url", dataType: utils.FieldDataTypeString, stringValue: "https://api.example.com/users/42", calculated: true}, byKey["http_url"])
+	assert.Equal(t, spanFieldRow{key: "response_status_code", dataType: utils.FieldDataTypeString, stringValue: "200", calculated: true}, byKey["response_status_code"])
+	assert.Equal(t, spanFieldRow{key: "is_remote", dataType: utils.FieldDataTypeString, stringValue: "false", calculated: true}, byKey["is_remote"])
+
+	// bool columns record the key and type only, like bool span attributes
+	assert.Equal(t, spanFieldRow{key: "has_error", dataType: utils.FieldDataTypeBool, calculated: true}, byKey["has_error"])
+
+	// empty calculated strings are not suggestions
+	for _, key := range []string{"db_name", "db_operation", "external_http_method", "external_http_url"} {
+		_, ok := byKey[key]
+		assert.False(t, ok, "expected no row for empty %q", key)
+	}
+}
+
+func TestSpanFieldRowDedupeKeyIsPerColumn(t *testing.T) {
+	// the same value under two columns must not collapse into one row
+	name := spanFieldRow{key: "name", dataType: utils.FieldDataTypeString, stringValue: "Server"}
+	kind := spanFieldRow{key: "kind_string", dataType: utils.FieldDataTypeString, stringValue: "Server"}
+	assert.NotEqual(t, name.dedupeKey(), kind.dedupeKey())
+
+	// and the same column with two values yields two rows
+	assert.NotEqual(t,
+		spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 1}.dedupeKey(),
+		spanFieldRow{key: "kind", dataType: utils.FieldDataTypeFloat64, numberValue: 2}.dedupeKey(),
+	)
+}

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -358,6 +358,7 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 
 	mapOfSpanFields := make(map[spanFieldDedupeKey]struct{})
 	spanFields := make([]spanFieldRow, 0, 16)
+	skippedSpanFields := skippedSpanFieldColumns(shouldSkipKeys)
 
 	for _, span := range batchSpans {
 		unixMilli := (int64(span.StartTimeUnixNano/1e6) / 3600000) * 3600000
@@ -452,21 +453,21 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 		// attributes, written as tag_type=spanfield
 		spanFields = spanFieldRows(span, spanFields[:0])
 		for _, row := range spanFields {
+			// limits first, so rows that are never written do not grow the dedupe map
+			if row.calculated {
+				if _, skip := skippedSpanFields[row.key]; skip {
+					continue
+				}
+				if len(row.stringValue) > common.MaxAttributeValueLength {
+					continue
+				}
+			}
+
 			dedupeKey := row.dedupeKey()
 			if _, ok := mapOfSpanFields[dedupeKey]; ok {
 				continue
 			}
 			mapOfSpanFields[dedupeKey] = struct{}{}
-
-			if row.calculated {
-				if len(row.stringValue) > common.MaxAttributeValueLength {
-					w.logger.Debug("span field value length exceeds the limit", zap.String("key", row.key))
-					continue
-				}
-				if _, skip := shouldSkipKeys[utils.MakeKeyForAttributeKeys(row.key, utils.TagTypeSpanField, row.dataType)]; skip {
-					continue
-				}
-			}
 
 			var stringValue, numberValue any
 			switch row.dataType {

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -447,24 +447,34 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 			}
 		}
 
-		// span fields
-		// name, kind, kind_string, status_code_string, status_code
-		if _, ok := mapOfSpanFields[span.Name]; !ok {
-			mapOfSpanFields[span.Name] = struct{}{}
+		// span fields: the top-level columns and the columns calculated from
+		// attributes, written as tag_type=spanfield
+		for _, row := range spanFieldRows(span) {
+			dedupeKey := row.dedupeKey()
+			if _, ok := mapOfSpanFields[dedupeKey]; ok {
+				continue
+			}
+			mapOfSpanFields[dedupeKey] = struct{}{}
+
+			if row.calculated {
+				if len(row.stringValue) > common.MaxAttributeValueLength {
+					w.logger.Debug("span field value length exceeds the limit", zap.String("key", row.key))
+					continue
+				}
+				if _, skip := shouldSkipKeys[utils.MakeKeyForAttributeKeys(row.key, utils.TagTypeSpanField, row.dataType)]; skip {
+					continue
+				}
+			}
+
+			var stringValue, numberValue any
+			switch row.dataType {
+			case utils.FieldDataTypeString:
+				stringValue = row.stringValue
+			case utils.FieldDataTypeFloat64:
+				numberValue = row.numberValue
+			}
 			// TODO: handle error
-			_ = tagStatementV2.Append(unixMilli, "name", utils.TagTypeSpanField, utils.FieldDataTypeString, span.Name, nil)
-		}
-		if _, ok := mapOfSpanFields[span.SpanKind]; !ok {
-			mapOfSpanFields[span.SpanKind] = struct{}{}
-			// TODO: handle error
-			_ = tagStatementV2.Append(unixMilli, "kind_string", utils.TagTypeSpanField, utils.FieldDataTypeString, span.SpanKind, nil)
-			_ = tagStatementV2.Append(unixMilli, "kind", utils.TagTypeSpanField, utils.FieldDataTypeFloat64, nil, float64(span.Kind))
-		}
-		if _, ok := mapOfSpanFields[span.StatusCodeString]; !ok {
-			mapOfSpanFields[span.StatusCodeString] = struct{}{}
-			// TODO: handle error
-			_ = tagStatementV2.Append(unixMilli, "status_code_string", utils.TagTypeSpanField, utils.FieldDataTypeString, span.StatusCodeString, nil)
-			_ = tagStatementV2.Append(unixMilli, "status_code", utils.TagTypeSpanField, utils.FieldDataTypeFloat64, nil, float64(span.StatusCode))
+			_ = tagStatementV2.Append(unixMilli, row.key, utils.TagTypeSpanField, row.dataType, stringValue, numberValue)
 		}
 	}
 

--- a/exporter/clickhousetracesexporter/writer.go
+++ b/exporter/clickhousetracesexporter/writer.go
@@ -356,7 +356,8 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 	// create map of span attributes of key, tagType, dataType, isColumn and value to avoid duplicates in batch
 	mapOfSpanAttributeValues := make(map[string]struct{})
 
-	mapOfSpanFields := make(map[string]struct{})
+	mapOfSpanFields := make(map[spanFieldDedupeKey]struct{})
+	spanFields := make([]spanFieldRow, 0, 16)
 
 	for _, span := range batchSpans {
 		unixMilli := (int64(span.StartTimeUnixNano/1e6) / 3600000) * 3600000
@@ -449,7 +450,8 @@ func (w *SpanWriter) writeTagBatchV3(ctx context.Context, batchSpans []*SpanV3) 
 
 		// span fields: the top-level columns and the columns calculated from
 		// attributes, written as tag_type=spanfield
-		for _, row := range spanFieldRows(span) {
+		spanFields = spanFieldRows(span, spanFields[:0])
+		for _, row := range spanFields {
 			dedupeKey := row.dedupeKey()
 			if _, ok := mapOfSpanFields[dedupeKey]; ok {
 				continue


### PR DESCRIPTION
…ield rows


https://github.com/SigNoz/signoz/pull/10110 was reverted because we have these calculated fields as quick filter fields, but they were not written to `tag_attributes_v2` so values was returning empty and reverted. This change populates so they can be used again.


- write `http_method`, `http_host`, `http_url`, `response_status_code`, `db_name`, `db_operation`, `external_http_method`, `external_http_url`, `is_remote` and `has_error` to `tag_attributes_v2` with `tag_type=spanfield`, next to the existing name/kind/status rows, so the fields API can suggest their values
- calculated rows are subject to the attribute value length limit and the high-cardinality skip list; intrinsic rows keep their always-write path
- dedupe span field rows per column and value within a batch instead of by value alone


Assisted-by: Claude Fable 5.1