### PR TITLE
feat(metadataexporter): write intrinsic fields to their own map and m…

### DIFF
--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations.go
@@ -20,6 +20,16 @@ var MetadataMigrations = []SchemaMigrationRecord{
 					{Name: "resource_attributes", Type: MapColumnType{KeyType: LowCardinalityColumnType{ColumnTypeString}, ValueType: ColumnTypeString}},
 					{Name: "attributes", Type: MapColumnType{KeyType: LowCardinalityColumnType{ColumnTypeString}, ValueType: ColumnTypeString}},
 				},
+				// These skip indexes do not prune the related-values query. The
+				// condition builder wraps the map lookup in if(mapContains(...), ...,
+				// false), which ClickHouse does not analyse for skip indexes; with a
+				// bare mapContains(...) AND m[k] = v predicate only the resource-values
+				// index skips granules (attribute sets are hash-ordered inside a
+				// bucket, so any value common enough to filter on sits in every
+				// granule, and id-like keys saturate the ngram filter). Building them
+				// adds about 45% (ngrambf) and 20% (tokenbf) to insert CPU. See the
+				// "Skip-index probe" section of collector-v1-changes.md in the signoz
+				// repo's .local notes.
 				Indexes: []Index{
 					{Name: "idx_resource_attributes_map_keys", Expression: "mapKeys(resource_attributes)", Type: "tokenbf_v1(1024, 2, 0)", Granularity: 1},
 					{Name: "idx_attributes_map_keys", Expression: "mapKeys(attributes)", Type: "tokenbf_v1(1024, 2, 0)", Granularity: 1},
@@ -148,6 +158,33 @@ var MetadataMigrations = []SchemaMigrationRecord{
 			DropTableOperation{
 				Database: "signoz_metadata",
 				Table:    "column_evolution_metadata",
+			},
+		},
+	},
+	{
+		MigrationID: 1002,
+		UpItems: []Operation{
+			AlterTableAddColumn{
+				Database: "signoz_metadata",
+				Table:    "attributes_metadata",
+				Column:   Column{Name: "intrinsic_attributes", Type: MapColumnType{KeyType: LowCardinalityColumnType{ColumnTypeString}, ValueType: ColumnTypeString}},
+			},
+			AlterTableAddColumn{
+				Database: "signoz_metadata",
+				Table:    "distributed_attributes_metadata",
+				Column:   Column{Name: "intrinsic_attributes", Type: MapColumnType{KeyType: LowCardinalityColumnType{ColumnTypeString}, ValueType: ColumnTypeString}},
+			},
+		},
+		DownItems: []Operation{
+			AlterTableDropColumn{
+				Database: "signoz_metadata",
+				Table:    "distributed_attributes_metadata",
+				Column:   Column{Name: "intrinsic_attributes"},
+			},
+			AlterTableDropColumn{
+				Database: "signoz_metadata",
+				Table:    "attributes_metadata",
+				Column:   Column{Name: "intrinsic_attributes"},
 			},
 		},
 	},

--- a/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
+++ b/cmd/signozschemamigrator/schema_migrator/metadata_migrations_test.go
@@ -17,6 +17,7 @@ func TestMetadataMigrationsExactNature(t *testing.T) {
 		[]SchemaMigrationRecord{
 			MetadataMigrations[0],
 			MetadataMigrations[1],
+			MetadataMigrations[2],
 		},
 		[]SchemaMigrationRecord{},
 	)

--- a/exporter/clickhousetracesexporter/clickhouse_exporter.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	hasIsRemoteMask          uint32 = 0x00000100
-	isRemoteMask             uint32 = 0x00000200
 	defaultDatasource        string = "tcp://127.0.0.1:9000/?database=signoz_traces"
 	defaultTraceDatabase     string = "signoz_traces"
 	defaultErrorTable        string = "distributed_signoz_error_index_v2"

--- a/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
+++ b/exporter/clickhousetracesexporter/clickhouse_exporter_v3.go
@@ -5,8 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"net/url"
-	"strconv"
+	"github.com/SigNoz/signoz-otel-collector/internal/common/spanfields"
 	"strings"
 	"time"
 
@@ -24,11 +23,6 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.uber.org/zap"
 )
-
-var possibleHostAttr = utils.ToLookUpMap([]string{
-	"http.host", "server.address", "client.address",
-	"http.request.header.host", "net.peer.name",
-})
 
 func makeJaegerProtoReferences(
 	links ptrace.SpanLinkSlice,
@@ -89,54 +83,15 @@ func ServiceNameForResource(resource pcommon.Resource) string {
 }
 
 func populateCustomAttrsAndAttrs(attributes pcommon.Map, span *SpanV3) {
-	attributes.Range(func(k string, v pcommon.Value) bool {
-		if k == "http.status_code" || k == "http.response.status_code" {
-			// Handle both string/int http status codes.
-			statusString, err := strconv.Atoi(v.Str())
-			statusInt := v.Int()
-			if err == nil && statusString != 0 {
-				statusInt = int64(statusString)
-			}
-			span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
-		} else if (k == "http.url" || k == "url.full") && span.Kind == 3 {
-			value := v.Str()
-			valueUrl, err := url.Parse(value)
-			if err == nil {
-				value = valueUrl.Hostname()
-			}
-			span.ExternalHttpUrl = value
-			span.HttpUrl = v.Str()
-			if span.HttpHost == "" { // skip override if already set using possibleHostAttr
-				span.HttpHost = value
-			}
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind == 3 {
-			span.ExternalHttpMethod = v.Str()
-			span.HttpMethod = v.Str()
-		} else if (k == "http.url" || k == "url.full") && span.Kind != 3 {
-			span.HttpUrl = v.Str()
-		} else if (k == "http.method" || k == "http.request.method") && span.Kind != 3 {
-			span.HttpMethod = v.Str()
-		} else if _, ok := possibleHostAttr[k]; ok {
-			span.HttpHost = v.Str()
-		} else if k == "db.name" || k == "db.namespace" {
-			span.DBName = v.Str()
-		} else if k == "db.operation" || k == "db.operation.name" {
-			span.DBOperation = v.Str()
-		} else if k == "rpc.grpc.status_code" {
-			// Handle both string/int status code in GRPC spans.
-			statusString, err := strconv.Atoi(v.Str())
-			statusInt := v.Int()
-			if err == nil && statusString != 0 {
-				statusInt = int64(statusString)
-			}
-			span.ResponseStatusCode = strconv.FormatInt(statusInt, 10)
-		} else if k == "rpc.jsonrpc.error_code" {
-			span.ResponseStatusCode = v.Str()
-		}
-		return true
-
-	})
-
+	c := spanfields.CalculatedFrom(attributes, ptrace.SpanKind(span.Kind))
+	span.HttpMethod = c.HttpMethod
+	span.HttpHost = c.HttpHost
+	span.HttpUrl = c.HttpUrl
+	span.ResponseStatusCode = c.ResponseStatusCode
+	span.DBName = c.DBName
+	span.DBOperation = c.DBOperation
+	span.ExternalHttpMethod = c.ExternalHttpMethod
+	span.ExternalHttpUrl = c.ExternalHttpUrl
 }
 
 func populateEventsV3(events ptrace.SpanEventSlice, span *SpanV3, lowCardinalExceptionGrouping bool) {
@@ -287,14 +242,7 @@ func (attrMap *attributesData) add(key string, value pcommon.Value) {
 func newStructuredSpanV3(bucketStart uint64, fingerprint string, otelSpan ptrace.Span, ServiceName string, resource pcommon.Resource, scope pcommon.InstrumentationScope, config storageConfig, promotedPaths map[string]struct{}) (*SpanV3, error) {
 	durationNano := uint64(otelSpan.EndTimestamp() - otelSpan.StartTimestamp())
 
-	isRemote := "unknown"
-	flags := otelSpan.Flags()
-	if flags&hasIsRemoteMask != 0 {
-		isRemote = "no"
-		if flags&isRemoteMask != 0 {
-			isRemote = "yes"
-		}
-	}
+	isRemote := spanfields.IsRemote(otelSpan.Flags())
 
 	attrMap := attributesData{
 		StringMap:      make(map[string]string),

--- a/exporter/metadataexporter/attribute_writer.go
+++ b/exporter/metadataexporter/attribute_writer.go
@@ -2,6 +2,7 @@ package metadataexporter
 
 import (
 	"context"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/SigNoz/signoz-otel-collector/constants"
@@ -19,8 +20,12 @@ type attributeMetadataWriter struct {
 	conn   driver.Conn
 	logger *zap.Logger
 
+	bucket time.Duration
+
 	shouldSkipFromDB      func(ctx context.Context, key, datasource string) bool
 	filterAttrs           func(ctx context.Context, attrs map[string]any, datasource string) map[string]any
+	filterIntrinsics      func(ctx context.Context, fields map[string]string, datasource string) map[string]string
+	filterResourceAttrs   func(ctx context.Context, attrs map[string]any, datasource string) map[string]any
 	writeToStatementBatch func(ctx context.Context, stmt driver.Batch, records []writeToStatementBatchRecord, ds pipeline.Signal) (int, error)
 }
 
@@ -28,8 +33,11 @@ func newAttributeMetadataWriter(e *metadataExporter) *attributeMetadataWriter {
 	return &attributeMetadataWriter{
 		conn:                  e.conn,
 		logger:                e.set.Logger,
+		bucket:                e.cfg.MaxDistinctValues.Logs.Bucket,
 		shouldSkipFromDB:      e.shouldSkipAttributeFromDB,
 		filterAttrs:           e.filterAttrs,
+		filterIntrinsics:      e.filterIntrinsics,
+		filterResourceAttrs:   e.filterResourceAttrs,
 		writeToStatementBatch: e.writeToStatementBatch,
 	}
 }
@@ -44,6 +52,7 @@ func (w *attributeMetadataWriter) Process(ctx context.Context, ld plog.Logs) err
 
 	totalLogRecords := 0
 	records := make([]writeToStatementBatchRecord, 0)
+	now := time.Now()
 
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
@@ -56,7 +65,7 @@ func (w *attributeMetadataWriter) Process(ctx context.Context, ld plog.Logs) err
 			resourceAttrs[k] = v.AsRaw()
 			return true
 		})
-		flattenedResourceAttrs := flatten.FlattenJSON(resourceAttrs, "")
+		flattenedResourceAttrs := w.filterResourceAttrs(ctx, flatten.FlattenJSON(resourceAttrs, ""), pipeline.SignalLogs.String())
 		resourceFingerprint := fingerprint.FingerprintHash(flattenedResourceAttrs)
 
 		sls := rl.ScopeLogs()
@@ -80,16 +89,21 @@ func (w *attributeMetadataWriter) Process(ctx context.Context, ld plog.Logs) err
 
 				flattenedLogRecordAttrs := flatten.FlattenJSON(logRecordAttrs, "")
 				filteredLogRecordAttrs := w.filterAttrs(ctx, flattenedLogRecordAttrs, pipeline.SignalLogs.String())
-				logRecordFingerprint := fingerprint.FingerprintHash(filteredLogRecordAttrs)
+				intrinsics := w.filterIntrinsics(ctx, logIntrinsics(logRecord), pipeline.SignalLogs.String())
+				logRecordFingerprint := setFingerprint(filteredLogRecordAttrs, intrinsics)
 
-				unixMilli := logRecord.Timestamp().AsTime().UnixMilli()
-				roundedSixHrsUnixMilli := (unixMilli / sixHoursInMs) * sixHoursInMs
+				ts := logRecord.Timestamp()
+				if ts == 0 {
+					ts = logRecord.ObservedTimestamp()
+				}
+				roundedSixHrsUnixMilli := bucketStart(ts.AsTime(), now, w.bucket)
 
 				records = append(records, writeToStatementBatchRecord{
 					resourceFingerprint:    resourceFingerprint,
 					fprint:                 logRecordFingerprint,
 					rAttrs:                 flattenedResourceAttrs,
 					attrs:                  filteredLogRecordAttrs,
+					intrinsics:             intrinsics,
 					roundedSixHrsUnixMilli: roundedSixHrsUnixMilli,
 				})
 			}

--- a/exporter/metadataexporter/cache/inmemory.go
+++ b/exporter/metadataexporter/cache/inmemory.go
@@ -180,43 +180,66 @@ func (c *InMemoryKeyCache) AttrsExistForResource(ctx context.Context, resourceFp
 	return out, nil
 }
 
+// getMaxTotalCardinality picks the total attribute set limit for the signal.
+func (c *InMemoryKeyCache) getMaxTotalCardinality(ds pipeline.Signal) uint64 {
+	switch ds {
+	case pipeline.SignalTraces:
+		return c.tracesMaxTotalCardinality
+	case pipeline.SignalMetrics:
+		return c.metricsMaxTotalCardinality
+	case pipeline.SignalLogs:
+		return c.logsMaxTotalCardinality
+	}
+	return 0
+}
+
 func (c *InMemoryKeyCache) ResourcesLimitExceeded(ctx context.Context, ds pipeline.Signal) bool {
-	cache, _, _ := c.getCacheAndLimits(ds)
-	return uint64(len(cache.Keys())) >= c.maxTracesResourceFp
+	cache, maxResourceCount, _ := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
+	return uint64(len(cache.Keys())) >= maxResourceCount
 }
 
 func (c *InMemoryKeyCache) TotalCardinalityLimitExceeded(ctx context.Context, ds pipeline.Signal) bool {
+	cache, _, _ := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
 	// combine the cardinality of all resources
 	var totalCardinality uint64
-	for _, resourceFp := range c.tracesCache.Keys() {
-		entry := c.tracesCache.Get(resourceFp)
+	for _, resourceFp := range cache.Keys() {
+		entry := cache.Get(resourceFp)
+		if entry == nil {
+			continue
+		}
+		entry.Value().mu.RLock()
 		totalCardinality += uint64(len(entry.Value().attrs))
+		entry.Value().mu.RUnlock()
 	}
-	return totalCardinality >= c.maxTracesCardinalityPerResource
+	return totalCardinality >= c.getMaxTotalCardinality(ds)
 }
 
 func (c *InMemoryKeyCache) CardinalityLimitExceededMulti(ctx context.Context, resourceFps []uint64, ds pipeline.Signal) ([]bool, error) {
-	cache, _, _ := c.getCacheAndLimits(ds)
-
 	out := make([]bool, len(resourceFps))
 	for i, resourceFp := range resourceFps {
-		entry := cache.Get(resourceFp)
-		if entry == nil {
-			out[i] = false
-			continue
-		}
-		out[i] = uint64(len(entry.Value().attrs)) >= c.maxTracesCardinalityPerResource
+		out[i] = c.CardinalityLimitExceeded(ctx, resourceFp, ds)
 	}
 	return out, nil
 }
 
 func (c *InMemoryKeyCache) CardinalityLimitExceeded(ctx context.Context, resourceFp uint64, ds pipeline.Signal) bool {
-	cache, _, _ := c.getCacheAndLimits(ds)
+	cache, _, maxAttrCount := c.getCacheAndLimits(ds)
+	if cache == nil {
+		return false
+	}
 	entry := cache.Get(resourceFp)
 	if entry == nil {
 		return false
 	}
-	return uint64(len(entry.Value().attrs)) >= c.maxTracesCardinalityPerResource
+	entry.Value().mu.RLock()
+	defer entry.Value().mu.RUnlock()
+	return uint64(len(entry.Value().attrs)) >= maxAttrCount
 }
 
 func (c *InMemoryKeyCache) Debug(ctx context.Context) {

--- a/exporter/metadataexporter/cache/inmemory_test.go
+++ b/exporter/metadataexporter/cache/inmemory_test.go
@@ -288,3 +288,44 @@ func TestInMemoryKeyCache_Debug(t *testing.T) {
 	// Just verify we don't panic or error
 	cache.Debug(ctx)
 }
+
+func TestInMemoryKeyCache_LimitsArePerSignal(t *testing.T) {
+	ctx := context.Background()
+
+	cache, err := NewInMemoryKeyCache(InMemoryKeyCacheOptions{
+		MaxTracesResourceFp:              1,
+		MaxTracesCardinalityPerResource:  1,
+		TracesMaxTotalCardinality:        1,
+		TracesFingerprintCacheTTL:        time.Minute,
+		MaxMetricsResourceFp:             10,
+		MaxMetricsCardinalityPerResource: 10,
+		MetricsMaxTotalCardinality:       10,
+		MetricsFingerprintCacheTTL:       time.Minute,
+		MaxLogsResourceFp:                10,
+		MaxLogsCardinalityPerResource:    3,
+		LogsMaxTotalCardinality:          5,
+		LogsFingerprintCacheTTL:          time.Minute,
+		TenantID:                         "tenant1",
+		Logger:                           zap.NewNop(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cache.AddAttrsToResource(ctx, 1, []uint64{1}, pipeline.SignalTraces))
+	assert.True(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalTraces))
+	assert.True(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalTraces))
+	assert.True(t, cache.CardinalityLimitExceeded(ctx, 1, pipeline.SignalTraces))
+
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalLogs), "a full traces cache does not block logs")
+	assert.False(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalLogs))
+	assert.False(t, cache.CardinalityLimitExceeded(ctx, 1, pipeline.SignalLogs))
+
+	require.NoError(t, cache.AddAttrsToResource(ctx, 1, []uint64{1, 2, 3}, pipeline.SignalLogs))
+	require.NoError(t, cache.AddAttrsToResource(ctx, 2, []uint64{4, 5}, pipeline.SignalLogs))
+	assert.True(t, cache.CardinalityLimitExceeded(ctx, 1, pipeline.SignalLogs), "the logs per-resource limit applies to logs")
+	exceeds, err := cache.CardinalityLimitExceededMulti(ctx, []uint64{1, 2, 3}, pipeline.SignalLogs)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, false}, exceeds)
+	assert.True(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalLogs), "the logs total is compared with the logs total limit")
+	assert.False(t, cache.ResourcesLimitExceeded(ctx, pipeline.SignalLogs))
+	assert.False(t, cache.TotalCardinalityLimitExceeded(ctx, pipeline.SignalMetrics))
+}

--- a/exporter/metadataexporter/cache/redis.go
+++ b/exporter/metadataexporter/cache/redis.go
@@ -20,6 +20,10 @@ type RedisKeyCache struct {
 	metricsTTL time.Duration
 	logsTTL    time.Duration
 
+	tracesWindow  time.Duration
+	metricsWindow time.Duration
+	logsWindow    time.Duration
+
 	// Max # of resource fingerprints in each pipeline
 	maxTracesResourceFp  uint64
 	maxMetricsResourceFp uint64
@@ -51,6 +55,11 @@ type RedisKeyCacheOptions struct {
 	MetricsTTL time.Duration
 	LogsTTL    time.Duration
 
+	// Write window per signal; keys embed the window they belong to.
+	TracesWindow  time.Duration
+	MetricsWindow time.Duration
+	LogsWindow    time.Duration
+
 	// Limits
 	MaxTracesResourceFp  uint64
 	MaxMetricsResourceFp uint64
@@ -69,11 +78,8 @@ type RedisKeyCacheOptions struct {
 
 var _ KeyCache = (*RedisKeyCache)(nil)
 
-// 6-hour rolling window
-const (
-	sixHours     = 6 * time.Hour
-	sixHoursInMs = int64(sixHours / time.Millisecond)
-)
+// defaultWindow is the write window used for a signal without a configured TTL.
+const defaultWindow = 6 * time.Hour
 
 func NewRedisKeyCache(opts RedisKeyCacheOptions) (*RedisKeyCache, error) {
 	client := redis.NewClient(&redis.Options{
@@ -95,6 +101,10 @@ func NewRedisKeyCache(opts RedisKeyCacheOptions) (*RedisKeyCache, error) {
 		tracesTTL:  opts.TracesTTL,
 		metricsTTL: opts.MetricsTTL,
 		logsTTL:    opts.LogsTTL,
+
+		tracesWindow:  opts.TracesWindow,
+		metricsWindow: opts.MetricsWindow,
+		logsWindow:    opts.LogsWindow,
 
 		maxTracesResourceFp:  opts.MaxTracesResourceFp,
 		maxMetricsResourceFp: opts.MaxMetricsResourceFp,
@@ -121,32 +131,56 @@ func (c *RedisKeyCache) getTTL(ds pipeline.Signal) time.Duration {
 	case pipeline.SignalLogs:
 		return c.logsTTL
 	default:
-		return sixHours
+		return defaultWindow
 	}
 }
 
-func getCurrentEpochWindowMillis() int64 {
-	return time.Now().UnixMilli() / sixHoursInMs * sixHoursInMs
+func (c *RedisKeyCache) getWindow(ds pipeline.Signal) time.Duration {
+	switch ds {
+	case pipeline.SignalTraces:
+		return c.tracesWindow
+	case pipeline.SignalMetrics:
+		return c.metricsWindow
+	case pipeline.SignalLogs:
+		return c.logsWindow
+	default:
+		return defaultWindow
+	}
+}
+
+// getCurrentEpochWindowMillis returns the start of the current write window.
+// Every key embeds the window it belongs to, so a new window starts with an
+// empty cache.
+func getCurrentEpochWindowMillis(window time.Duration) int64 {
+	if window <= 0 {
+		window = defaultWindow
+	}
+	windowMs := window.Milliseconds()
+	return time.Now().UnixMilli() / windowMs * windowMs
+}
+
+func (c *RedisKeyCache) windowStart(ds pipeline.Signal) int64 {
+	return getCurrentEpochWindowMillis(c.getWindow(ds))
 }
 
 func (c *RedisKeyCache) getAttrsKey(ds pipeline.Signal, resourceFpStr string) string {
-	// e.g. "tenantID:metadata:traces:<6hWindow>:resource:<resourceFpStr>"
+	// e.g. "tenantID:metadata:traces:<windowStart>:resource:<resourceFpStr>"
 	return fmt.Sprintf("%s:metadata:%s:%d:resource:%s",
-		c.tenantID, ds.String(), getCurrentEpochWindowMillis(), resourceFpStr)
+		c.tenantID, ds.String(), c.windowStart(ds), resourceFpStr)
 }
 
 // getResourcesHLLKey returns the HLL key for the set of resource fingerprints
-// for the current 6h window for the given signal (for total unique resources)
+// for the current window for the given signal (for total unique resources)
 func (c *RedisKeyCache) getResourcesHLLKey(ds pipeline.Signal) string {
 	return fmt.Sprintf("%s:metadata:%s:%d:resources:hll",
-		c.tenantID, ds.String(), getCurrentEpochWindowMillis())
+		c.tenantID, ds.String(), c.windowStart(ds))
 }
 
 // getAttrsHLLKey returns the HLL key for the set of attribute fingerprints
-// for the current 6h window for the given signal (for total unique attributes)
+// for the current window for the given signal (for total unique attributes)
 func (c *RedisKeyCache) getAttrsHLLKey(ds pipeline.Signal) string {
 	return fmt.Sprintf("%s:metadata:%s:%d:attrs:hll",
-		c.tenantID, ds.String(), getCurrentEpochWindowMillis())
+		c.tenantID, ds.String(), c.windowStart(ds))
 }
 
 func (c *RedisKeyCache) getMaxResourceFp(ds pipeline.Signal) uint64 {

--- a/exporter/metadataexporter/cache/redis_test.go
+++ b/exporter/metadataexporter/cache/redis_test.go
@@ -45,7 +45,7 @@ func buildMockRedisKeyCache(_ *testing.T, mockFn func(redismock.ClientMock)) (*R
 
 func TestRedisKeyCache_AddAttrsToResource_NewResource_Success(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	resourceHLLKey := fmt.Sprintf("testTenant:metadata:traces:%d:resources:hll", epochWindow)
 	attrsKey := fmt.Sprintf("testTenant:metadata:traces:%d:resource:1000", epochWindow)
 	attrsHLLKey := fmt.Sprintf("testTenant:metadata:traces:%d:attrs:hll", epochWindow)
@@ -77,7 +77,7 @@ func TestRedisKeyCache_AddAttrsToResource_NewResource_Success(t *testing.T) {
 
 func TestRedisKeyCache_AddAttrsToResource_ResourceLimitExceeded(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	resourceHLLKey := fmt.Sprintf("testTenant:metadata:traces:%d:resources:hll", epochWindow)
 	attrsKey := fmt.Sprintf("testTenant:metadata:traces:%d:resource:1000", epochWindow)
 
@@ -96,7 +96,7 @@ func TestRedisKeyCache_AddAttrsToResource_ResourceLimitExceeded(t *testing.T) {
 
 func TestRedisKeyCache_AddAttrsToResource_AttrCardinalityExceeded(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	resourceHLLKey := fmt.Sprintf("testTenant:metadata:traces:%d:resources:hll", epochWindow)
 	attrsKey := fmt.Sprintf("testTenant:metadata:traces:%d:resource:3000", epochWindow)
 
@@ -133,7 +133,7 @@ func TestRedisKeyCache_AddAttrsToResource_EmptyList(t *testing.T) {
 
 func TestRedisKeyCache_AttrsExistForResource_Basic(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	attrsKey := fmt.Sprintf("testTenant:metadata:metrics:%d:resource:5555", epochWindow)
 
 	cache, mock := buildMockRedisKeyCache(t, func(m redismock.ClientMock) {
@@ -165,7 +165,7 @@ func TestRedisKeyCache_AttrsExistForResource_Empty(t *testing.T) {
 func TestRedisKeyCache_ResourcesLimitExceeded(t *testing.T) {
 	ctx := context.Background()
 
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	resourceHLLKey := fmt.Sprintf("testTenant:metadata:traces:%d:resources:hll", epochWindow)
 
 	cache, mock := buildMockRedisKeyCache(t, func(m redismock.ClientMock) {
@@ -181,7 +181,7 @@ func TestRedisKeyCache_ResourcesLimitExceeded(t *testing.T) {
 
 func TestRedisKeyCache_CardinalityLimitExceeded(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	attrsKey := fmt.Sprintf("testTenant:metadata:traces:%d:resource:777", epochWindow)
 
 	cache, mock := buildMockRedisKeyCache(t, func(m redismock.ClientMock) {
@@ -197,7 +197,7 @@ func TestRedisKeyCache_CardinalityLimitExceeded(t *testing.T) {
 
 func TestRedisKeyCache_Debug(t *testing.T) {
 	ctx := context.Background()
-	epochWindow := getCurrentEpochWindowMillis()
+	epochWindow := getCurrentEpochWindowMillis(6 * time.Hour)
 	resourceSetKey := fmt.Sprintf("testTenant:metadata:traces:%d:resources", epochWindow)
 	attrsKey := fmt.Sprintf("testTenant:metadata:traces:%d:resource:1000", epochWindow)
 

--- a/exporter/metadataexporter/config.go
+++ b/exporter/metadataexporter/config.go
@@ -1,6 +1,8 @@
 package metadataexporter
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -16,10 +18,32 @@ const (
 )
 
 type LimitsConfig struct {
-	MaxKeys                 uint64        `mapstructure:"max_keys"`
-	MaxStringDistinctValues uint64        `mapstructure:"max_string_distinct_values"`
-	MaxStringLength         uint64        `mapstructure:"max_string_length"`
+	MaxKeys                 uint64 `mapstructure:"max_keys"`
+	MaxStringDistinctValues uint64 `mapstructure:"max_string_distinct_values"`
+	// MaxStringLength is the longest attribute value that is written to the
+	// metadata table. A key whose value exceeds it is dropped from every
+	// subsequent row of the signal until the key has been absent for a while.
+	MaxStringLength uint64 `mapstructure:"max_string_length"`
+	// MaxResourceStringLength is the same limit applied to resource attribute
+	// values. Keys listed in always_include_attributes are exempt.
+	MaxResourceStringLength uint64        `mapstructure:"max_resource_string_length"`
 	FetchInterval           time.Duration `mapstructure:"fetch_interval"`
+	// Bucket is the time window a resource+attribute set is written once per.
+	// The query side must floor its window start to the largest bucket in use.
+	Bucket time.Duration `mapstructure:"bucket"`
+}
+
+func (c LimitsConfig) validate(signal string) error {
+	if c.Bucket < time.Millisecond {
+		return fmt.Errorf("max_distinct_values::%s::bucket must be at least 1ms", signal)
+	}
+	if c.MaxStringLength == 0 {
+		return fmt.Errorf("max_distinct_values::%s::max_string_length must be positive", signal)
+	}
+	if c.MaxResourceStringLength == 0 {
+		return fmt.Errorf("max_distinct_values::%s::max_resource_string_length must be positive", signal)
+	}
+	return nil
 }
 
 type MaxDistinctValuesConfig struct {
@@ -101,4 +125,13 @@ type Config struct {
 
 	// JSON configures JSON field processing for body (and attributes in future).
 	JSON JSONConfig `mapstructure:"json"`
+}
+
+// Validate checks the per-signal limits.
+func (cfg *Config) Validate() error {
+	return errors.Join(
+		cfg.MaxDistinctValues.Traces.validate("traces"),
+		cfg.MaxDistinctValues.Logs.validate("logs"),
+		cfg.MaxDistinctValues.Metrics.validate("metrics"),
+	)
 }

--- a/exporter/metadataexporter/config_test.go
+++ b/exporter/metadataexporter/config_test.go
@@ -30,7 +30,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{
-				TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+				TimeoutConfig:    exporterhelper.TimeoutConfig{Timeout: DefaultTimeout},
 				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 				DSN:              "tcp://localhost:9000",
@@ -38,20 +38,26 @@ func TestLoadConfig(t *testing.T) {
 					Traces: LimitsConfig{
 						MaxKeys:                 100,
 						MaxStringLength:         128,
+						MaxResourceStringLength: 256,
 						MaxStringDistinctValues: 420,
 						FetchInterval:           5 * time.Minute,
+						Bucket:                  DefaultBucket,
 					},
 					Logs: LimitsConfig{
 						MaxKeys:                 100,
 						MaxStringLength:         64,
+						MaxResourceStringLength: 64,
 						MaxStringDistinctValues: 512,
 						FetchInterval:           10 * time.Minute,
+						Bucket:                  DefaultBucket,
 					},
 					Metrics: LimitsConfig{
 						MaxKeys:                 100,
 						MaxStringLength:         16,
+						MaxResourceStringLength: 64,
 						MaxStringDistinctValues: 1024,
 						FetchInterval:           5 * time.Minute,
+						Bucket:                  12 * time.Hour,
 					},
 				},
 				Cache: CacheConfig{

--- a/exporter/metadataexporter/exporter.go
+++ b/exporter/metadataexporter/exporter.go
@@ -2,12 +2,13 @@ package metadataexporter
 
 import (
 	"context"
-	"strings"
+	"strconv"
 	"sync/atomic"
 	"time"
 
 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz-otel-collector/internal/common/spanfields"
 	"github.com/SigNoz/signoz-otel-collector/utils"
 	"github.com/SigNoz/signoz-otel-collector/utils/fingerprint"
 	"github.com/SigNoz/signoz-otel-collector/utils/flatten"
@@ -19,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pipeline"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -26,16 +29,51 @@ import (
 )
 
 const (
-	sixHours           = 6 * time.Hour                      // window size for attributes aggregation
-	sixHoursInMs       = int64(sixHours / time.Millisecond) // window size in ms
-	valuTrackerKeysTTL = 45 * time.Minute                   // ttl for keys in value tracker
-	insertStmtQuery    = "INSERT INTO signoz_metadata.distributed_attributes_metadata"
+	valuTrackerKeysTTL = 45 * time.Minute // ttl for keys in value tracker
+	// skipDecisionTTL is how long a key stays skipped after the periodic
+	// tag_attributes_v2 count last found it over the limit.
+	skipDecisionTTL = 24 * time.Hour
+	// metadataRetention matches the TTL of attributes_metadata.
+	metadataRetention = 30 * 24 * time.Hour
+	// maxFutureSkew is how far ahead of the collector clock a record timestamp
+	// may be before the current time is used instead.
+	maxFutureSkew = time.Hour
+	// maxExecutionTimeSetting is the ClickHouse setting that bounds an INSERT
+	// server-side; it is set from the exporter timeout unless the DSN sets it.
+	maxExecutionTimeSetting = "max_execution_time"
+	insertStmtQuery         = "INSERT INTO signoz_metadata.distributed_attributes_metadata (unix_milli, data_source, resource_fingerprint, attrs_fingerprint, resource_attributes, attributes, intrinsic_attributes)"
+	// intrinsicTrackerPrefix keeps intrinsic field names apart from attribute
+	// keys of the same name in the value tracker.
+	intrinsicTrackerPrefix = "intrinsic:"
+	meterName              = "github.com/SigNoz/signoz-otel-collector/exporter/metadataexporter"
+)
+
+// drop reasons recorded on the values_dropped counter.
+const (
+	dropReasonEmpty             = "empty"
+	dropReasonOversized         = "oversized"
+	dropReasonResourceOversized = "resource_oversized"
+	dropReasonCardinality       = "cardinality"
 )
 
 type tagValueCountFromDB struct {
 	tagDataType         string
 	stringTagValueCount uint64
 	numberValueCount    uint64
+	// skippedUntil is set when the count was found over the limit; the key
+	// stays skipped until then even if a later count falls under the limit.
+	skippedUntil time.Time
+}
+
+// exceeds reports whether the DB-derived count puts the key over the limit.
+func (c tagValueCountFromDB) exceeds(limits LimitsConfig) bool {
+	switch c.tagDataType {
+	case "string":
+		return c.stringTagValueCount > limits.MaxStringDistinctValues
+	case "float64", "int64":
+		return true
+	}
+	return false
 }
 
 type metadataExporter struct {
@@ -68,6 +106,10 @@ type metadataExporter struct {
 	// logsMetadataWriters is the ordered list of writers dispatched in parallel on
 	// every PushLogs call.
 	logsMetadataWriters []LogsMetadataWriter
+
+	valuesDropped metric.Int64Counter
+	rowsWritten   metric.Int64Counter
+	insertErrors  metric.Int64Counter
 }
 
 type writeToStatementBatchRecord struct {
@@ -75,7 +117,88 @@ type writeToStatementBatchRecord struct {
 	fprint                 uint64
 	rAttrs                 map[string]any
 	attrs                  map[string]any
+	intrinsics             map[string]string
 	roundedSixHrsUnixMilli int64
+}
+
+// setFingerprint identifies an attribute set by its attributes and its
+// intrinsic fields together. The two hashes are combined in order, so equal
+// maps do not cancel out and swapped maps give a different set.
+func setFingerprint(attrs map[string]any, intrinsics map[string]string) uint64 {
+	fp := fingerprint.FingerprintHash(attrs)
+	if len(intrinsics) == 0 {
+		return fp
+	}
+	return fp ^ (fingerprint.FingerprintHashStrings(intrinsics) + 0x9e3779b97f4a7c15 + (fp << 6) + (fp >> 2))
+}
+
+// intrinsicFieldNames are the keys written to the intrinsic map; their
+// tracker keys are built once.
+var intrinsicFieldNames = []string{
+	"name", "kind_string", "status_code_string", "has_error", "is_remote",
+	"http_method", "http_host", "http_url", "response_status_code", "db_name", "db_operation",
+	"external_http_method", "external_http_url",
+	"severity_text", "severity_number",
+}
+
+var intrinsicTrackerKeys = func() map[string]string {
+	keys := make(map[string]string, len(intrinsicFieldNames))
+	for _, name := range intrinsicFieldNames {
+		keys[name] = intrinsicTrackerPrefix + name
+	}
+	return keys
+}()
+
+func intrinsicTrackerKey(name string) string {
+	if key, ok := intrinsicTrackerKeys[name]; ok {
+		return key
+	}
+	return intrinsicTrackerPrefix + name
+}
+
+// spanIntrinsics returns the span's intrinsic and calculated fields under the
+// names the fields API uses for the span context. Empty calculated fields are
+// left out.
+func spanIntrinsics(span ptrace.Span) map[string]string {
+	c := spanfields.CalculatedFrom(span.Attributes(), span.Kind())
+	hasError := "false"
+	if span.Status().Code() == ptrace.StatusCodeError {
+		hasError = "true"
+	}
+	m := make(map[string]string, 13)
+	m["name"] = span.Name()
+	m["kind_string"] = span.Kind().String()
+	m["status_code_string"] = span.Status().Code().String()
+	m["has_error"] = hasError
+	m["is_remote"] = spanfields.IsRemote(span.Flags())
+	putNonEmpty(m, "http_method", c.HttpMethod)
+	putNonEmpty(m, "http_host", c.HttpHost)
+	putNonEmpty(m, "http_url", c.HttpUrl)
+	putNonEmpty(m, "response_status_code", c.ResponseStatusCode)
+	putNonEmpty(m, "db_name", c.DBName)
+	putNonEmpty(m, "db_operation", c.DBOperation)
+	putNonEmpty(m, "external_http_method", c.ExternalHttpMethod)
+	putNonEmpty(m, "external_http_url", c.ExternalHttpUrl)
+	return m
+}
+
+func putNonEmpty(m map[string]string, key, value string) {
+	if value != "" {
+		m[key] = value
+	}
+}
+
+// logIntrinsics returns the log record's severity fields under the names the
+// fields API uses for the log context.
+func logIntrinsics(lr plog.LogRecord) map[string]string {
+	m := make(map[string]string, 2)
+	if lr.SeverityText() != "" {
+		m["severity_text"] = lr.SeverityText()
+	}
+	if lr.SeverityNumber() != plog.SeverityNumberUnspecified {
+		m["severity_number"] = strconv.Itoa(int(lr.SeverityNumber()))
+	}
+	return m
 }
 
 func flattenJSONToStringMap(data map[string]any) map[string]string {
@@ -94,11 +217,20 @@ func newMetadataExporter(ctx context.Context, cfg Config, set exporter.Settings)
 	if err != nil {
 		return nil, err
 	}
+	if opts.Settings == nil {
+		opts.Settings = clickhouse.Settings{}
+	}
+	if _, ok := opts.Settings[maxExecutionTimeSetting]; !ok && cfg.Timeout > 0 {
+		opts.Settings[maxExecutionTimeSetting] = int(cfg.Timeout.Seconds())
+	}
 	conn, err := clickhouse.Open(opts)
 	if err != nil {
 		return nil, err
 	}
+	return newMetadataExporterWithConn(ctx, cfg, set, conn)
+}
 
+func newMetadataExporterWithConn(ctx context.Context, cfg Config, set exporter.Settings, conn driver.Conn) (*metadataExporter, error) {
 	set.Logger.Info("cache provider", zap.String("provider", string(cfg.Cache.Provider)))
 	var keyCache kash.KeyCache
 	var cacheErr error
@@ -112,9 +244,13 @@ func newMetadataExporter(ctx context.Context, cfg Config, set exporter.Settings)
 			TenantID: cfg.TenantID,
 			Logger:   set.Logger,
 
-			TracesTTL:  sixHours,
-			MetricsTTL: sixHours,
-			LogsTTL:    sixHours,
+			TracesTTL:  cfg.MaxDistinctValues.Traces.Bucket,
+			MetricsTTL: cfg.MaxDistinctValues.Metrics.Bucket,
+			LogsTTL:    cfg.MaxDistinctValues.Logs.Bucket,
+
+			TracesWindow:  cfg.MaxDistinctValues.Traces.Bucket,
+			MetricsWindow: cfg.MaxDistinctValues.Metrics.Bucket,
+			LogsWindow:    cfg.MaxDistinctValues.Logs.Bucket,
 
 			MaxTracesResourceFp:              cfg.Cache.Traces.MaxResources,
 			MaxMetricsResourceFp:             cfg.Cache.Metrics.MaxResources,
@@ -135,9 +271,9 @@ func newMetadataExporter(ctx context.Context, cfg Config, set exporter.Settings)
 			MaxTracesCardinalityPerResource:  cfg.Cache.Traces.MaxCardinalityPerResource,
 			MaxMetricsCardinalityPerResource: cfg.Cache.Metrics.MaxCardinalityPerResource,
 			MaxLogsCardinalityPerResource:    cfg.Cache.Logs.MaxCardinalityPerResource,
-			TracesFingerprintCacheTTL:        sixHours,
-			MetricsFingerprintCacheTTL:       sixHours,
-			LogsFingerprintCacheTTL:          sixHours,
+			TracesFingerprintCacheTTL:        cfg.MaxDistinctValues.Traces.Bucket,
+			MetricsFingerprintCacheTTL:       cfg.MaxDistinctValues.Metrics.Bucket,
+			LogsFingerprintCacheTTL:          cfg.MaxDistinctValues.Logs.Bucket,
 			TenantID:                         cfg.TenantID,
 			Logger:                           set.Logger,
 			TracesMaxTotalCardinality:        cfg.Cache.Traces.MaxTotalCardinality,
@@ -166,6 +302,29 @@ func newMetadataExporter(ctx context.Context, cfg Config, set exporter.Settings)
 		int(cfg.MaxDistinctValues.Logs.MaxStringDistinctValues),
 		valuTrackerKeysTTL,
 	)
+
+	meter := set.MeterProvider.Meter(meterName)
+	valuesDropped, err := meter.Int64Counter(
+		"signoz_metadata_exporter_values_dropped",
+		metric.WithDescription("Attribute values left out of the metadata table, by signal and reason"),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create exporter metrics")
+	}
+	rowsWritten, err := meter.Int64Counter(
+		"signoz_metadata_exporter_rows_written",
+		metric.WithDescription("Rows appended to the metadata table insert, by signal"),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create exporter metrics")
+	}
+	insertErrors, err := meter.Int64Counter(
+		"signoz_metadata_exporter_insert_errors",
+		metric.WithDescription("Failed inserts into the metadata table, by signal"),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create exporter metrics")
+	}
 
 	logTagValueCountCtx, logTagValueCountCtxCancel := context.WithCancel(context.Background())
 	tracesTagValueCountCtx, tracesTagValueCountCtxCancel := context.WithCancel(context.Background())
@@ -211,6 +370,10 @@ func newMetadataExporter(ctx context.Context, cfg Config, set exporter.Settings)
 		alwaysIncludeTracesAttributes:  alwaysIncludeTraces,
 		alwaysIncludeLogsAttributes:    alwaysIncludeLogs,
 		alwaysIncludeMetricsAttributes: alwaysIncludeMetrics,
+
+		valuesDropped: valuesDropped,
+		rowsWritten:   rowsWritten,
+		insertErrors:  insertErrors,
 	}
 
 	e.logTagValueCountFromDB.Store(initMap())
@@ -365,14 +528,36 @@ func (e *metadataExporter) updateTagValueCountFromDB(ctx context.Context, p *upd
 }
 
 func (e *metadataExporter) storeLogTagValues(newValues map[string]tagValueCountFromDB) {
-	e.storeTagValuesAtomic(&e.logTagValueCountFromDB, newValues)
+	e.storeTagValuesAtomic(&e.logTagValueCountFromDB, newValues, e.cfg.MaxDistinctValues.Logs, time.Now())
 }
 
 func (e *metadataExporter) storeTracesTagValues(newValues map[string]tagValueCountFromDB) {
-	e.storeTagValuesAtomic(&e.tracesTagValueCountFromDB, newValues)
+	e.storeTagValuesAtomic(&e.tracesTagValueCountFromDB, newValues, e.cfg.MaxDistinctValues.Traces, time.Now())
 }
 
-func (e *metadataExporter) storeTagValuesAtomic(target *atomic.Pointer[map[string]tagValueCountFromDB], newValues map[string]tagValueCountFromDB) {
+// storeTagValuesAtomic replaces the DB-derived counts. A key found over the
+// limit is marked skipped for skipDecisionTTL, and a previously marked key is
+// carried over while its mark lasts if the new counts no longer put it over
+// the limit; the other exporters stop writing such keys to tag_attributes_v2,
+// which would otherwise re-admit them here on the next refresh.
+func (e *metadataExporter) storeTagValuesAtomic(target *atomic.Pointer[map[string]tagValueCountFromDB], newValues map[string]tagValueCountFromDB, limits LimitsConfig, now time.Time) {
+	for key, val := range newValues {
+		if val.exceeds(limits) {
+			val.skippedUntil = now.Add(skipDecisionTTL)
+			newValues[key] = val
+		}
+	}
+	if prev := target.Load(); prev != nil {
+		for key, val := range *prev {
+			if !val.skippedUntil.After(now) {
+				continue
+			}
+			if cur, ok := newValues[key]; ok && cur.exceeds(limits) {
+				continue
+			}
+			newValues[key] = val
+		}
+	}
 	target.Store(&newValues)
 }
 
@@ -427,80 +612,43 @@ func (e *metadataExporter) shouldSkipAttributeFromDB(_ context.Context, key, dat
 	if !ok {
 		return false
 	}
-
-	switch val.tagDataType {
-	case "string":
-		return val.stringTagValueCount > cfgMax.MaxStringDistinctValues
-	case "float64", "int64":
-		return true
-	}
-	return false
+	return val.exceeds(cfgMax)
 }
 
-func makeUVTKey(key, datasource string) string {
-	builder := strings.Builder{}
-	builder.Grow(len(key) + 1 + len(datasource))
-	builder.WriteString(key)
-	builder.WriteByte(':')
-	builder.WriteString(datasource)
-	return builder.String()
-}
-
-// addToUVT adds a value to the unique value tracker
-func (e *metadataExporter) addToUVT(_ context.Context, key string, value any, datasource string) {
+// signalGuards returns the value tracker, the always-include set and the
+// limits for the signal. ok is false for an unknown signal.
+func (e *metadataExporter) signalGuards(datasource string) (tracker *ValueTracker, alwaysInclude map[string]struct{}, limits LimitsConfig, ok bool) {
 	switch datasource {
 	case pipeline.SignalTraces.String():
-		e.tracesTracker.AddValue(key, value)
+		return e.tracesTracker, e.alwaysIncludeTracesAttributes, e.cfg.MaxDistinctValues.Traces, true
 	case pipeline.SignalMetrics.String():
-		e.metricsTracker.AddValue(key, value)
+		return e.metricsTracker, e.alwaysIncludeMetricsAttributes, e.cfg.MaxDistinctValues.Metrics, true
 	case pipeline.SignalLogs.String():
-		e.logsTracker.AddValue(key, value)
+		return e.logsTracker, e.alwaysIncludeLogsAttributes, e.cfg.MaxDistinctValues.Logs, true
 	}
+	return nil, nil, LimitsConfig{}, false
 }
 
 // shouldSkipAttributeUVT checks if an attribute should be skipped based on the unique value tracker
 func (e *metadataExporter) shouldSkipAttributeUVT(_ context.Context, key, datasource string) bool {
-	typ := e.getType(key, datasource)
-	var cnt int
-
-	switch datasource {
-	case pipeline.SignalTraces.String():
-		if _, ok := e.alwaysIncludeTracesAttributes[key]; ok {
-			return false
-		}
-		cnt = e.tracesTracker.GetUniqueValueCount(makeUVTKey(key, datasource))
-		if typ == utils.FieldDataTypeString.String() && e.cfg.MaxDistinctValues.Traces.MaxStringDistinctValues > 0 && cnt > int(e.cfg.MaxDistinctValues.Traces.MaxStringDistinctValues) {
-			return true
-		}
-		if typ == utils.FieldDataTypeFloat64.String() {
-			return true
-		}
-
-	case pipeline.SignalMetrics.String():
-		if _, ok := e.alwaysIncludeMetricsAttributes[key]; ok {
-			return false
-		}
-		cnt = e.metricsTracker.GetUniqueValueCount(makeUVTKey(key, datasource))
-		if typ == utils.FieldDataTypeString.String() && e.cfg.MaxDistinctValues.Metrics.MaxStringDistinctValues > 0 && cnt > int(e.cfg.MaxDistinctValues.Metrics.MaxStringDistinctValues) {
-			return true
-		}
-		if typ == utils.FieldDataTypeFloat64.String() {
-			return true
-		}
-
-	case pipeline.SignalLogs.String():
-		if _, ok := e.alwaysIncludeLogsAttributes[key]; ok {
-			return false
-		}
-		cnt = e.logsTracker.GetUniqueValueCount(makeUVTKey(key, datasource))
-		if typ == utils.FieldDataTypeString.String() && e.cfg.MaxDistinctValues.Logs.MaxStringDistinctValues > 0 && cnt > int(e.cfg.MaxDistinctValues.Logs.MaxStringDistinctValues) {
-			return true
-		}
-		if typ == utils.FieldDataTypeFloat64.String() {
-			return true
-		}
+	tracker, alwaysInclude, _, ok := e.signalGuards(datasource)
+	if !ok {
+		return false
 	}
-	return false
+	if _, ok := alwaysInclude[key]; ok {
+		return false
+	}
+	if e.getType(key, datasource) == utils.FieldDataTypeFloat64.String() {
+		return true
+	}
+	return tracker.IsOverLimit(key)
+}
+
+func (e *metadataExporter) recordDrop(ctx context.Context, datasource, reason string) {
+	e.valuesDropped.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("signal", datasource),
+		attribute.String("reason", reason),
+	))
 }
 
 func removeDuplicateRecords(records []writeToStatementBatchRecord) []writeToStatementBatchRecord {
@@ -608,15 +756,17 @@ func (e *metadataExporter) writeToStatementBatch(ctx context.Context, stmt drive
 		}
 
 		for _, nr := range newRecords {
-			// TODO: handle error
-			_ = stmt.Append(
+			if err := stmt.Append(
 				nr.roundedSixHrsUnixMilli,
 				ds,
 				nr.resourceFingerprint,
 				nr.fprint,
 				flattenJSONToStringMap(nr.rAttrs),
 				flattenJSONToStringMap(nr.attrs),
-			)
+				nr.intrinsics,
+			); err != nil {
+				e.set.Logger.Debug("failed to append record", zap.Error(err), zap.String("datasource", ds.String()))
+			}
 		}
 
 		// We'll accumulate how many new records we wrote
@@ -638,8 +788,10 @@ func (e *metadataExporter) writeToStatementBatch(ctx context.Context, stmt drive
 
 	stmtStart := time.Now()
 	if err := stmt.Send(); err != nil {
+		e.insertErrors.Add(ctx, 1, metric.WithAttributes(attribute.String("signal", ds.String())))
 		return totalWrites, err
 	}
+	e.rowsWritten.Add(ctx, int64(totalWrites), metric.WithAttributes(attribute.String("signal", ds.String())))
 	stmtDuration := time.Since(stmtStart)
 	e.set.Logger.Debug("stmtDuration",
 		zap.Int64("duration", stmtDuration.Milliseconds()),
@@ -650,37 +802,127 @@ func (e *metadataExporter) writeToStatementBatch(ctx context.Context, stmt drive
 	return totalWrites, nil
 }
 
-// filterAttrs filters attributes based on the unique value tracker
+// filterAttrs removes the attributes that must not reach the metadata table:
+// keys the value tracker has flagged, empty strings, strings over
+// max_string_length (the key is then flagged so its shorter values are dropped
+// too), keys whose DB-derived type is float64, and string or numeric values
+// that take a key past max_string_distinct_values. Bools are passed through.
 func (e *metadataExporter) filterAttrs(ctx context.Context, attrs map[string]any, datasource string) map[string]any {
+	return e.filterValues(ctx, attrs, datasource)
+}
 
-	var maxLen int
-	switch datasource {
-	case pipeline.SignalTraces.String():
-		maxLen = int(e.cfg.MaxDistinctValues.Traces.MaxStringLength)
-	case pipeline.SignalLogs.String():
-		maxLen = int(e.cfg.MaxDistinctValues.Logs.MaxStringLength)
-	case pipeline.SignalMetrics.String():
-		maxLen = int(e.cfg.MaxDistinctValues.Metrics.MaxStringLength)
+// filterIntrinsics applies the attribute rules to the intrinsic field map. An
+// oversized value is dropped from its row only: one long span name must not
+// take the name field out of every other span.
+func (e *metadataExporter) filterIntrinsics(ctx context.Context, fields map[string]string, datasource string) map[string]string {
+	tracker, alwaysInclude, limits, ok := e.signalGuards(datasource)
+	if !ok {
+		return fields
 	}
+	maxLen := int(limits.MaxStringLength)
+
+	for k, v := range fields {
+		if _, ok := alwaysInclude[k]; ok {
+			continue
+		}
+		trackerKey := intrinsicTrackerKey(k)
+		if tracker.IsOverLimit(trackerKey) {
+			delete(fields, k)
+			e.recordDrop(ctx, datasource, dropReasonCardinality)
+			continue
+		}
+		if len(v) == 0 {
+			delete(fields, k)
+			continue
+		}
+		if len(v) > maxLen {
+			delete(fields, k)
+			e.recordDrop(ctx, datasource, dropReasonOversized)
+			continue
+		}
+		if tracker.AddString(trackerKey, v) {
+			delete(fields, k)
+			e.recordDrop(ctx, datasource, dropReasonCardinality)
+		}
+	}
+	return fields
+}
+
+func (e *metadataExporter) filterValues(ctx context.Context, attrs map[string]any, datasource string) map[string]any {
+	tracker, alwaysInclude, limits, ok := e.signalGuards(datasource)
+	if !ok {
+		return attrs
+	}
+	maxLen := int(limits.MaxStringLength)
 
 	for k, v := range attrs {
-		// if the attribute should be skipped, remove it
-		if e.shouldSkipAttributeUVT(ctx, k, datasource) {
+		if _, ok := alwaysInclude[k]; ok {
+			continue
+		}
+		if e.getType(k, datasource) == utils.FieldDataTypeFloat64.String() || tracker.IsOverLimit(k) {
 			delete(attrs, k)
+			e.recordDrop(ctx, datasource, dropReasonCardinality)
 			continue
 		}
 		switch v := v.(type) {
 		case string:
-			if len(v) == 0 || len(v) > maxLen {
+			if len(v) == 0 {
+				delete(attrs, k)
+				e.recordDrop(ctx, datasource, dropReasonEmpty)
 				continue
 			}
-			e.addToUVT(ctx, makeUVTKey(k, datasource), v, datasource)
-		default:
-			// boolean, numbers would be skipped by the shouldSkipAttributeUVT
-			continue
+			if len(v) > maxLen {
+				tracker.MarkOverLimit(k)
+				delete(attrs, k)
+				e.recordDrop(ctx, datasource, dropReasonOversized)
+				continue
+			}
+			if tracker.AddString(k, v) {
+				delete(attrs, k)
+				e.recordDrop(ctx, datasource, dropReasonCardinality)
+			}
+		case int64, float64:
+			if tracker.AddValue(k, v) {
+				delete(attrs, k)
+				e.recordDrop(ctx, datasource, dropReasonCardinality)
+			}
 		}
 	}
 	return attrs
+}
+
+// filterResourceAttrs removes resource attribute values longer than
+// max_resource_string_length unless the key is in always_include_attributes.
+func (e *metadataExporter) filterResourceAttrs(ctx context.Context, attrs map[string]any, datasource string) map[string]any {
+	_, alwaysInclude, limits, ok := e.signalGuards(datasource)
+	if !ok {
+		return attrs
+	}
+	maxLen := int(limits.MaxResourceStringLength)
+
+	for k, v := range attrs {
+		s, isString := v.(string)
+		if !isString || len(s) <= maxLen {
+			continue
+		}
+		if _, ok := alwaysInclude[k]; ok {
+			continue
+		}
+		delete(attrs, k)
+		e.recordDrop(ctx, datasource, dropReasonResourceOversized)
+	}
+	return attrs
+}
+
+// bucketStart returns the start of the write bucket that holds ts. A zero
+// timestamp, one older than the metadata retention or one more than
+// maxFutureSkew ahead of now is replaced by now.
+func bucketStart(ts, now time.Time, bucket time.Duration) int64 {
+	if ts.IsZero() || ts.Unix() == 0 || ts.Before(now.Add(-metadataRetention)) || ts.After(now.Add(maxFutureSkew)) {
+		ts = now
+	}
+	bucketMs := bucket.Milliseconds()
+	return (ts.UnixMilli() / bucketMs) * bucketMs
 }
 
 func (e *metadataExporter) PushTraces(ctx context.Context, td ptrace.Traces) error {
@@ -696,6 +938,7 @@ func (e *metadataExporter) PushTraces(ctx context.Context, td ptrace.Traces) err
 
 	totalSpans := 0
 	records := make([]writeToStatementBatchRecord, 0)
+	now := time.Now()
 
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
@@ -708,7 +951,7 @@ func (e *metadataExporter) PushTraces(ctx context.Context, td ptrace.Traces) err
 			resourceAttrs[k] = v.AsRaw()
 			return true
 		})
-		flattenedResourceAttrs := flatten.FlattenJSON(resourceAttrs, "")
+		flattenedResourceAttrs := e.filterResourceAttrs(ctx, flatten.FlattenJSON(resourceAttrs, ""), pipeline.SignalTraces.String())
 		resourceFingerprint := fingerprint.FingerprintHash(flattenedResourceAttrs)
 
 		scopeSpans := rs.ScopeSpans()
@@ -726,20 +969,25 @@ func (e *metadataExporter) PushTraces(ctx context.Context, td ptrace.Traces) err
 					spanAttrs[attrKey] = v.AsRaw()
 					return true
 				})
-				spanAttrs["name"] = span.Name()
+				intrinsics := e.filterIntrinsics(ctx, spanIntrinsics(span), pipeline.SignalTraces.String())
 
 				flattenedSpanAttrs := flatten.FlattenJSON(spanAttrs, "")
 				filteredSpanAttrs := e.filterAttrs(ctx, flattenedSpanAttrs, pipeline.SignalTraces.String())
-				spanFingerprint := fingerprint.FingerprintHash(filteredSpanAttrs)
+				// The span name stays in attributes until the query side reads
+				// intrinsic_attributes.
+				if name, ok := intrinsics["name"]; ok {
+					filteredSpanAttrs["name"] = name
+				}
+				spanFingerprint := setFingerprint(filteredSpanAttrs, intrinsics)
 
-				unixMilli := span.StartTimestamp().AsTime().UnixMilli()
-				roundedSixHrsUnixMilli := (unixMilli / sixHoursInMs) * sixHoursInMs
+				roundedSixHrsUnixMilli := bucketStart(span.StartTimestamp().AsTime(), now, e.cfg.MaxDistinctValues.Traces.Bucket)
 
 				records = append(records, writeToStatementBatchRecord{
 					resourceFingerprint:    resourceFingerprint,
 					fprint:                 spanFingerprint,
 					rAttrs:                 flattenedResourceAttrs,
 					attrs:                  filteredSpanAttrs,
+					intrinsics:             intrinsics,
 					roundedSixHrsUnixMilli: roundedSixHrsUnixMilli,
 				})
 			}
@@ -768,6 +1016,7 @@ func (e *metadataExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) 
 
 	totalDps := 0
 	records := make([]writeToStatementBatchRecord, 0)
+	now := time.Now()
 
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
@@ -777,7 +1026,7 @@ func (e *metadataExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) 
 			resourceAttrs[k] = v.AsRaw()
 			return true
 		})
-		flattenedResourceAttrs := flatten.FlattenJSON(resourceAttrs, "")
+		flattenedResourceAttrs := e.filterResourceAttrs(ctx, flatten.FlattenJSON(resourceAttrs, ""), pipeline.SignalMetrics.String())
 		resourceFingerprint := fingerprint.FingerprintHash(flattenedResourceAttrs)
 
 		scopeMetrics := rm.ScopeMetrics()
@@ -826,10 +1075,9 @@ func (e *metadataExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) 
 						return true
 					})
 
-					flattenedMetricAttrs := flatten.FlattenJSON(metricAttrs, "")
+					flattenedMetricAttrs := e.filterAttrs(ctx, flatten.FlattenJSON(metricAttrs, ""), pipeline.SignalMetrics.String())
 					metricFingerprint := fingerprint.FingerprintHash(flattenedMetricAttrs)
-					unixMilli := time.Now().UnixMilli()
-					roundedSixHrsUnixMilli := (unixMilli / sixHoursInMs) * sixHoursInMs
+					roundedSixHrsUnixMilli := bucketStart(now, now, e.cfg.MaxDistinctValues.Metrics.Bucket)
 
 					records = append(records, writeToStatementBatchRecord{
 						resourceFingerprint:    resourceFingerprint,

--- a/exporter/metadataexporter/exporter_test.go
+++ b/exporter/metadataexporter/exporter_test.go
@@ -1,0 +1,439 @@
+package metadataexporter
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/SigNoz/signoz-otel-collector/exporter/metadataexporter/internal/metadata"
+)
+
+// capturedRow is one row appended to the attributes_metadata insert.
+type capturedRow struct {
+	unixMilli     int64
+	signal        string
+	resourceAttrs map[string]string
+	attrs         map[string]string
+	intrinsics    map[string]string
+}
+
+type fakeBatch struct {
+	driver.Batch
+	conn *fakeConn
+}
+
+func (b *fakeBatch) Append(v ...any) error {
+	b.conn.rows = append(b.conn.rows, capturedRow{
+		unixMilli:     v[0].(int64),
+		signal:        v[1].(pipeline.Signal).String(),
+		resourceAttrs: v[4].(map[string]string),
+		attrs:         v[5].(map[string]string),
+		intrinsics:    v[6].(map[string]string),
+	})
+	return nil
+}
+
+func (b *fakeBatch) Send() error  { return nil }
+func (b *fakeBatch) Close() error { return nil }
+
+// fakeConn records the rows of every batch prepared on it.
+type fakeConn struct {
+	driver.Conn
+	rows []capturedRow
+}
+
+func (c *fakeConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return &fakeBatch{conn: c}, nil
+}
+
+func (c *fakeConn) Close() error { return nil }
+
+func newTestExporter(t *testing.T, configure func(cfg *Config)) (*metadataExporter, *fakeConn) {
+	t.Helper()
+	cfg := createDefaultConfig().(*Config)
+	cfg.Enabled = true
+	if configure != nil {
+		configure(cfg)
+	}
+	conn := &fakeConn{}
+	e, err := newMetadataExporterWithConn(context.Background(), *cfg, exportertest.NewNopSettings(metadata.Type), conn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Shutdown(context.Background()) })
+	return e, conn
+}
+
+func attrValues(rows []capturedRow, key string) []string {
+	values := []string{}
+	for _, row := range rows {
+		if v, ok := row.attrs[key]; ok {
+			values = append(values, v)
+		}
+	}
+	return values
+}
+
+func newSpan(t *testing.T, td ptrace.Traces, name string, start time.Time, attrs map[string]any) ptrace.Span {
+	t.Helper()
+	var rs ptrace.ResourceSpans
+	if td.ResourceSpans().Len() == 0 {
+		rs = td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", "checkout")
+		rs.ScopeSpans().AppendEmpty()
+	} else {
+		rs = td.ResourceSpans().At(0)
+	}
+	span := rs.ScopeSpans().At(0).Spans().AppendEmpty()
+	span.SetName(name)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	require.NoError(t, span.Attributes().FromRaw(attrs))
+	return span
+}
+
+func TestPushTracesDropsOversizedValuesAndKeepsTheKeyOut(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxStringLength = 16
+	})
+	now := time.Now()
+
+	td := ptrace.NewTraces()
+	newSpan(t, td, "GET /users", now, map[string]any{"payload": strings.Repeat("p", 64), "http.route": "/users"})
+	newSpan(t, td, "GET /orders", now, map[string]any{"payload": "short", "http.route": "/orders", "empty": ""})
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	require.Len(t, conn.rows, 2)
+	assert.Empty(t, attrValues(conn.rows, "payload"), "the key is dropped from the row after an oversized value and from later rows with short values")
+	assert.Empty(t, attrValues(conn.rows, "empty"), "empty values are not written")
+	assert.ElementsMatch(t, []string{"/users", "/orders"}, attrValues(conn.rows, "http.route"))
+	assert.ElementsMatch(t, []string{"GET /users", "GET /orders"}, attrValues(conn.rows, "name"))
+}
+
+func TestPushTracesDropsKeyPastTheDistinctValueLimit(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxStringDistinctValues = 3
+	})
+	now := time.Now()
+
+	td := ptrace.NewTraces()
+	for _, id := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		newSpan(t, td, "GET /users", now, map[string]any{"aws.request_id": id})
+	}
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	assert.ElementsMatch(t, []string{"r1", "r2", "r3"}, attrValues(conn.rows, "aws.request_id"), "values past the limit are not written")
+	require.Len(t, conn.rows, 4, "spans without the key collapse into one row")
+
+	td = ptrace.NewTraces()
+	newSpan(t, td, "GET /users", now, map[string]any{"aws.request_id": "r1"})
+	require.NoError(t, e.PushTraces(context.Background(), td))
+	assert.Len(t, conn.rows, 4, "a value seen before the limit is also dropped once the key is over the limit")
+}
+
+func TestPushTracesTracksNumericIds(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxStringDistinctValues = 2
+	})
+	now := time.Now()
+
+	td := ptrace.NewTraces()
+	for id := int64(1); id <= 5; id++ {
+		newSpan(t, td, "GET /users", now, map[string]any{"task.id": id, "retry": false})
+	}
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	assert.Len(t, conn.rows, 3, "two sets carry a task.id, the rest collapse into one set without it")
+}
+
+func TestPushTracesDropsOversizedResourceValues(t *testing.T) {
+	arn := "arn:aws:ecs:us-east-1:123456789012:task/prod-cluster/0123456789abcdef0123456789abcdef"
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxResourceStringLength = 32
+		cfg.AlwaysIncludeAttributes.Traces = []string{"aws.log.group.arn"}
+	})
+
+	td := ptrace.NewTraces()
+	newSpan(t, td, "GET /users", time.Now(), nil)
+	resource := td.ResourceSpans().At(0).Resource().Attributes()
+	resource.PutStr("aws.ecs.task.arn", arn)
+	resource.PutStr("aws.log.group.arn", arn)
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	require.Len(t, conn.rows, 1)
+	assert.Equal(t, map[string]string{"service.name": "checkout", "aws.log.group.arn": arn}, conn.rows[0].resourceAttrs)
+}
+
+func TestPushTracesClampsTimestampsToTheBucket(t *testing.T) {
+	e, conn := newTestExporter(t, nil)
+	now := time.Now()
+	bucket := e.cfg.MaxDistinctValues.Traces.Bucket
+	current := now.UnixMilli() / bucket.Milliseconds() * bucket.Milliseconds()
+	earlier := now.Add(-2 * bucket)
+	earlierBucket := earlier.UnixMilli() / bucket.Milliseconds() * bucket.Milliseconds()
+
+	td := ptrace.NewTraces()
+	newSpan(t, td, "in-range", earlier, map[string]any{"case": "in-range"})
+	newSpan(t, td, "unset", time.Time{}, map[string]any{"case": "unset"}).SetStartTimestamp(0)
+	newSpan(t, td, "epoch", time.Unix(0, 0), map[string]any{"case": "epoch"})
+	newSpan(t, td, "future", now.Add(48*time.Hour), map[string]any{"case": "future"})
+	newSpan(t, td, "expired", now.Add(-metadataRetention-time.Hour), map[string]any{"case": "expired"})
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	got := map[string]int64{}
+	for _, row := range conn.rows {
+		got[row.attrs["case"]] = row.unixMilli
+	}
+	assert.Equal(t, map[string]int64{
+		"in-range": earlierBucket,
+		"unset":    current,
+		"epoch":    current,
+		"future":   current,
+		"expired":  current,
+	}, got)
+}
+
+func TestPushTracesKeepsKeyOutAfterTheDBCountFallsUnderTheLimit(t *testing.T) {
+	e, conn := newTestExporter(t, nil)
+	now := time.Now()
+	push := func() {
+		td := ptrace.NewTraces()
+		newSpan(t, td, "GET /users", now, map[string]any{"aws.request_id": "r1", "http.route": "/users"})
+		require.NoError(t, e.PushTraces(context.Background(), td))
+	}
+
+	e.storeTracesTagValues(map[string]tagValueCountFromDB{
+		"aws.request_id": {tagDataType: "string", stringTagValueCount: 5000},
+	})
+	push()
+	e.storeTracesTagValues(map[string]tagValueCountFromDB{
+		"aws.request_id": {tagDataType: "string", stringTagValueCount: 10},
+	})
+	push()
+	e.storeTracesTagValues(map[string]tagValueCountFromDB{})
+	push()
+
+	require.Len(t, conn.rows, 1, "the same set is written once")
+	assert.Empty(t, attrValues(conn.rows, "aws.request_id"), "a key found over the limit stays out when later counts are under it")
+	assert.Equal(t, []string{"/users"}, attrValues(conn.rows, "http.route"))
+}
+
+func TestPushMetricsFiltersAttributesAndUsesTheMetricsBucket(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Metrics.MaxStringLength = 16
+		cfg.MaxDistinctValues.Metrics.MaxResourceStringLength = 16
+	})
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("host.name", "node-1")
+	rm.Resource().Attributes().PutStr("os.description", strings.Repeat("Linux 6.1 ", 8))
+	metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("system.disk.io")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("device", "disk0")
+	dp.Attributes().PutStr("mount.options", strings.Repeat("rw,", 20))
+	require.NoError(t, e.PushMetrics(context.Background(), md))
+
+	require.Len(t, conn.rows, 1)
+	row := conn.rows[0]
+	assert.Equal(t, "metrics", row.signal)
+	assert.Equal(t, map[string]string{"device": "disk0"}, row.attrs)
+	assert.Equal(t, map[string]string{"host.name": "node-1"}, row.resourceAttrs)
+	assert.Zero(t, row.unixMilli%DefaultMetricsBucket.Milliseconds(), "metrics rows are written per metrics bucket")
+}
+
+func TestPushLogsUsesTheObservedTimestampWhenTheTimestampIsUnset(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Logs.MaxStringLength = 16
+	})
+	bucket := e.cfg.MaxDistinctValues.Logs.Bucket
+	observed := time.Now().Add(-3 * bucket)
+	observedBucket := observed.UnixMilli() / bucket.Milliseconds() * bucket.Milliseconds()
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "checkout")
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(observed))
+	lr.Attributes().PutStr("log.level", "error")
+	lr.Attributes().PutStr("stacktrace", strings.Repeat("at frame\n", 10))
+	require.NoError(t, e.PushLogs(context.Background(), ld))
+
+	require.Len(t, conn.rows, 1)
+	assert.Equal(t, "logs", conn.rows[0].signal)
+	assert.Equal(t, observedBucket, conn.rows[0].unixMilli)
+	assert.Equal(t, map[string]string{"log.level": "error"}, conn.rows[0].attrs)
+}
+
+func TestConfigValidateRejectsAZeroBucket(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, cfg.Validate())
+
+	cfg.MaxDistinctValues.Metrics.Bucket = 0
+	assert.ErrorContains(t, cfg.Validate(), "metrics::bucket")
+}
+
+func TestPushTracesWritesIntrinsicFields(t *testing.T) {
+	e, conn := newTestExporter(t, nil)
+
+	td := ptrace.NewTraces()
+	span := newSpan(t, td, "POST /charge", time.Now(), map[string]any{
+		"http.method":      "POST",
+		"http.url":         "https://payments.example.com/charge",
+		"http.status_code": int64(502),
+		"db.name":          "orders",
+	})
+	span.SetKind(ptrace.SpanKindClient)
+	span.Status().SetCode(ptrace.StatusCodeError)
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	require.Len(t, conn.rows, 1)
+	assert.Equal(t, map[string]string{
+		"name":                 "POST /charge",
+		"kind_string":          "Client",
+		"status_code_string":   "Error",
+		"has_error":            "true",
+		"is_remote":            "unknown",
+		"http_method":          "POST",
+		"http_host":            "payments.example.com",
+		"http_url":             "https://payments.example.com/charge",
+		"response_status_code": "502",
+		"db_name":              "orders",
+		"external_http_method": "POST",
+		"external_http_url":    "payments.example.com",
+	}, conn.rows[0].intrinsics)
+	assert.Equal(t, map[string]string{
+		"name":        "POST /charge",
+		"http.method": "POST",
+		"http.url":    "https://payments.example.com/charge",
+		"db.name":     "orders",
+	}, conn.rows[0].attrs, "the span name is still written to attributes; calculated fields are not")
+}
+
+func TestPushTracesIntrinsicFieldsTellSetsApart(t *testing.T) {
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxStringLength = 16
+	})
+	now := time.Now()
+
+	td := ptrace.NewTraces()
+	newSpan(t, td, "GET /users", now, map[string]any{"http.route": "/users"})
+	newSpan(t, td, "GET /users", now, map[string]any{"http.route": "/users"}).Status().SetCode(ptrace.StatusCodeError)
+	newSpan(t, td, strings.Repeat("n", 32), now, map[string]any{"http.route": "/users"})
+	newSpan(t, td, "GET /orders", now, map[string]any{"http.route": "/users"})
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	require.Len(t, conn.rows, 4, "same attributes with different intrinsic fields are different sets")
+	names := []string{}
+	for _, row := range conn.rows {
+		names = append(names, row.intrinsics["name"])
+	}
+	assert.ElementsMatch(t, []string{"GET /users", "GET /users", "", "GET /orders"}, names, "an oversized name is dropped from its row without taking the field out of later rows")
+}
+
+func TestPushLogsWritesSeverityFields(t *testing.T) {
+	e, conn := newTestExporter(t, nil)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "checkout")
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	lr.SetSeverityText("ERROR")
+	lr.SetSeverityNumber(plog.SeverityNumberError)
+	lr.Attributes().PutStr("logger", "payments")
+	require.NoError(t, e.PushLogs(context.Background(), ld))
+
+	require.Len(t, conn.rows, 1)
+	assert.Equal(t, map[string]string{"severity_text": "ERROR", "severity_number": "17"}, conn.rows[0].intrinsics)
+	assert.Equal(t, map[string]string{"logger": "payments"}, conn.rows[0].attrs)
+}
+
+func TestPushLogsTellsApartSetsWhoseAttributesEqualTheirIntrinsics(t *testing.T) {
+	e, conn := newTestExporter(t, nil)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "checkout")
+	for _, severity := range []string{"INFO", "ERROR"} {
+		lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		lr.SetSeverityText(severity)
+		lr.Attributes().PutStr("severity_text", severity)
+	}
+	require.NoError(t, e.PushLogs(context.Background(), ld))
+
+	require.Len(t, conn.rows, 2, "sets whose attribute map equals their intrinsic map must not share a fingerprint")
+}
+
+func TestConfigValidateRejectsASubMillisecondBucket(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.MaxDistinctValues.Logs.Bucket = time.Microsecond
+	assert.ErrorContains(t, cfg.Validate(), "logs::bucket")
+}
+
+func BenchmarkPushTracesRepeatedValues(b *testing.B) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Enabled = true
+	conn := &fakeConn{}
+	e, err := newMetadataExporterWithConn(context.Background(), *cfg, exportertest.NewNopSettings(metadata.Type), conn)
+	require.NoError(b, err)
+	defer func() { _ = e.Shutdown(context.Background()) }()
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "checkout")
+	rs.Resource().Attributes().PutStr("deployment.environment", "prod")
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+	now := time.Now()
+	for i := 0; i < 1000; i++ {
+		span := spans.AppendEmpty()
+		span.SetName("GET /users/{id}")
+		span.SetKind(ptrace.SpanKindServer)
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(now))
+		attrs := span.Attributes()
+		attrs.PutStr("http.method", "GET")
+		attrs.PutStr("http.route", "/users/{id}")
+		attrs.PutStr("http.status_code", "200")
+		attrs.PutStr("db.system", "postgresql")
+		attrs.PutStr("db.operation", "SELECT")
+		attrs.PutStr("rpc.service", "users")
+		attrs.PutStr("user.tier", "free")
+		attrs.PutStr("region", "us-east-1")
+		attrs.PutStr("feature.flag", "flag-"+strconv.Itoa(i%20))
+		attrs.PutStr("queue.name", "q-"+strconv.Itoa(i%5))
+	}
+	require.NoError(b, e.PushTraces(context.Background(), td))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = e.PushTraces(context.Background(), td)
+	}
+}
+
+func TestPushTracesKeepsAnAlwaysIncludedIntrinsicFieldWhateverItsLength(t *testing.T) {
+	name := strings.Repeat("GET /very/long/route/", 5)
+	e, conn := newTestExporter(t, func(cfg *Config) {
+		cfg.MaxDistinctValues.Traces.MaxStringLength = 16
+		cfg.AlwaysIncludeAttributes.Traces = []string{"name"}
+	})
+
+	td := ptrace.NewTraces()
+	newSpan(t, td, name, time.Now(), nil)
+	require.NoError(t, e.PushTraces(context.Background(), td))
+
+	require.Len(t, conn.rows, 1)
+	assert.Equal(t, name, conn.rows[0].intrinsics["name"])
+	assert.Equal(t, name, conn.rows[0].attrs["name"])
+}

--- a/exporter/metadataexporter/factory.go
+++ b/exporter/metadataexporter/factory.go
@@ -19,6 +19,18 @@ const (
 	DefaultMaxResources              = 8192
 	DefaultMaxCardinalityPerResource = 2048
 	DefaultMaxTotalCardinality       = 3_000_000
+
+	// DefaultTimeout bounds one INSERT into the metadata table; it is also
+	// applied as max_execution_time on the ClickHouse connection.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultBucket is the write window for traces and logs sets.
+	DefaultBucket = 6 * time.Hour
+	// DefaultMetricsBucket is the write window for metrics sets. It matches
+	// the six-hour floor the fields API applies to a request start; a longer
+	// bucket (metric sets are long-lived) needs the reader to floor the start
+	// to it first.
+	DefaultMetricsBucket = 6 * time.Hour
 )
 
 // NewFactory creates Metadata exporter factory.
@@ -35,7 +47,7 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		TimeoutConfig:    exporterhelper.TimeoutConfig{Timeout: DefaultTimeout},
 		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 		DSN:              "tcp://localhost:9000",
@@ -43,20 +55,26 @@ func createDefaultConfig() component.Config {
 			Traces: LimitsConfig{
 				MaxKeys:                 4096,
 				MaxStringLength:         64,
+				MaxResourceStringLength: 64,
 				MaxStringDistinctValues: 2048,
 				FetchInterval:           15 * time.Minute,
+				Bucket:                  DefaultBucket,
 			},
 			Logs: LimitsConfig{
 				MaxKeys:                 4096,
 				MaxStringLength:         64,
+				MaxResourceStringLength: 64,
 				MaxStringDistinctValues: 2048,
 				FetchInterval:           15 * time.Minute,
+				Bucket:                  DefaultBucket,
 			},
 			Metrics: LimitsConfig{
 				MaxKeys:                 4096,
 				MaxStringLength:         64,
+				MaxResourceStringLength: 64,
 				MaxStringDistinctValues: 2048,
 				FetchInterval:           15 * time.Minute,
+				Bucket:                  DefaultMetricsBucket,
 			},
 		},
 		Cache: CacheConfig{
@@ -108,6 +126,7 @@ func (f *metadataExporterFactory) createTracesExporter(
 		&oCfg,
 		exp.PushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.BackOffConfig),
 		exporterhelper.WithQueue(oCfg.QueueBatchConfig),
 		exporterhelper.WithStart(exp.Start),
@@ -130,6 +149,7 @@ func (f *metadataExporterFactory) createMetricsExporter(
 		&oCfg,
 		exp.PushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.BackOffConfig),
 		exporterhelper.WithQueue(oCfg.QueueBatchConfig),
 		exporterhelper.WithStart(exp.Start),
@@ -152,6 +172,7 @@ func (f *metadataExporterFactory) createLogsExporter(
 		&oCfg,
 		exp.PushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.BackOffConfig),
 		exporterhelper.WithQueue(oCfg.QueueBatchConfig),
 		exporterhelper.WithStart(exp.Start),

--- a/exporter/metadataexporter/json_writer.go
+++ b/exporter/metadataexporter/json_writer.go
@@ -265,7 +265,7 @@ func (w *jsonMetadataWriter) skipStoringInDB(key string) bool {
 // this key already exceeds the configured limit. Unlike the parent exporter's
 // implementation it does NOT unconditionally skip number or bool keys.
 func (w *jsonMetadataWriter) skipUVT(key string) bool {
-	return w.valueTracker.GetUniqueValueCount(key) > int(w.limits.MaxStringDistinctValues)
+	return w.valueTracker.IsOverLimit(key)
 }
 
 func (w *jsonMetadataWriter) Process(ctx context.Context, ld plog.Logs) error {
@@ -281,7 +281,7 @@ func (w *jsonMetadataWriter) Process(ctx context.Context, ld plog.Logs) error {
 		stmt:             vaStmt,
 		shouldSkipFromDB: w.skipStoringInDB,
 		shouldSkipUVT:    w.skipUVT,
-		addToUVT:         w.valueTracker.AddValue,
+		addToUVT:         func(key string, value any) { w.valueTracker.AddValue(key, value) },
 	}
 
 	rls := ld.ResourceLogs()

--- a/exporter/metadataexporter/testdata/config.yaml
+++ b/exporter/metadataexporter/testdata/config.yaml
@@ -3,6 +3,7 @@ metadataexporter:
     traces:
       max_keys: 100
       max_string_length: 128
+      max_resource_string_length: 256
       max_string_distinct_values: 420
       fetch_interval: 5m
     metrics:
@@ -10,6 +11,7 @@ metadataexporter:
       max_string_length: 16
       max_string_distinct_values: 1024
       fetch_interval: 5m
+      bucket: 12h
     logs:
       max_keys: 100
       max_string_length: 64

--- a/exporter/metadataexporter/vt.go
+++ b/exporter/metadataexporter/vt.go
@@ -1,25 +1,53 @@
 package metadataexporter
 
 import (
+	"fmt"
+	"strconv"
+	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jellydator/ttlcache/v3"
 )
 
+// trackedValues is the set of distinct values seen for one key. Once the set
+// grows past the configured limit the values are released and only the
+// over-limit flag is kept.
+type trackedValues struct {
+	mu        sync.Mutex
+	values    map[string]struct{}
+	overLimit bool
+	// touched is when the entry's TTL was last extended.
+	touched time.Time
+}
+
+// trackerTouchInterval is how often an entry that keeps being accessed has
+// its TTL extended; extending it on every access re-arms the cache's
+// expiration timer each time.
+const trackerTouchInterval = time.Minute
+
+// ValueTracker records the distinct values seen per key within a TTL window
+// and reports which keys have exceeded the distinct-value limit. An entry's TTL
+// is extended while it keeps being accessed, so a key stays over the limit for
+// as long as it keeps arriving and is re-admitted only after it has been
+// absent for a full TTL.
 type ValueTracker struct {
-	ttl             *ttlcache.Cache[string, *lru.Cache[any, struct{}]]
+	ttl             *ttlcache.Cache[string, *trackedValues]
 	maxValuesPerKey int
 }
 
+// NewValueTracker returns a tracker that flags a key once more than
+// maxValuesPerKey distinct values are seen for it. A non-positive
+// maxValuesPerKey disables the distinct-value limit; keys can then only be
+// flagged through MarkOverLimit.
 func NewValueTracker(
 	maxKeys int,
 	maxValuesPerKey int,
 	ttl time.Duration,
 ) *ValueTracker {
 	cache := ttlcache.New(
-		ttlcache.WithTTL[string, *lru.Cache[any, struct{}]](ttl),
-		ttlcache.WithCapacity[string, *lru.Cache[any, struct{}]](uint64(maxKeys)),
+		ttlcache.WithTTL[string, *trackedValues](ttl),
+		ttlcache.WithCapacity[string, *trackedValues](uint64(maxKeys)),
+		ttlcache.WithDisableTouchOnHit[string, *trackedValues](),
 	)
 
 	go cache.Start()
@@ -30,32 +58,104 @@ func NewValueTracker(
 	}
 }
 
-func (vt *ValueTracker) AddValue(key string, value any) {
-	// Get or create LRU cache for this key
-	var valueCache *lru.Cache[any, struct{}]
-	if item := vt.ttl.Get(key); item != nil {
-		valueCache = item.Value()
-	} else {
-		// Create new LRU cache for this key
-		newCache, err := lru.New[any, struct{}](vt.maxValuesPerKey)
-		if err != nil {
-			return
-		}
-		valueCache = newCache
-		vt.ttl.Set(key, valueCache, ttlcache.DefaultTTL)
-	}
-
-	// Add value to the LRU cache
-	valueCache.Add(value, struct{}{})
+func (vt *ValueTracker) entry(key string) *trackedValues {
+	item, _ := vt.ttl.GetOrSetFunc(key, newTrackedValues)
+	tv := item.Value()
+	vt.touch(key, tv)
+	return tv
 }
 
-func (vt *ValueTracker) GetUniqueValueCount(key string) int {
-	if item := vt.ttl.Get(key); item != nil {
-		return item.Value().Len()
+func newTrackedValues() *trackedValues {
+	return &trackedValues{values: make(map[string]struct{}), touched: time.Now()}
+}
+
+// touch extends the entry's TTL once per trackerTouchInterval.
+func (vt *ValueTracker) touch(key string, tv *trackedValues) {
+	now := time.Now()
+	tv.mu.Lock()
+	stale := now.Sub(tv.touched) >= trackerTouchInterval
+	if stale {
+		tv.touched = now
 	}
-	return 0
+	tv.mu.Unlock()
+	if stale {
+		vt.ttl.Touch(key)
+	}
+}
+
+// AddValue records a value for the key and reports whether the key is over the
+// limit afterwards, so the value that takes it past the limit is reported too.
+// Strings are recorded as-is, integers and floats in their decimal form, and
+// every other type in its Go string form.
+func (vt *ValueTracker) AddValue(key string, value any) bool {
+	return vt.AddString(key, valueString(value))
+}
+
+// AddString is AddValue for a string value.
+func (vt *ValueTracker) AddString(key string, s string) bool {
+	tv := vt.entry(key)
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+
+	if tv.overLimit {
+		return true
+	}
+	if vt.maxValuesPerKey <= 0 {
+		return false
+	}
+	if _, ok := tv.values[s]; ok {
+		return false
+	}
+	if len(tv.values) >= vt.maxValuesPerKey {
+		tv.overLimit = true
+		tv.values = nil
+		return true
+	}
+	tv.values[s] = struct{}{}
+	return false
+}
+
+// MarkOverLimit flags the key as over the limit regardless of how many values
+// have been seen for it.
+func (vt *ValueTracker) MarkOverLimit(key string) {
+	tv := vt.entry(key)
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	tv.overLimit = true
+	tv.values = nil
+}
+
+// IsOverLimit reports whether the key has exceeded the distinct-value limit or
+// was flagged with MarkOverLimit within the TTL window.
+func (vt *ValueTracker) IsOverLimit(key string) bool {
+	item := vt.ttl.Get(key)
+	if item == nil {
+		return false
+	}
+	tv := item.Value()
+	vt.touch(key, tv)
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	return tv.overLimit
 }
 
 func (vt *ValueTracker) Close() {
 	vt.ttl.Stop()
+}
+
+func valueString(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case int:
+		return strconv.Itoa(v)
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		return fmt.Sprint(v)
+	}
 }

--- a/exporter/metadataexporter/vt_test.go
+++ b/exporter/metadataexporter/vt_test.go
@@ -5,8 +5,45 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
+func TestValueTrackerFlagsAKeyPastTheDistinctValueLimit(t *testing.T) {
+	tracker := NewValueTracker(10, 2, time.Minute)
+	defer tracker.Close()
+
+	assert.False(t, tracker.AddValue("http.route", "/users"))
+	assert.False(t, tracker.AddValue("http.route", "/users"))
+	assert.False(t, tracker.AddValue("http.route", "/orders"))
+	assert.False(t, tracker.IsOverLimit("http.route"), "two distinct values are within the limit of two")
+
+	assert.True(t, tracker.AddValue("http.route", "/carts"), "a third distinct value puts the key over the limit")
+	assert.True(t, tracker.IsOverLimit("http.route"))
+	assert.True(t, tracker.AddValue("http.route", "/users"), "an earlier value is over the limit too once the key is")
+
+	tracker.AddValue("task.id", int64(1))
+	tracker.AddValue("task.id", int64(1))
+	tracker.AddValue("task.id", 1.0)
+	assert.False(t, tracker.IsOverLimit("task.id"), "numbers are compared by their decimal form")
+
+	tracker.MarkOverLimit("payload")
+	assert.True(t, tracker.IsOverLimit("payload"), "a marked key is over the limit without any values")
+	assert.False(t, tracker.IsOverLimit("unknown"))
+}
+
+func TestValueTrackerWithoutALimitOnlyFlagsMarkedKeys(t *testing.T) {
+	tracker := NewValueTracker(10, 0, time.Minute)
+	defer tracker.Close()
+
+	for i := 0; i < 100; i++ {
+		tracker.AddValue("http.route", fmt.Sprintf("/users/%d", i))
+	}
+	assert.False(t, tracker.IsOverLimit("http.route"))
+
+	tracker.MarkOverLimit("http.route")
+	assert.True(t, tracker.IsOverLimit("http.route"))
+}
 func BenchmarkValueTracker_RealisticLoad(b *testing.B) {
 	const (
 		numSpans         = 100_000
@@ -75,7 +112,7 @@ func BenchmarkValueTracker_RealisticLoad(b *testing.B) {
 
 			for k := 0; k < 10; k++ {
 				key := keys[r.Intn(len(keys))]
-				tracker.GetUniqueValueCount(key)
+				tracker.IsOverLimit(key)
 			}
 		}
 	}

--- a/internal/common/spanfields/spanfields.go
+++ b/internal/common/spanfields/spanfields.go
@@ -1,0 +1,105 @@
+// Package spanfields derives the span fields that SigNoz stores beside the raw
+// span attributes: the calculated HTTP, database and status fields and the
+// remote flag. The traces exporter and the metadata exporter share it so both
+// write the same values.
+package spanfields
+
+import (
+	"net/url"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const (
+	hasIsRemoteMask uint32 = 0x00000100
+	isRemoteMask    uint32 = 0x00000200
+)
+
+// Calculated holds the span fields derived from the span attributes.
+type Calculated struct {
+	HttpMethod         string
+	HttpHost           string
+	HttpUrl            string
+	ResponseStatusCode string
+	DBName             string
+	DBOperation        string
+	ExternalHttpMethod string
+	ExternalHttpUrl    string
+}
+
+var hostAttributes = map[string]struct{}{
+	"http.host":                {},
+	"server.address":           {},
+	"client.address":           {},
+	"http.request.header.host": {},
+	"net.peer.name":            {},
+}
+
+// CalculatedFrom derives the calculated fields from the span attributes. The
+// external fields are set for client spans only; the host is taken from a host
+// attribute when present and from the URL of a client span otherwise.
+func CalculatedFrom(attributes pcommon.Map, kind ptrace.SpanKind) Calculated {
+	var c Calculated
+	client := kind == ptrace.SpanKindClient
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		switch {
+		case k == "http.status_code" || k == "http.response.status_code":
+			c.ResponseStatusCode = statusCode(v)
+		case (k == "http.url" || k == "url.full") && client:
+			value := v.Str()
+			if parsed, err := url.Parse(value); err == nil {
+				value = parsed.Hostname()
+			}
+			c.ExternalHttpUrl = value
+			c.HttpUrl = v.Str()
+			if c.HttpHost == "" {
+				c.HttpHost = value
+			}
+		case (k == "http.method" || k == "http.request.method") && client:
+			c.ExternalHttpMethod = v.Str()
+			c.HttpMethod = v.Str()
+		case k == "http.url" || k == "url.full":
+			c.HttpUrl = v.Str()
+		case k == "http.method" || k == "http.request.method":
+			c.HttpMethod = v.Str()
+		case k == "db.name" || k == "db.namespace":
+			c.DBName = v.Str()
+		case k == "db.operation" || k == "db.operation.name":
+			c.DBOperation = v.Str()
+		case k == "rpc.grpc.status_code":
+			c.ResponseStatusCode = statusCode(v)
+		case k == "rpc.jsonrpc.error_code":
+			c.ResponseStatusCode = v.Str()
+		default:
+			if _, ok := hostAttributes[k]; ok {
+				c.HttpHost = v.Str()
+			}
+		}
+		return true
+	})
+	return c
+}
+
+// statusCode formats a status code that arrives as either a string or an
+// integer as its decimal form.
+func statusCode(v pcommon.Value) string {
+	statusInt := v.Int()
+	if parsed, err := strconv.Atoi(v.Str()); err == nil && parsed != 0 {
+		statusInt = int64(parsed)
+	}
+	return strconv.FormatInt(statusInt, 10)
+}
+
+// IsRemote reports the span's remote flag as "yes", "no" or "unknown" when
+// the flags do not carry it.
+func IsRemote(flags uint32) string {
+	if flags&hasIsRemoteMask == 0 {
+		return "unknown"
+	}
+	if flags&isRemoteMask != 0 {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/common/spanfields/spanfields_test.go
+++ b/internal/common/spanfields/spanfields_test.go
@@ -1,0 +1,56 @@
+package spanfields
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestCalculatedFrom(t *testing.T) {
+	tests := []struct {
+		name  string
+		kind  ptrace.SpanKind
+		attrs map[string]any
+		want  Calculated
+	}{
+		{
+			name:  "server span keeps the full url and takes the host from the host attribute",
+			kind:  ptrace.SpanKindServer,
+			attrs: map[string]any{"http.method": "GET", "http.url": "https://api.example.com/users/42", "http.host": "api.example.com", "http.status_code": int64(200)},
+			want:  Calculated{HttpMethod: "GET", HttpUrl: "https://api.example.com/users/42", HttpHost: "api.example.com", ResponseStatusCode: "200"},
+		},
+		{
+			name:  "client span sets the external fields and derives the host from the url",
+			kind:  ptrace.SpanKindClient,
+			attrs: map[string]any{"http.request.method": "POST", "url.full": "https://payments.example.com/charge"},
+			want:  Calculated{HttpMethod: "POST", ExternalHttpMethod: "POST", HttpUrl: "https://payments.example.com/charge", ExternalHttpUrl: "payments.example.com", HttpHost: "payments.example.com"},
+		},
+		{
+			name:  "string status codes and database fields",
+			kind:  ptrace.SpanKindClient,
+			attrs: map[string]any{"rpc.grpc.status_code": "14", "db.namespace": "orders", "db.operation.name": "SELECT"},
+			want:  Calculated{ResponseStatusCode: "14", DBName: "orders", DBOperation: "SELECT"},
+		},
+		{
+			name:  "no matching attributes",
+			kind:  ptrace.SpanKindInternal,
+			attrs: map[string]any{"custom": "x"},
+			want:  Calculated{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := pcommon.NewMap()
+			assert.NoError(t, attrs.FromRaw(tt.attrs))
+			assert.Equal(t, tt.want, CalculatedFrom(attrs, tt.kind))
+		})
+	}
+}
+
+func TestIsRemote(t *testing.T) {
+	assert.Equal(t, "unknown", IsRemote(0))
+	assert.Equal(t, "no", IsRemote(hasIsRemoteMask))
+	assert.Equal(t, "yes", IsRemote(hasIsRemoteMask|isRemoteMask))
+}

--- a/utils/fingerprint/hash.go
+++ b/utils/fingerprint/hash.go
@@ -45,7 +45,36 @@ func FingerprintHash(attribs map[string]any) uint64 {
 	for _, k := range keys {
 		sum = hashAdd(sum, k)
 		sum = hashAddByte(sum, separatorByte)
-		sum = hashAdd(sum, fmt.Sprintf("%v", attribs[k]))
+		switch v := attribs[k].(type) {
+		case string:
+			sum = hashAdd(sum, v)
+		default:
+			sum = hashAdd(sum, fmt.Sprintf("%v", v))
+		}
+		sum = hashAddByte(sum, separatorByte)
+	}
+	return sum
+}
+
+// FingerprintHashStrings is FingerprintHash for a map of string values; a
+// string map hashes the same as the equivalent map[string]any.
+func FingerprintHashStrings(attribs map[string]string) uint64 {
+	if len(attribs) == 0 {
+		return offset64
+	}
+
+	keys := make([]string, 0, len(attribs))
+	for k := range attribs {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	sum := offset64
+	for _, k := range keys {
+		sum = hashAdd(sum, k)
+		sum = hashAddByte(sum, separatorByte)
+		sum = hashAdd(sum, attribs[k])
 		sum = hashAddByte(sum, separatorByte)
 	}
 	return sum

--- a/utils/flatten/flatten.go
+++ b/utils/flatten/flatten.go
@@ -32,7 +32,7 @@ func FlattenJSON(data map[string]interface{}, prefix string) map[string]interfac
 			result[fullKey] = float64(v.Int())
 		case float32:
 			result[fullKey] = float64(value)
-		case float64, bool:
+		case float64, bool, string:
 			result[fullKey] = value
 		default:
 			result[fullKey] = fmt.Sprintf("%v", value)


### PR DESCRIPTION
…ake the guards work

- migration 1002 adds intrinsic_attributes Map(LowCardinality(String), String) to attributes_metadata and its distributed table; traces write name, kind_string, status_code_string, has_error, is_remote and the non-empty calculated fields (http_method, http_host, http_url, response_status_code, db_name, db_operation, external_http_method, external_http_url), logs write severity_text and severity_number; the span name is still written to attributes until the query side reads the new column
- the calculated span fields are derived in internal/common/spanfields, shared with the traces exporter, so both write the same values
- the set fingerprint covers the intrinsic map, combining the two hashes in order so equal maps do not cancel out
- the value tracker is a bounded set with an over-limit flag; the LRU it replaces could never exceed the limit it was compared against, so the in-process cardinality guard never fired
- filterAttrs deletes empty values, values over max_string_length (the key is flagged so its shorter values are dropped too) and the value that takes a key past max_string_distinct_values; integers and floats are tracked like strings, bools pass through; intrinsic values follow the same rules but an oversized value is dropped from its row only, and always_include_attributes exempts a field
- resource attribute values over max_resource_string_length are dropped unless the key is in always_include_attributes; PushMetrics runs the same guards as traces and logs
- a key the periodic tag_attributes_v2 count finds over the limit stays skipped for a day even when a later count is under the limit
- rows are written once per configurable bucket per signal (six hours by default; the fields API floors a request start to six hours); the redis key window and the in-memory cache TTL follow the bucket
- unset, epoch, expired and far-future record timestamps are replaced by the current time; logs fall back to the observed timestamp
- the exporter timeout is 30 s, passed to exporterhelper and applied as max_execution_time on the connection; values_dropped, rows_written and insert_errors counters are emitted per signal
- the in-memory key cache checks each signal against its own cache and limits; it compared every signal against the traces cache and the per-resource limit, so logs and metrics metadata stopped once traces held 2048 sets
- tracker entries are touched at most once a minute, the tracker takes strings without boxing, tracker keys no longer carry the signal name, and string values are no longer reformatted while flattening or fingerprinting
- the attributes_metadata skip indexes stay, with a note on the definitions that they do not prune the related-values query

Assisted-by: Claude Fable 5.1

## Pull Request

### Summary
Briefly describe the change and its purpose.

### Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

### Resource Impact
**Will this change affect the application's resource usage?**
- [ ] Yes
- [ ] No

If **Yes**, describe:
- **Resources impacted:** (CPU, Memory, Disk, Network, etc.)
- **Expected change:** (e.g., +10% CPU, -150MB RAM)
- **Benchmarks:** Provide before/after results and how they were measured.
  
<!-- Ideally the test should be done where you keep ingestion rate and configuration same
and observe the changes in CPU, Memory, Ingestion Rate and the Lag on Kafka>