### PR TITLE
feat(trace-json): promote default trace attributes to json

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
@@ -2,8 +2,32 @@ package schemamigrator
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
+
+// defaultPromotedTraceAttributes are the span attributes promoted into the
+// attributes_promoted JSON column by default. They match the keys that were
+// materialized from the attributes map before traces moved to JSON storage.
+var defaultPromotedTraceAttributes = []string{
+	"http.route",
+	"messaging.system",
+	"messaging.operation",
+	"db.system",
+	"rpc.system",
+	"rpc.service",
+	"rpc.method",
+	"peer.service",
+}
+
+func promotedTraceAttributeSeedValues() string {
+	releaseTime := time.Now().UnixNano()
+	tuples := make([]string, 0, len(defaultPromotedTraceAttributes))
+	for _, name := range defaultPromotedTraceAttributes {
+		tuples = append(tuples, fmt.Sprintf("('traces', 'attributes_promoted', 'JSON', 'attribute', '%s', 0, %d)", name, releaseTime))
+	}
+	return strings.Join(tuples, ", ")
+}
 
 var MetadataMigrations = []SchemaMigrationRecord{
 	{
@@ -150,5 +174,19 @@ var MetadataMigrations = []SchemaMigrationRecord{
 				Table:    "column_evolution_metadata",
 			},
 		},
+	},
+	{
+		MigrationID: 1002,
+		UpItems: []Operation{
+			InsertIntoTable{
+				Database:    "signoz_metadata",
+				Table:       "distributed_column_evolution_metadata",
+				LightWeight: true,
+				Synchronous: true,
+				Columns:     []string{"signal", "column_name", "column_type", "field_context", "field_name", "version", "release_time"},
+				Values:      promotedTraceAttributeSeedValues(),
+			},
+		},
+		DownItems: []Operation{},
 	},
 }

--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
@@ -17,6 +17,7 @@ func TestMetadataMigrationsExactNature(t *testing.T) {
 		[]SchemaMigrationRecord{
 			MetadataMigrations[0],
 			MetadataMigrations[1],
+			MetadataMigrations[2],
 		},
 		[]SchemaMigrationRecord{},
 	)


### PR DESCRIPTION
## Pull Request

### Summary
Seed `signoz_metadata.column_evolution_metadata` so the trace exporter promotes, by default, the attributes that were materialized from the `attributes` map before traces moved to JSON storage:

- `http.route`
- `messaging.system`, `messaging.operation`
- `db.system`
- `rpc.system`, `rpc.service`, `rpc.method`
- `peer.service`

The `attributes_promoted` JSON column and its paths index already exist (from the promoted-attributes mechanism in #835); the exporter promotes whatever `field_name`s are registered in the evolution table for `signal='traces'`, `column_name='attributes_promoted'`, `field_context='attribute'`. This migration registers the default set so these keys keep getting indexed on the JSON side, matching the old map-based materialized columns.

Only newly-written spans are affected; historical rows continue to resolve these keys from the existing map columns.

### Related Issues
Part of https://github.com/SigNoz/engineering-pod/issues/5068
Closes https://github.com/SigNoz/engineering-pod/issues/5965

### Resource Impact
**Will this change affect the application's resource usage?**
- [x] Yes
- [ ] No

If **Yes**, describe:
- **Resources impacted:** Disk (these paths materialize as dedicated JSON sub-columns in `attributes_promoted`), minor CPU (per-span extraction of the promoted paths).
- **Expected change:** Small; bounded by the 8 promoted keys. Billed record size is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)